### PR TITLE
Parse shale.conf into an ordered layer list

### DIFF
--- a/shale
+++ b/shale
@@ -13,6 +13,8 @@ fi
 set -uo pipefail
 
 PROG=shale
+DOTFILES=${HOME-}/.dotfiles
+CONF=$DOTFILES/shale.conf
 
 # Diagnostics: first line prefixed 'shale: ', continuation lines 'shale:   '.
 emit() {
@@ -63,7 +65,194 @@ not_implemented() {
   die "$1 is not implemented yet"
 }
 
+# ------------------------------------------------------------------ the config
+
+config_error() {
+  CONFIG_ERRORS=$((CONFIG_ERRORS + 1))
+  emit "$@"
+}
+
+# A layer name and every component of a layer path share one grammar.
+valid_component() {
+  case "${1-}" in
+    '') return 1 ;;
+    [A-Za-z0-9_]*) ;;
+    *) return 1 ;;
+  esac
+  case "$1" in
+    *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# '.', '..', an absolute path, a doubled or trailing '/' all fail as a component
+# that is empty or does not start with a name character.
+valid_path() {
+  local rest=${1-} component
+  while :; do
+    component=${rest%%/*}
+    valid_component "$component" || return 1
+    case "$rest" in
+      */*) rest=${rest#*/} ;;
+      *) return 0 ;;
+    esac
+  done
+}
+
+# Fills LAYER_NAMES/LAYER_PATHS/LAYER_LINES in config order - line order is
+# precedence and nothing else determines it - and the clone-root-to-url map in
+# CLONE_ROOTS/CLONE_URLS/CLONE_LINES.  Collects every error into CONFIG_ERRORS
+# and returns non-zero; it must never exit, because doctor calls it bare and
+# goes on to report the rest of its findings.
+parse_config() {
+  local line lineno name path url extra root ok dup found i
+  LAYER_NAMES=()
+  LAYER_PATHS=()
+  LAYER_LINES=()
+  # Parallel indexed arrays: bash 3.2 has no associative arrays.
+  CLONE_ROOTS=()
+  CLONE_URLS=()
+  CLONE_LINES=()
+  CONFIG_ERRORS=0
+
+  if [ ! -e "$CONF" ]; then
+    config_error "no config file at $CONF" \
+      "list one layer per line, lowest precedence first: NAME PATH [URL]"
+    return 1
+  fi
+  if [ ! -f "$CONF" ]; then
+    config_error "$CONF is not a regular file"
+    return 1
+  fi
+  if [ ! -r "$CONF" ]; then
+    config_error "cannot read $CONF: permission denied"
+    return 1
+  fi
+
+  lineno=0
+  # The '|| [ -n "$line" ]' arm is what parses a last line with no newline
+  # after it, which read reports as a failure having still assigned it.
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    name=
+    path=
+    url=
+    extra=
+    # Default IFS: fields split on runs of spaces and tabs, and a fourth field
+    # onwards lands whole in extra.
+    read -r name path url extra <<EOF
+$line
+EOF
+    # '#' opens a comment where it starts a word, so everything from that field
+    # on is comment whatever it holds.
+    case "$path" in
+      '#'*)
+        path=
+        url=
+        extra=
+        ;;
+    esac
+    case "$url" in
+      '#'*)
+        url=
+        extra=
+        ;;
+    esac
+    case "$extra" in
+      '#'*) extra= ;;
+    esac
+    case "$name" in
+      '' | '#'*) continue ;;
+    esac
+
+    if [ -z "$path" ]; then
+      config_error "$CONF:$lineno: expected 'NAME PATH [URL]', got only '$name'" \
+        "PATH is relative to $DOTFILES"
+      continue
+    fi
+    if [ -n "$extra" ]; then
+      config_error "$CONF:$lineno: expected 'NAME PATH [URL]', got extra fields: $extra" \
+        "a name or a path cannot contain whitespace"
+      continue
+    fi
+
+    ok=1
+    if ! valid_component "$name"; then
+      config_error "$CONF:$lineno: invalid layer name '$name'" \
+        "a name starts with a letter, digit or '_' and may also contain '.' and '-'"
+      ok=0
+    fi
+    if ! valid_path "$path"; then
+      config_error "$CONF:$lineno: invalid layer path '$path'" \
+        "a path is one or more names joined by '/', relative to $DOTFILES"
+      ok=0
+    fi
+    [ "$ok" -eq 1 ] || continue
+
+    root=${path%%/*}
+    case "$root" in
+      current | current.new | current.old)
+        config_error "$CONF:$lineno: layer path '$path' starts with the reserved directory '$root'" \
+          "shale builds into $DOTFILES/current"
+        continue
+        ;;
+    esac
+
+    dup=0
+    i=0
+    while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
+      if [ "${LAYER_NAMES[$i]}" = "$name" ]; then
+        config_error "$CONF:$lineno: duplicate layer name '$name', first used on line ${LAYER_LINES[$i]}"
+        dup=1
+      fi
+      if [ "${LAYER_PATHS[$i]}" = "$path" ]; then
+        config_error "$CONF:$lineno: duplicate layer path '$path', first used on line ${LAYER_LINES[$i]}"
+        dup=1
+      fi
+      i=$((i + 1))
+    done
+    [ "$dup" -eq 0 ] || continue
+
+    # A url declares how to obtain the clone root, not the layer: several layers
+    # commonly come from one clone, so it is given once and omitted after.
+    if [ -n "$url" ]; then
+      found=-1
+      i=0
+      while [ "$i" -lt "${#CLONE_ROOTS[@]}" ]; do
+        if [ "${CLONE_ROOTS[$i]}" = "$root" ]; then
+          found=$i
+          break
+        fi
+        i=$((i + 1))
+      done
+      if [ "$found" -lt 0 ]; then
+        CLONE_ROOTS+=("$root")
+        CLONE_URLS+=("$url")
+        CLONE_LINES+=("$lineno")
+      elif [ "${CLONE_URLS[$found]}" != "$url" ]; then
+        config_error "$CONF:$lineno: conflicting urls for clone root '$root'" \
+          "line ${CLONE_LINES[$found]}: ${CLONE_URLS[$found]}" \
+          "line $lineno: $url"
+      fi
+    fi
+
+    LAYER_NAMES+=("$name")
+    LAYER_PATHS+=("$path")
+    LAYER_LINES+=("$lineno")
+  done <"$CONF"
+
+  if [ "$CONFIG_ERRORS" -eq 0 ] && [ "${#LAYER_NAMES[@]}" -eq 0 ]; then
+    config_error "no layers configured in $CONF" \
+      "list one layer per line, lowest precedence first: NAME PATH [URL]"
+  fi
+  [ "$CONFIG_ERRORS" -eq 0 ] || return 1
+  return 0
+}
+
+# ----------------------------------------------------------------- the commands
+
 cmd_build() {
+  parse_config || exit 1
   not_implemented build
 }
 

--- a/tests/run
+++ b/tests/run
@@ -527,7 +527,10 @@ test_usage_command_surface_is_closed() {
   done
 }
 
+# build parses the config before anything else, so reaching the stub message is
+# itself the claim that a good config parsed clean.
 test_usage_build_is_stubbed() {
+  conf 'base personal/base' 'local local'
   run_shale build
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" 'shale: build is not implemented yet' 'stderr'
@@ -553,6 +556,228 @@ test_usage_which_is_stubbed() {
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" 'shale: which is not implemented yet' 'stderr'
   assert_empty "$shale_out" 'stdout'
+}
+
+# --------------------------------------------------------------- config cases
+#
+# parse_config has no output of its own.  build runs it before reporting itself
+# unimplemented, so a clean parse is observable as the stub message and a broken
+# one as a diagnostic naming the file and line in its place.  The urls here are
+# opaque strings on purpose: shale passes a url to git verbatim and never looks
+# inside it, and no case in this suite may name a host.
+
+test_config_comments_blanks_and_whitespace_are_accepted() {
+  local tab
+  tab=$(printf '\t')
+  conf \
+    '' \
+    '# a whole-line comment' \
+    '   # an indented comment' \
+    "base${tab}${tab}personal/base${tab}url-one   # a trailing comment" \
+    '   wsl     personal/wsl   # a comment where the url would go' \
+    '' \
+    'local  local' \
+    '#'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" 'shale: build is not implemented yet' 'stderr'
+  assert_not_contains "$shale_err" 'shale.conf:' 'stderr'
+}
+
+test_config_two_and_three_column_lines_are_accepted() {
+  conf 'base personal/base url-one' 'wsl personal/wsl' 'local local'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" 'shale: build is not implemented yet' 'stderr'
+  assert_not_contains "$shale_err" 'shale.conf:' 'stderr'
+}
+
+# Two components is the shape every other case uses, and it is the one length at
+# which trimming the first component and trimming all but the last agree.
+test_config_a_deep_layer_path_is_accepted() {
+  conf 'base personal/base' 'deep personal/wsl/nested/deeper'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" 'shale: build is not implemented yet' 'stderr'
+  assert_not_contains "$shale_err" 'shale.conf:' 'stderr'
+}
+
+test_config_conflicting_urls_for_one_root_are_rejected() {
+  conf \
+    'base personal/base url-one' \
+    'wsl personal/wsl' \
+    'work work url-work' \
+    'extra personal/extra url-two'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/shale.conf:4: conflicting urls for clone root 'personal'" 'stderr'
+  assert_contains "$shale_err" 'shale:   line 1: url-one' 'stderr'
+  assert_contains "$shale_err" 'shale:   line 4: url-two' 'stderr'
+  assert_not_contains "$shale_err" 'not implemented' 'stderr'
+  assert_empty "$shale_out" 'stdout'
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+test_config_a_repeated_identical_url_is_accepted() {
+  conf 'base personal/base url-one' 'wsl personal/wsl url-one'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" 'shale: build is not implemented yet' 'stderr'
+  assert_not_contains "$shale_err" 'conflicting' 'stderr'
+}
+
+test_config_a_four_column_line_is_rejected() {
+  conf 'base personal/base url-one' 'wsl personal/wsl url-one spare'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:2:" 'stderr'
+  assert_contains "$shale_err" 'extra fields: spare' 'stderr'
+  assert_not_contains "$shale_err" 'not implemented' 'stderr'
+}
+
+test_config_a_line_without_a_path_is_rejected() {
+  local line
+  # The second form is a half-written line, not a path of '#': the comment is
+  # gone by the time the record is judged.
+  for line in 'base' 'base # the path goes here'; do
+    conf "$line"
+    run_shale build
+    assert_status 1 "$shale_status" "'$line' exit status"
+    assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:1:" "'$line' stderr"
+    assert_contains "$shale_err" "got only 'base'" "'$line' stderr"
+    assert_not_contains "$shale_err" 'not implemented' "'$line' stderr"
+  done
+}
+
+# The quoting and escaping forms are here because they are the only way a path
+# with whitespace in it can be written at all: the format cannot represent one,
+# and the quote and the backslash are simply characters a path may not contain.
+test_config_invalid_paths_are_rejected() {
+  local path
+  # SC2088/SC1003: the tilde and the trailing backslash are the literals under
+  # test, not expansions or escapes that got away.
+  # shellcheck disable=SC2088,SC1003
+  for path in \
+    . ./current .. /etc/skel '~/x' personal//base personal/base/ personal/../base \
+    current current.new current.old current/x '"my' 'my\'; do
+    conf "base $path"
+    run_shale build
+    assert_status 1 "$shale_status" "path '$path' exit status"
+    assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:1:" "path '$path' stderr"
+    assert_not_contains "$shale_err" 'not implemented' "path '$path' stderr"
+  done
+}
+
+test_config_invalid_names_are_rejected() {
+  local name
+  # 'ba#se' is a name with a '#' in it, not a comment: '#' opens one only where
+  # it starts a word.
+  for name in .hidden -lead 'bad/name' 'na*me' 'ba#se'; do
+    conf "$name personal/base"
+    run_shale build
+    assert_status 1 "$shale_status" "name '$name' exit status"
+    assert_contains "$shale_err" \
+      "shale: $HOME/.dotfiles/shale.conf:1: invalid layer name '$name'" "name '$name' stderr"
+    assert_not_contains "$shale_err" 'not implemented' "name '$name' stderr"
+  done
+}
+
+test_config_duplicate_names_and_paths_are_rejected() {
+  conf 'base personal/base' 'base other' 'wsl personal/base'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/shale.conf:2: duplicate layer name 'base', first used on line 1" 'stderr'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/shale.conf:3: duplicate layer path 'personal/base', first used on line 1" 'stderr'
+  assert_not_contains "$shale_err" 'not implemented' 'stderr'
+}
+
+# Config errors cluster, and revealing them one run at a time is infuriating.
+# The two lines that are rejected outright come first, so a parser that stopped
+# at either of them would lose everything asserted below it.
+test_config_every_error_is_reported_in_one_run() {
+  conf \
+    'lonely' \
+    'four fields are too many' \
+    '.bad ../nope' \
+    'base personal/base url-one' \
+    'wsl personal/wsl url-two'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:1: expected" 'stderr'
+  assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:2: expected" 'stderr'
+  assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:3: invalid layer name" 'stderr'
+  assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:3: invalid layer path" 'stderr'
+  assert_contains "$shale_err" "shale: $HOME/.dotfiles/shale.conf:5: conflicting urls" 'stderr'
+  assert_not_contains "$shale_err" 'not implemented' 'stderr'
+}
+
+test_config_a_missing_config_is_shales_message() {
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" "shale: no config file at $HOME/.dotfiles/shale.conf" 'stderr'
+  assert_not_contains "$shale_err" 'No such file' 'stderr'
+  assert_not_contains "$shale_err" 'not implemented' 'stderr'
+  assert_empty "$shale_out" 'stdout'
+}
+
+# Without the regular-file guard the read loop reaches a directory and bash
+# diagnoses it instead of shale, which is the failure this case names.
+test_config_a_config_that_is_a_directory_is_shales_message() {
+  sandbox_mkdir "$HOME/.dotfiles/shale.conf"
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/shale.conf is not a regular file" 'stderr'
+  assert_not_contains "$shale_err" 'read error' 'stderr'
+  assert_not_contains "$shale_err" 'unbound variable' 'stderr'
+  assert_not_contains "$shale_err" 'not implemented' 'stderr'
+  assert_empty "$shale_out" 'stdout'
+}
+
+test_config_an_unreadable_config_reports_permissions() {
+  skip_if_root
+  conf 'base personal/base'
+  chmod 0000 "$HOME/.dotfiles/shale.conf" || fail 'could not remove the read bit'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: cannot read $HOME/.dotfiles/shale.conf: permission denied" 'stderr'
+  assert_not_contains "$shale_err" 'no layers' 'stderr'
+}
+
+test_config_a_config_with_no_records_reports_no_layers() {
+  conf '# nothing here' ''
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: no layers configured in $HOME/.dotfiles/shale.conf" 'stderr'
+  assert_not_contains "$shale_err" 'not implemented' 'stderr'
+}
+
+# The last line is the invalid one, so its diagnostic is proof it was read at
+# all rather than dropped for want of a newline after it.
+test_config_a_missing_trailing_newline_still_parses_the_last_line() {
+  sandbox_target "$HOME/.dotfiles" shale.conf
+  printf 'base personal/base\nlocal ~/oops' >"$sandbox_path" ||
+    fail "could not write $sandbox_path"
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/shale.conf:2: invalid layer path '~/oops'" 'stderr'
+}
+
+test_config_reached_through_a_symlink_parses() {
+  sandbox_write "$HOME/.dotfiles/elsewhere" shale.conf 'base personal/base'
+  sandbox_mkdir "$HOME/.dotfiles"
+  ln -s "$HOME/.dotfiles/elsewhere/shale.conf" "$HOME/.dotfiles/shale.conf" ||
+    fail 'could not link the config'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" 'shale: build is not implemented yet' 'stderr'
+  assert_not_contains "$shale_err" 'shale.conf:' 'stderr'
 }
 
 # ------------------------------------------------------------------ meta cases


### PR DESCRIPTION
Closes #4.

`build` parses the config and then reports not-implemented. That is the order of operations `build` will have anyway, and it is what makes the parser observable at all — the harness drives `shale` through its command line and cannot call internal functions, so a parser wired to nothing could not be tested. Only `build` is wired; `apply`, `doctor` and `which` keep their immediate stubs, and #5, #8 and #9 each carry a note to pick it up.

`shale` 123 → 312 lines. Suite 44 → 61 cases. No new harness machinery — the two cases needing unusual writes use the existing `sandbox_*` primitives.

## Review

One code-review round and one functional-verification round, by independent agents. **Both returned "merges", with no blockers and no majors, and neither found a defect in the parser.**

Things they checked that are worth recording:

- **Config data cannot execute.** Field splitting is `read -r name path url extra` from a heredoc whose body is the literal text `$line`; the result of a parameter expansion is not rescanned. Verified by running a config line containing `$(touch PWNED)`, backticks, globs and quotes — all arrived as inert text, no files created, no glob expansion.
- **The component grammar holds under `LC_ALL=C` and `en_AU.UTF-8`**, so the negated bracket set is not leaking accented characters through collation.
- **bash 3.2**: exactly three `[@]` occurrences, all `${#arr[@]}` length forms, so no bare array expansion exists under `set -u` yet. Not executed on 3.2 — that remains review-only, per #15.
- **`parse_config` provably never exits** — four `return`s, zero `exit`/`die` — which is what will let `doctor` call it bare.

## Mutation testing found what review alone did not

The functional gate ran 33 independent mutations; 30 were killed by the 15 new cases. The three survivors were real coverage holes and are closed here:

| mutation | now caught by |
|---|---|
| delete `[ ! -f "$CONF" ]` | a config that is a directory |
| `${rest%%/*}` → `${rest%/*}` | a layer path deeper than two components |
| record test `'#'*` → `*'#'*` | a name containing `#` |

The first mattered most: without it the mutant emits `read error: Is a directory` and `line: unbound variable` — bash's messages, which is exactly what #4's criterion forbids — and every case stayed green.

## Coordinator verification

Independent of the implementing agent:

- `./tests/run` → 61 passed, 0 failed, 0 skipped.
- Disabling the regular-file guard fails exactly the new case and nothing else.
- A nine-line config with five faults reports all of them in one pass, in line order, with `path:LINE:` prefixes, exit 1.
- Conflicting URLs name the clone root and both lines; an identical repeated URL is accepted silently; a clean config reaches the stub; a missing config gives shale's message, not bash's.
- `~/.dotfiles` still contains only `common`.

## Noted, not fixed

- Issue #4's criterion "a whitespace-containing path is rejected" is not achievable as written — `base my dir/base` is indistinguishable from a valid three-column record with `dir/base` as the URL, since URLs are opaque by design. Both gates independently confirmed this. The issue text has been corrected; what *is* rejected is any attempt to write whitespace into a path, which needs a quote or a backslash.
- A line failing the field-count check reports only that, not its name and path errors, costing one extra run. Left deliberately: once the field count is wrong you cannot tell which token was meant as the name.
- The parse is O(n²) in layer count — 3.3s at 1000 layers, irrelevant for a realistic config.