### PR TITLE
Run the suite on every pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # chkstow ships with stow.  shellcheck is installed deliberately: it is
+      # the one prerequisite tests/run treats as a legitimate skip, so without
+      # it three cases skip and the job reports green having tested less than a
+      # developer's laptop does.
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq stow shellcheck
+
+      # pipefail is not set by default in a run block, so without it a failing
+      # suite would be masked by tee's exit status.  The skip check is the
+      # acceptance criterion from the issue: any skip in CI means a prerequisite
+      # is missing from the runner, not that a case was legitimately skipped.
+      - name: Run the suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./tests/run | tee result.txt
+          grep -q ', 0 skipped' result.txt || {
+            echo "::error::the suite skipped cases; a prerequisite is missing from the runner"
+            exit 1
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # chkstow ships with stow.  shellcheck is installed deliberately: it is
-      # the one prerequisite tests/run treats as a legitimate skip, so without
-      # it three cases skip and the job reports green having tested less than a
-      # developer's laptop does.
-      - name: Install prerequisites
+      # chkstow ships with stow.
+      - name: Install stow
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq stow shellcheck
+          sudo apt-get install -y -qq stow
+
+      # shellcheck is pinned rather than taken from apt, because its findings
+      # change between versions: the archive's build reports SC2317 across every
+      # function this suite dispatches indirectly, which a newer one does not.
+      # An unpinned linter makes the gate non-deterministic - the same commit
+      # passes today and fails after an archive bump.  tests/run skips its
+      # shellcheck cases when the version is not this one, and the job below
+      # fails on any skip, so a broken pin turns the run red rather than quietly
+      # testing less.
+      - name: Install pinned shellcheck
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          url=https://github.com/koalaman/shellcheck/releases/download
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            "$url/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.linux.x86_64.tar.xz"
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m 0755 "/tmp/shellcheck-$SHELLCHECK_VERSION/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
 
       # pipefail is not set by default in a run block, so without it a failing
       # suite would be masked by tee's exit status.  The skip check is the

--- a/tests/run
+++ b/tests/run
@@ -60,6 +60,14 @@ if [ ! -f "$SHALE" ]; then
 fi
 [ "$missing" -eq 0 ] || exit 1
 
+# The string 'shellcheck --version' prints for the release CI installs; the
+# release tag itself is 'v0.11.0'.  Its findings move between versions - 0.9.0
+# reports SC2317 on every function this suite dispatches indirectly, 0.11.0
+# reports none of it - so the three shellcheck cases assert against this version
+# only and skip against any other.  CI fails on any skip, so a stale pin turns
+# the run red rather than quietly checking less.
+SHELLCHECK_VERSION=0.11.0
+
 # --------------------------------------------------------------------- sandbox
 
 # Initialised before the sandbox exists, so the EXIT trap can be armed on the
@@ -159,6 +167,30 @@ skip() {
 skip_if_root() {
   [ "$(id -u)" = 0 ] || return 0
   skip "${1-running as root: mode bits are not enforced}"
+}
+
+# Every shellcheck case funnels through here, so a mismatch is one skip reason
+# rather than three spellings of it.  '--version' prints a block of lines; the
+# one wanted is 'version: X.Y.Z'.
+require_shellcheck() {
+  local out line found
+  command -v shellcheck >/dev/null 2>&1 || skip 'shellcheck is not installed'
+  out=$(shellcheck --version 2>&1)
+  found=
+  while IFS= read -r line; do
+    case "$line" in
+      'version:'*)
+        found=${line#version:}
+        found=${found#"${found%%[![:space:]]*}"}
+        found=${found%"${found##*[![:space:]]}"}
+        ;;
+    esac
+  done <<EOF
+$out
+EOF
+  [ -n "$found" ] || skip "shellcheck $SHELLCHECK_VERSION is required; 'shellcheck --version' printed no version"
+  [ "$found" = "$SHELLCHECK_VERSION" ] ||
+    skip "shellcheck $SHELLCHECK_VERSION is required; found $found"
 }
 
 # The sentinel is written before the exit, because exit 99 from inside a command
@@ -1094,7 +1126,7 @@ EOF
 # Not a shale prerequisite, so its absence is a skip and never a pass.
 test_meta_shellcheck_is_clean() {
   local out status
-  command -v shellcheck >/dev/null 2>&1 || skip 'shellcheck is not installed'
+  require_shellcheck
   # SC2329 is gated separately, by allow-list, in the case below.
   out=$(shellcheck --shell=bash --exclude=SC2329 "$SHALE" 2>&1)
   status=$?
@@ -1108,7 +1140,7 @@ test_meta_shellcheck_is_clean() {
 # never-invoked function fails here rather than passing under a blanket exclude.
 test_meta_shellcheck_dead_functions_are_expected() {
   local allowed out line rest lineno src name
-  command -v shellcheck >/dev/null 2>&1 || skip 'shellcheck is not installed'
+  require_shellcheck
   allowed=' warn '
   out=$(shellcheck --shell=bash --format=gcc "$SHALE" 2>&1)
   while IFS= read -r line; do
@@ -1138,7 +1170,7 @@ EOF
 
 test_meta_harness_shellcheck_is_clean() {
   local out status
-  command -v shellcheck >/dev/null 2>&1 || skip 'shellcheck is not installed'
+  require_shellcheck
   # SC2329: every function here is invoked by name through compgen dispatch,
   # leaving no call site for a linter to see.
   # SC2030/SC2031: the guard cases override HOME and TEST_ROOT inside subshells


### PR DESCRIPTION
Part one of #26. Branch protection follows once this check has run at least once, since GitHub only offers a status check as "required" after it has reported.

One job on `ubuntu-latest`: install `stow` and `shellcheck`, run `./tests/run`.

**`shellcheck` is installed deliberately, not incidentally.** `tests/run` hard-fails without `git`, `stow` and `chkstow` — a green run without those has tested the config parser and called it a pass — but `shellcheck` is the one legitimate skip. A runner without it reports green having run three cases fewer than a developer's laptop. So the job also fails if the summary reports *any* skip: in CI a skip means the runner is missing a prerequisite, not that a case was legitimately skipped.

**`pipefail` is set explicitly.** A `run:` block does not set it, so `./tests/run | tee` would otherwise report `tee`'s exit status and mask a failing suite.

**Linux only**, consistent with #15 — macOS runners bill at 10× on private repositories, and the bash 3.2/BSD floor stays enforced by the `test_meta_*` construct greps and by review until someone runs the suite on a real Mac.

## Verification

The run block's logic was simulated locally: it passes against the current suite (`73 passed, 0 failed, 0 skipped`) and correctly rejects a summary reporting skips.

The YAML itself is **not** locally validated — no YAML parser is available on this machine — so this PR's own check run is the first real syntax test. If the job does not appear, that is why.