### PR TITLE
Run the suite on macOS under system bash

### DIFF
--- a/.claude/agents/functional-verifier.md
+++ b/.claude/agents/functional-verifier.md
@@ -22,7 +22,7 @@ the code is right. You are the independent check.
 
 **Never operate on the real `$HOME`.** Every invocation runs with `HOME` redirected into a directory
 you created under `mktemp -d`. Before you run shale even once, confirm your sandbox: print the value
-of `HOME`, confirm it is under your temp root and is not `/home/beno`, and confirm
+of `HOME`, confirm it is under your temp root and is not the real home directory, and confirm
 `~/.dotfiles/current` inside it does not resolve to anything real. Real dotfiles are live on this
 machine and `stow` creates and removes symlinks in whatever target it is given.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,56 @@ jobs:
             echo "::error::the suite skipped cases; a prerequisite is missing from the runner"
             exit 1
           }
+
+  # macOS is the reason shale is written to bash 3.2 and POSIX utility flags,
+  # and until now nothing had executed a line of it there - the floor was held
+  # up by grep patterns over the source and by review.  This job is what turns
+  # that into evidence, or shows it was wrong.
+  #
+  # Deliberately NOT added to the required checks on main: its job is to tell us
+  # whether the claims hold, not to block work while we find out.  It is left
+  # able to fail visibly rather than marked continue-on-error, because a red
+  # check nobody can miss is the entire point.
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # chkstow ships with stow.
+      - name: Install stow
+        run: brew install stow
+
+      - name: Install pinned shellcheck
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            arm64 | aarch64) arch=aarch64 ;;
+            *) arch=x86_64 ;;
+          esac
+          url=https://github.com/koalaman/shellcheck/releases/download
+          curl -fsSL -o /tmp/shellcheck.tar.gz \
+            "$url/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.darwin.$arch.tar.gz"
+          tar -xzf /tmp/shellcheck.tar.gz -C /tmp
+          sudo install -m 0755 "/tmp/shellcheck-$SHELLCHECK_VERSION/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
+
+      # Recorded in the log so a failure can be read against the actual version
+      # rather than an assumption about what the image ships.
+      - name: Report the interpreter and userland
+        run: |
+          /bin/bash --version | head -1
+          command -v stow chkstow git
+          cp --version 2>/dev/null | head -1 || echo "cp: BSD (no --version)"
+
+      # /bin/bash explicitly, not the shebang: brew may put a newer bash earlier
+      # on PATH, which would quietly test the wrong thing.
+      - name: Run the suite under system bash
+        run: |
+          set -euo pipefail
+          /bin/bash tests/run | tee result.txt
+          grep -q ', 0 skipped' result.txt || {
+            echo "::error::the suite skipped cases; a prerequisite is missing from the runner"
+            exit 1
+          }


### PR DESCRIPTION
Closes #15.

macOS is the reason `shale` is written to bash 3.2 and POSIX utility flags, and until now nothing had executed a line of it there — the floor was held up by grep patterns over the source and by review. Public repositories get macOS runners at no cost, so the claim can be tested rather than asserted.

**The suite is invoked as `/bin/bash tests/run`, not through the shebang.** Homebrew may put a newer bash earlier on `PATH`, and the shebang would then quietly exercise the wrong interpreter — producing a green tick that proves nothing. That distinction is the whole value of the job.

The job also records the bash version, the tool paths, and whether `cp` is BSD, so a failure can be read against what the image actually ships rather than against an assumption.

**Not added to the required checks on `main`**, and deliberately *not* marked `continue-on-error`. Its purpose is to report whether the portability claims hold, not to block work while we find out — and a red check nobody can miss is the point of adding it.

Also included: the functional verifier's safety rule named one machine's home directory. The rule holds for anyone running this, and the agent already captures the real home at startup to compare against, so the literal path bought nothing. Found while scanning before making the repository public — no secrets were present anywhere in the tree or history.

## Expectation, recorded before the result

I expect this to fail. Nothing has run under bash 3.2 or BSD userland, the harness leans on `pwd -P`, `mkfifo`, `find -maxdepth`, `-ef` and `mktemp -d`, and 88 cases is a lot of surface for first contact with a different userland. If it fails, the job is working.