### PR TITLE
Add doctor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,10 +58,11 @@ jobs:
   # up by grep patterns over the source and by review.  This job is what turns
   # that into evidence, or shows it was wrong.
   #
-  # Deliberately NOT added to the required checks on main: its job is to tell us
-  # whether the claims hold, not to block work while we find out.  It is left
-  # able to fail visibly rather than marked continue-on-error, because a red
-  # check nobody can miss is the entire point.
+  # It passed on first contact - bash 3.2.57 on arm64 Darwin, 73 cases, no
+  # failures - so it is now a required check on main alongside the Linux job.
+  # The floor is therefore enforced by execution rather than by the construct
+  # greps alone.  Not marked continue-on-error: a red check nobody can miss is
+  # the entire point of having it.
   test-macos:
     runs-on: macos-latest
     steps:

--- a/shale
+++ b/shale
@@ -16,14 +16,22 @@ PROG=shale
 DOTFILES=${HOME-}/.dotfiles
 CONF=$DOTFILES/shale.conf
 
-# Diagnostics: first line prefixed 'shale: ', continuation lines 'shale:   '.
-emit() {
+# First line prefixed 'shale: ', continuation lines 'shale:   '.  On stdout,
+# which is where a command's own result belongs: doctor's report and which's
+# answer are what those commands are for, and both are routinely redirected.
+report() {
   local line prefix
   prefix="$PROG: "
   for line in "$@"; do
-    printf '%s%s\n' "$prefix" "$line" >&2
+    printf '%s%s\n' "$prefix" "$line"
     prefix="$PROG:   "
   done
+}
+
+# The same lines on stderr, for everything that is not a result: diagnostics,
+# usage errors, and the notes a command emits alongside its answer.
+emit() {
+  report "$@" >&2
 }
 
 warn() {
@@ -249,6 +257,75 @@ EOF
   return 0
 }
 
+# The url configured for clone root $1, in CLONE_URL; non-zero when the config
+# gave none.  A url belongs to a clone root rather than to a layer, so several
+# layers can share one.
+clone_url() {
+  local root=$1 i
+  CLONE_URL=
+  i=0
+  while [ "$i" -lt "${#CLONE_ROOTS[@]}" ]; do
+    if [ "${CLONE_ROOTS[$i]}" = "$root" ]; then
+      CLONE_URL=${CLONE_URLS[$i]}
+      return 0
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# ------------------------------------------------------------------- the doctor
+
+# A finding is a defect in the setup, and the count of them is what decides
+# doctor's exit status.  Warnings and notes go through note and never count.
+# Both are the report rather than a diagnostic, so both are on stdout.
+finding() {
+  FINDINGS=$((FINDINGS + 1))
+  report "$@"
+}
+
+note() {
+  report "$@"
+}
+
+# The running script's own path relative to $HOME, in SELF_REL.  Non-zero when
+# the script is not under $HOME, which is the ordinary case for an install on
+# PATH.  shale never learns or hard-codes where it lives: this is derived at
+# runtime from the path it was invoked by.
+#
+# The leaf is left unresolved because a symlink there is still a path a layer
+# can shadow.  The directory part is resolved, and has the opposite exposure:
+# once ~/.local/bin is itself a link into current, pwd -P answers with the path
+# inside current, and the check then reports clean on a setup that does shadow
+# the script.  Resolving neither would fail on any '..' or symlinked parent,
+# which is the commoner case.
+self_relative_path() {
+  local src base dir home
+  SELF_REL=
+  src=${BASH_SOURCE[0]-}
+  [ -n "$src" ] || return 1
+  [ -n "${HOME-}" ] || return 1
+  base=${src##*/}
+  dir=${src%/*}
+  # No '/' in the invocation at all: bash found it in the current directory.
+  [ "$dir" != "$src" ] || dir=.
+  dir=$(cd "$dir" 2>/dev/null && pwd -P) || return 1
+  home=$(cd "$HOME" 2>/dev/null && pwd -P) || return 1
+  { [ -n "$dir" ] && [ -n "$home" ]; } || return 1
+  if [ "$dir" = "$home" ]; then
+    SELF_REL=$base
+    return 0
+  fi
+  # The '/' in the pattern is what stops a sibling like "$HOME-elsewhere" from
+  # matching.  The one appended to dir would matter only for dir = home, which
+  # the branch above has already returned from.
+  case "$dir/" in
+    "$home"/*) SELF_REL=${dir#"$home"/}/$base ;;
+    *) return 1 ;;
+  esac
+  return 0
+}
+
 # ----------------------------------------------------------------- the commands
 
 cmd_build() {
@@ -260,8 +337,127 @@ cmd_apply() {
   not_implemented apply
 }
 
+# Ordered cheapest and most fundamental first.  Nothing here exits early or
+# short-circuits: every check runs whatever the ones before it found, and only
+# the finding count decides the exit status.
 cmd_doctor() {
-  not_implemented doctor
+  local tool i name path root dir entry leaf known
+
+  FINDINGS=0
+
+  for tool in git stow; do
+    command -v "$tool" >/dev/null 2>&1 ||
+      finding "$tool is not installed" \
+        "install it with your system package manager: shale installs nothing"
+  done
+  command -v chkstow >/dev/null 2>&1 ||
+    note "chkstow is not installed" \
+      "it comes with GNU stow, and without it shale cannot audit ${HOME-} for broken links"
+
+  if [ ! -d "$DOTFILES" ]; then
+    if [ -e "$DOTFILES" ] || [ -L "$DOTFILES" ]; then
+      finding "$DOTFILES exists but is not a directory" \
+        "shale keeps your layers, your config and its build output there"
+    else
+      finding "no dotfiles directory at $DOTFILES" \
+        "create it with: mkdir -p $DOTFILES"
+    fi
+  fi
+
+  # Bare, where every other command calls it as 'parse_config || exit 1': doctor
+  # must still report everything below when the config is broken or missing.
+  # The '2>&1' is on the call rather than in parse_config, which keeps writing to
+  # stderr for build, apply and which: here each of its errors is counted as a
+  # finding, so each has to appear in the report the count describes.
+  parse_config 2>&1
+  FINDINGS=$((FINDINGS + CONFIG_ERRORS))
+
+  i=0
+  while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
+    name=${LAYER_NAMES[$i]}
+    path=${LAYER_PATHS[$i]}
+    root=${path%%/*}
+    dir=$DOTFILES/$path
+    if [ -d "$dir" ]; then
+      :
+    elif [ -e "$dir" ] || [ -L "$dir" ]; then
+      finding "layer '$name': $dir exists but is not a directory"
+    elif [ -d "$DOTFILES/$root" ]; then
+      finding "layer '$name' has no directory at $dir, but its clone at $DOTFILES/$root exists" \
+        "check the path on line ${LAYER_LINES[$i]}"
+    elif clone_url "$root"; then
+      # A url means shale can obtain this one, so it is reported without
+      # counting: it is a state shale fixes, not a defect in the setup.
+      note "layer '$name' has no directory at $dir yet" \
+        "its clone root '$root' has a url: $CLONE_URL"
+    else
+      finding "layer '$name' has no directory at $dir and no url for '$root'" \
+        "add a url on that line, or create the directory"
+    fi
+    i=$((i + 1))
+  done
+
+  # Directories only, and nothing whose name begins with '.': a '.git' or a
+  # '.stowrc' beside the config is not a stray layer.
+  if [ -d "$DOTFILES" ]; then
+    for entry in "$DOTFILES"/*; do
+      # Also the arm the unmatched glob lands in.
+      [ -d "$entry" ] || continue
+      leaf=${entry##*/}
+      case "$leaf" in
+        current | current.new | current.old | "${CONF##*/}") continue ;;
+      esac
+      known=0
+      i=0
+      while [ "$i" -lt "${#LAYER_PATHS[@]}" ]; do
+        if [ "${LAYER_PATHS[$i]%%/*}" = "$leaf" ]; then
+          known=1
+          break
+        fi
+        i=$((i + 1))
+      done
+      [ "$known" -eq 0 ] || continue
+      note "$entry is not a configured layer" \
+        "it may be a leftover stow package, a stray clone, or a layer you removed from the config"
+    done
+  fi
+
+  # Never ship shale itself in a layer, enforced from the path the running
+  # script was invoked by so that shale still knows no install location.
+  if self_relative_path; then
+    i=0
+    while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
+      dir=$DOTFILES/${LAYER_PATHS[$i]}/$SELF_REL
+      if [ -e "$dir" ] || [ -L "$dir" ]; then
+        finding "layer '${LAYER_NAMES[$i]}' provides the running script itself at $dir" \
+          "applying it would replace the script with a link into $DOTFILES/current" \
+          "remove it from that layer: shale installs nothing, including itself"
+      fi
+      i=$((i + 1))
+    done
+  fi
+
+  # man stow, RESOURCE FILES: an option that may be given more than once -
+  # --ignore is the one that matters - is appended to the command line rather
+  # than overridden by it, so nothing shale passes can defend against this.
+  for entry in "${HOME-}/.stowrc" "$DOTFILES/.stowrc"; do
+    if [ -e "$entry" ] || [ -L "$entry" ]; then
+      note "a stow resource file exists at $entry" \
+        "stow adds its --ignore patterns to the ones shale passes rather than replacing them" \
+        "so it can silently drop files from an apply"
+    fi
+  done
+
+  if [ "$FINDINGS" -eq 0 ]; then
+    report 'no problems found'
+    exit 0
+  fi
+  if [ "$FINDINGS" -eq 1 ]; then
+    report '1 problem found'
+  else
+    report "$FINDINGS problems found"
+  fi
+  exit 1
 }
 
 cmd_which() {

--- a/tests/run
+++ b/tests/run
@@ -682,13 +682,6 @@ test_usage_apply_is_stubbed() {
   assert_empty "$shale_out" 'stdout'
 }
 
-test_usage_doctor_is_stubbed() {
-  run_shale doctor
-  assert_status 1 "$shale_status"
-  assert_contains "$shale_err" 'shale: doctor is not implemented yet' 'stderr'
-  assert_empty "$shale_out" 'stdout'
-}
-
 test_usage_which_is_stubbed() {
   run_shale which .zshrc
   assert_status 1 "$shale_status"
@@ -916,6 +909,431 @@ test_config_reached_through_a_symlink_parses() {
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" 'shale: build is not implemented yet' 'stderr'
   assert_not_contains "$shale_err" 'shale.conf:' 'stderr'
+}
+
+# --------------------------------------------------------------- doctor cases
+#
+# doctor reports and never repairs, so every case here asserts the text as well
+# as the status: a run that exits 1 for some other reason satisfies the status
+# on its own.  Findings decide the exit status, warnings and notes do not, and
+# the summary line is what pins which of the two a message was.
+#
+# The report is doctor's result, so all of it is on stdout - the split which
+# makes, not the one a diagnostic makes.  That includes parse_config's messages,
+# which doctor counts as findings and so must show in the report the count
+# describes, even though the same lines are stderr under build; the config cases
+# above pin that half, and these cases assert every line landed on stdout.
+
+test_doctor_a_clean_setup_reports_no_problems() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  assert_empty "$shale_err" 'stderr'
+}
+
+test_doctor_a_missing_layer_directory_is_a_finding() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: layer 'work' has no directory at $HOME/.dotfiles/work and no url for 'work'" 'stdout'
+  assert_contains "$shale_out" 'shale:   add a url on that line, or create the directory' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # A clean config and every prerequisite present: nothing here is a diagnostic.
+  assert_empty "$shale_err" 'stderr'
+}
+
+# A path typo under a clone root that is present reads completely differently
+# from a layer that was never obtained, so the wording branches on it.
+test_doctor_a_missing_layer_beside_its_clone_names_the_config_line() {
+  conf 'base personal/base url-one' 'wsl personal/wsl2'
+  mklayer personal/base .zshrc
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: layer 'wsl' has no directory at $HOME/.dotfiles/personal/wsl2, but its clone at $HOME/.dotfiles/personal exists" \
+    'stdout'
+  assert_contains "$shale_out" 'shale:   check the path on line 2' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# A dangling symlink is the variant no -e test can see, and it is what a layer
+# left behind by a deleted clone looks like.  Both spellings must reach the same
+# wording, or the file arm alone passes while a link reports something else.
+test_doctor_a_layer_path_that_is_not_a_directory_is_a_finding() {
+  local kind
+  for kind in file dangling; do
+    conf 'base personal/base' 'local local'
+    mklayer personal/base .zshrc
+    case "$kind" in
+      file) sandbox_write "$HOME/.dotfiles" local 'not a directory' ;;
+      dangling)
+        # Second, so what is removed here is the regular file the first pass
+        # wrote: sandbox_leaf refuses a symlink at this name, which is the proof
+        # that nothing else is being deleted.
+        sandbox_mkdir "$HOME/.dotfiles"
+        sandbox_leaf "$sandbox_dir" local
+        rm -f "$sandbox_path" || fail 'could not clear the layer path'
+        ln -s "$sandbox_dir/gone" "$sandbox_path" || fail 'could not link the layer path'
+        ;;
+    esac
+    run_shale doctor
+    assert_status 1 "$shale_status" "$kind exit status"
+    assert_contains "$shale_out" \
+      "shale: layer 'local': $HOME/.dotfiles/local exists but is not a directory" "$kind stdout"
+    assert_contains "$shale_out" 'shale: 1 problem found' "$kind stdout"
+  done
+}
+
+# The sibling of the layer-level check, at the top of the tree.  A dangling
+# ~/.dotfiles reads as "create it with mkdir -p" without the -L arm, which is
+# advice that cannot work: the name is taken.
+test_doctor_a_dotfiles_path_that_is_not_a_directory_is_a_finding() {
+  local kind
+  for kind in file dangling; do
+    sandbox_mkdir "$HOME"
+    # Nothing has created .dotfiles on the first pass, and the second removes
+    # only the regular file the first wrote: a symlink at this name would be
+    # refused here rather than followed.
+    sandbox_leaf "$sandbox_dir" .dotfiles
+    rm -f "$sandbox_path" || fail 'could not clear the dotfiles path'
+    case "$kind" in
+      file) sandbox_write "$HOME" .dotfiles 'not a directory' ;;
+      dangling)
+        ln -s "$sandbox_dir/gone" "$sandbox_path" || fail 'could not link the dotfiles path'
+        ;;
+    esac
+    run_shale doctor
+    assert_status 1 "$shale_status" "$kind exit status"
+    assert_contains "$shale_out" \
+      "shale: $HOME/.dotfiles exists but is not a directory" "$kind stdout"
+    assert_not_contains "$shale_out" 'mkdir -p' "$kind stdout"
+  done
+}
+
+# A layer the config says how to obtain is a state shale fixes, not a defect in
+# the setup, so it is reported without counting.
+test_doctor_an_uncloned_layer_with_a_url_is_noted_without_failing() {
+  conf 'base personal/base url-one'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: layer 'base' has no directory at $HOME/.dotfiles/personal/base yet" 'stdout'
+  assert_contains "$shale_out" "shale:   its clone root 'personal' has a url: url-one" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+test_doctor_a_missing_dotfiles_directory_is_a_finding() {
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" "shale: no dotfiles directory at $HOME/.dotfiles" 'stdout'
+  assert_contains "$shale_out" "shale:   create it with: mkdir -p $HOME/.dotfiles" 'stdout'
+  # The config check runs anyway rather than being skipped as pointless.
+  assert_contains "$shale_out" "shale: no config file at $HOME/.dotfiles/shale.conf" 'stdout'
+  assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
+  # Both counted problems are in the report, not one of them in the terminal.
+  assert_empty "$shale_err" 'stderr'
+}
+
+# One check for three hazards: a leftover pre-shale stow package, a stray clone,
+# and the orphaned directory of a layer removed from the config.
+test_doctor_an_unrecognised_directory_is_noted_without_failing() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/common"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/common is not a configured layer" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# Everything the scan must stay quiet about: a clone root, a layer that is its
+# own root, the build output under all three of its names, the config file, and
+# any other regular file.  A doctor that noted these would cry wolf on every
+# clean setup, and the file arm is what stops it noting shale.conf's neighbours.
+test_doctor_notes_only_unrecognised_directories() {
+  local name
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  for name in current current.new current.old; do
+    sandbox_mkdir "$HOME/.dotfiles/$name"
+  done
+  sandbox_write "$HOME/.dotfiles" notes.txt 'a file someone left here'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'is not a configured layer' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# Both locations stow reads: ~/.stowrc, and the one in the directory apply runs
+# from.  Neither can be defended against, hence a note rather than silence.
+test_doctor_a_stow_resource_file_is_noted() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .stowrc '--ignore=secret'
+  sandbox_write "$HOME/.dotfiles" .stowrc '--ignore=secret'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" "shale: a stow resource file exists at $HOME/.stowrc" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: a stow resource file exists at $HOME/.dotfiles/.stowrc" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# stow reads a resource file by name, so a link that points nowhere is still one
+# it will try to read.  Without the -L arm this note goes missing.
+test_doctor_a_dangling_stow_resource_file_is_still_noted() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME"
+  ln -s "$sandbox_dir/gone" "$sandbox_dir/.stowrc" || fail 'could not link the resource file'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" "shale: a stow resource file exists at $HOME/.stowrc" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The reason doctor calls parse_config bare where every other command exits on
+# it: a broken config is when you most need the rest of the report.
+test_doctor_a_broken_config_does_not_stop_the_later_checks() {
+  sandbox_mkdir "$HOME/.dotfiles/common"
+  sandbox_write "$HOME" .stowrc '--ignore=secret'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" "shale: no config file at $HOME/.dotfiles/shale.conf" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/common is not a configured layer" 'stdout'
+  assert_contains "$shale_out" "shale: a stow resource file exists at $HOME/.stowrc" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  assert_empty "$shale_err" 'stderr'
+}
+
+test_doctor_an_unreadable_config_still_reports_the_rest() {
+  skip_if_root
+  conf 'base personal/base'
+  sandbox_mkdir "$HOME/.dotfiles/common"
+  chmod 0000 "$HOME/.dotfiles/shale.conf" || fail 'could not remove the read bit'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: cannot read $HOME/.dotfiles/shale.conf: permission denied" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/common is not a configured layer" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# Problems cluster, and a doctor that stopped at the first is one you have to
+# run five times.  The config error comes from a line the parser rejects
+# outright, so an implementation that exited on it would lose both layer
+# findings below it.
+test_doctor_reports_every_finding_in_one_run() {
+  conf 'base personal/base' 'work work' 'local local' 'base spare'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME/.dotfiles" local 'not a directory'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/shale.conf:4: duplicate layer name 'base', first used on line 1" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: layer 'work' has no directory at $HOME/.dotfiles/work and no url for 'work'" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: layer 'local': $HOME/.dotfiles/local exists but is not a directory" 'stdout'
+  # All three counted problems are in the report: a config error is a finding
+  # like any other, and this is the case that would show it missing.
+  assert_contains "$shale_out" 'shale: 3 problems found' 'stdout'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# The order the checks run in is a claim of its own: each group is meaningless
+# if an earlier one failed, and a reordering leaves every other case green.  The
+# stub PATH is here only to make the prerequisite group produce a line, since it
+# is silent whenever the tools are all present.
+# shellcheck disable=SC2123
+test_doctor_reports_its_checks_in_order() {
+  local tool found stub saved line seen
+  conf 'base personal/base' 'work work' 'lonely'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/common"
+  sandbox_write "$HOME" .stowrc '--ignore=secret'
+  sandbox_mkdir "$CASE_DIR/stub-bin"
+  stub=$sandbox_dir
+  for tool in env bash cat sed git chkstow; do
+    found=$(command -v "$tool") || fail "$tool is not on PATH"
+    sandbox_leaf "$stub" "$tool" new
+    ln -s "$found" "$sandbox_path" || fail "could not link $tool"
+  done
+  saved=$PATH
+  PATH=$stub
+  run_shale doctor
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  seen=
+  while IFS= read -r line; do
+    case "$line" in
+      'shale: stow is not installed') seen="$seen prerequisite" ;;
+      "shale: $HOME/.dotfiles/shale.conf:3:"*) seen="$seen config" ;;
+      "shale: layer 'work'"*) seen="$seen layer" ;;
+      *' is not a configured layer') seen="$seen stray" ;;
+      'shale: a stow resource file'*) seen="$seen stowrc" ;;
+      'shale: 3 problems found') seen="$seen summary" ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq ' prerequisite config layer stray stowrc summary' "$seen" 'the order of the report'
+}
+
+# The stub PATH holds every other binary doctor and the harness need, so this
+# cannot pass because something unrelated was missing.  shellcheck's SC2123 is
+# about assigning a non-path to PATH; the assignment here is the whole point,
+# and it is restored before anything else in the case runs.
+# shellcheck disable=SC2123
+test_doctor_a_missing_prerequisite_is_named_and_nothing_is_installed() {
+  local tool found stub saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$CASE_DIR/stub-bin"
+  stub=$sandbox_dir
+  for tool in env bash cat sed git chkstow; do
+    found=$(command -v "$tool") || fail "$tool is not on PATH"
+    sandbox_leaf "$stub" "$tool" new
+    ln -s "$found" "$sandbox_path" || fail "could not link $tool"
+  done
+  saved=$PATH
+  PATH=$stub
+  run_shale doctor
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: stow is not installed' 'stdout'
+  assert_contains "$shale_out" 'shale:   install it with your system package manager' 'stdout'
+  assert_not_contains "$shale_out" 'git is not installed' 'stdout'
+  assert_not_contains "$shale_out" 'chkstow is not installed' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# chkstow degrades the report rather than being a defect in the setup, so it
+# warns and the run still exits 0.
+# shellcheck disable=SC2123
+test_doctor_a_missing_chkstow_warns_without_failing() {
+  local tool found stub saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$CASE_DIR/stub-bin"
+  stub=$sandbox_dir
+  for tool in env bash cat sed git stow; do
+    found=$(command -v "$tool") || fail "$tool is not on PATH"
+    sandbox_leaf "$stub" "$tool" new
+    ln -s "$found" "$sandbox_path" || fail "could not link $tool"
+  done
+  saved=$PATH
+  PATH=$stub
+  run_shale doctor
+  PATH=$saved
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale: chkstow is not installed' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The self-shadow check reads ${BASH_SOURCE[0]}, so nothing but a script that is
+# genuinely under $HOME exercises it, and the repo's own copy never is.  These
+# are the cases that cannot go through run_shale: each proves the sandbox itself
+# first, and then captures exactly what the wrapper would have captured.
+#
+# The variants are the shapes ${BASH_SOURCE[0]} arrives in and the shapes a
+# layer can provide the path in.  'bare' has no '/' in it at all, which is the
+# one spelling for which the directory cannot be taken from the invocation.
+test_doctor_a_layer_providing_the_running_script_is_a_finding() {
+  local copy dir variant out err status text
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.local/bin"
+  dir=$sandbox_dir
+  sandbox_leaf "$dir" shale new
+  copy=$sandbox_path
+  cp "$SHALE" "$copy" || fail 'could not copy the script'
+  chmod 0755 "$copy" || fail 'could not make the copy executable'
+  for variant in absolute relative bare dangling; do
+    case "$variant" in
+      dangling)
+        # Last, so what is removed is the regular file the earlier variants
+        # wrote: sandbox_leaf refuses a symlink at this name.
+        sandbox_mkdir "$HOME/.dotfiles/local/.local/bin"
+        sandbox_leaf "$sandbox_dir" shale
+        rm -f "$sandbox_path" || fail 'could not clear the layer file'
+        ln -s "$sandbox_dir/gone" "$sandbox_path" || fail 'could not link the layer file'
+        ;;
+      *) mklayer local .local/bin/shale ;;
+    esac
+    sandbox_leaf "$CASE_DIR" "$variant.out" new
+    out=$sandbox_path
+    sandbox_leaf "$CASE_DIR" "$variant.err" new
+    err=$sandbox_path
+    require_sandbox
+    status=0
+    case "$variant" in
+      relative) (cd "$dir" && ./shale doctor) >"$out" 2>"$err" || status=$? ;;
+      bare) (cd "$dir" && bash shale doctor) >"$out" 2>"$err" || status=$? ;;
+      *) "$copy" doctor >"$out" 2>"$err" || status=$? ;;
+    esac
+    text=$(cat "$out")
+    assert_status 1 "$status" "$variant exit status"
+    assert_contains "$text" \
+      "shale: layer 'local' provides the running script itself at $HOME/.dotfiles/local/.local/bin/shale" \
+      "$variant stdout"
+    assert_not_contains "$text" "layer 'base' provides" "$variant stdout"
+    assert_contains "$text" 'shale: 1 problem found' "$variant stdout"
+    assert_empty "$(cat "$err")" "$variant stderr"
+  done
+}
+
+# A script that sits directly in $HOME: its $HOME-relative path is the bare
+# leaf, with no directory part to strip.
+test_doctor_finds_a_layer_shipping_a_script_that_lives_in_home() {
+  local copy out err status text
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local shale
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" shale new
+  copy=$sandbox_path
+  cp "$SHALE" "$copy" || fail 'could not copy the script'
+  chmod 0755 "$copy" || fail 'could not make the copy executable'
+  sandbox_leaf "$CASE_DIR" copy.out new
+  out=$sandbox_path
+  sandbox_leaf "$CASE_DIR" copy.err new
+  err=$sandbox_path
+  require_sandbox
+  status=0
+  "$copy" doctor >"$out" 2>"$err" || status=$?
+  text=$(cat "$out")
+  assert_status 1 "$status"
+  assert_contains "$text" \
+    "shale: layer 'local' provides the running script itself at $HOME/.dotfiles/local/shale" 'stdout'
+  assert_contains "$text" 'shale: 1 problem found' 'stdout'
+  assert_empty "$(cat "$err")" 'stderr'
+}
+
+# The other half of that check: it is skipped when the running script is not
+# under $HOME, which is what a shale installed on PATH looks like.  The layer
+# ships both shapes the derived path could take - the bare leaf and the full
+# relative path - so an implementation that fell back to either instead of
+# skipping reports this layer.
+test_doctor_ignores_a_script_that_is_not_under_home() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local shale
+  mklayer local .local/bin/shale
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'running script' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
 }
 
 # ------------------------------------------------------------------ meta cases


### PR DESCRIPTION
Closes #5.

Suite 73 → 92. `shale` 312 → ~470 lines. First command that does real work rather than stubbing.

## Decisions worth knowing

**`parse_config` is called bare here, alone among the commands.** Every other caller exits on a bad config; doctor's whole value is reporting on prerequisites and layers *when* the config is broken. Its error count folds into the findings and the run continues.

**The report goes to stdout**, matching `which`, because it is the product of the command rather than a diagnostic about it — someone will run `shale doctor > report.txt`. That extends to the config errors doctor surfaces, which it counts as findings, so the call site redirects them while `build`, `apply` and `which` still send the same line to stderr. **Both directions are pinned by mutations**, so neither half can be simplified away without a red suite.

**Not everything wrong is a problem.** A layer whose directory does not exist yet but whose clone root has a url is a *note* — `shale build` is about to create it, and reporting it would be the same mistake as counting a missing `chkstow` as a defect. A path typo under an already-cloned root is still a finding, because the directory test precedes the url lookup.

**The self-shadow check derives its own path from `${BASH_SOURCE[0]}`** and skips when the script is not under `$HOME`. `shale` installs by copying it to any name on any `PATH`, so a hard-coded location would contradict the tool's own contract.

## Review

One code-review round and one functional round, both independent agents. **Both returned merge; neither found a functional defect.**

The functional gate wrote 28 mutations of its own and found **nine survivors** — cases that passed whether or not the code worked. All are now closed:

| gap | now killed by |
|---|---|
| four `[ -e ] \|\| [ -L ]` pairs, each individually | four cases, incl. a dangling `.stowrc` and a dangling `~/.dotfiles` |
| `[ "$dir" != "$src" ] \|\| dir=.` | the `bare` variant — `bash shale`, the only spelling where `${BASH_SOURCE[0]}` has no `/` |
| the `[ "$dir" = "$home" ]` block | a layer shipping a script that lives directly in `$HOME` |
| `*) return 1 ;;` weakening to `*) SELF_REL=$base ;;` | negative control now ships both `local/shale` and `local/.local/bin/shale` |
| `[ -d "$entry" ] \|\| continue` | a stray regular file must not draw a note |
| check order | `test_doctor_reports_its_checks_in_order` — walks the report, tags six groups, asserts the sequence |

Running total: **31 mutations, 31 killed, 0 survivors.** The earlier 21 were re-run against the final code rather than assumed, since several fixtures had moved.

Three comment corrections also went in, including one that credited the wrong mechanism: `self_relative_path`'s trailing-slash comment claimed the appended `/` was what stopped `$HOME-elsewhere` matching. The truth table says it is the `/` in the *pattern*; the appended one only matters for a case the branch above already returns from.

## Coordinator verification

- `./tests/run` → 92 passed, 0 failed, 0 skipped.
- Dropping the `-L` arm from the `.stowrc` check fails exactly one case.
- `shale doctor` on a broken config: whole report on stdout, **stderr empty**, exit 1, notes not counted.
- `shale build` on the same config still puts the error on stderr.
- `~/.dotfiles` still contains only `common`.

## Not fixed here

Filed as #29: two diagnostics inherited from #4 that misreport their cause, `~/.dotfiles` at mode 0111 silently yielding no stray notes, and — the one that matters — `$DOTFILES/.stowrc` being a bet on a cwd decision #8 has not made yet.

Also included: a one-line fix to the macOS job's comment, which claimed the check was deliberately not required. It became required an hour after that was written.