### PR TITLE
Clone missing layer roots during build

### DIFF
--- a/shale
+++ b/shale
@@ -277,21 +277,27 @@ clone_url() {
   return 1
 }
 
-# ---------------------------------------------------------------- the composer
+# ----------------------------------------------------------- the scratch trees
 
 # The scratch tree while one exists, and empty otherwise, which is what makes
-# cleanup idempotent.
+# cleanup idempotent.  CLONING is the same for the clone in flight: an
+# interrupted clone must leave nothing behind that a later run could walk.
 SCRATCH=
+CLONING=
 
-# The glob gate is the last line of defence on the only rm -rf in this script:
-# an empty or corrupted SCRATCH lands in the refusing branch rather than
-# deleting a layer or a home directory.  Blanking comes first so a second call
-# does nothing even if the removal failed.
+# The glob gates are the last line of defence on these two rm -rf calls, which
+# run from a trap at a moment nothing chose: an empty or corrupted variable
+# lands in a refusing branch rather than deleting a layer or a home directory.
+# Blanking comes first so a second call does nothing even if a removal failed.
 cleanup() {
-  local scratch=${SCRATCH-}
+  local scratch=${SCRATCH-} cloning=${CLONING-}
   SCRATCH=
+  CLONING=
   case "$scratch" in
     */current.new) rm -rf "$scratch" ;;
+  esac
+  case "$cloning" in
+    */.*.cloning) rm -rf "$cloning" ;;
   esac
 }
 
@@ -322,6 +328,71 @@ defer_signals() {
 
 DEFERRED=
 arm_traps
+
+# ------------------------------------------------------------------ the clones
+
+# Clones every configured clone root that has a url and nothing at its path,
+# before anything is composed, so a clone that fails costs nothing composed.
+# One clone per root however many layers derive from it, which is the whole
+# reason a url attaches to the root rather than to the layer.  A checkout that
+# is already there is left exactly as it is: updating one is git's job.
+clone_missing_roots() {
+  local i root url dir tmp have_git
+  have_git=0
+  i=0
+  while [ "$i" -lt "${#CLONE_ROOTS[@]}" ]; do
+    root=${CLONE_ROOTS[$i]}
+    url=${CLONE_URLS[$i]}
+    dir=$DOTFILES/$root
+    i=$((i + 1))
+    # -L as well as -e, because a dangling symlink is something someone else
+    # put there too: the layer check below names it, rather than this cloning
+    # into whatever it points at or renaming over it.
+    { [ ! -e "$dir" ] && [ ! -L "$dir" ]; } || continue
+    # Lazily, and once: a machine where every layer is already present builds
+    # with no git installed at all.
+    if [ "$have_git" -eq 0 ]; then
+      command -v git >/dev/null 2>&1 ||
+        die "git is not installed, and $dir must be cloned from $url" \
+          'install it with your system package manager: shale installs nothing'
+      have_git=1
+    fi
+    # The leading dot is what keeps this name out of the layer namespace: a
+    # path component in the config must start with a letter, digit or '_', so
+    # no configured layer can ever be called this.
+    tmp=$DOTFILES/.$root.cloning
+    rm -rf "$tmp" || die "could not remove $tmp"
+    { [ ! -e "$tmp" ] && [ ! -L "$tmp" ]; } || die "$tmp still exists"
+    report "cloning '$root' from $url into $dir"
+    # Into the temporary name and renamed after, so an interrupted or failed
+    # clone cannot leave a half-populated directory that looks like a layer.
+    # git's stderr is neither captured nor reformatted: it is the progress of
+    # the slowest part of a bootstrap, and the diagnosis when one fails.
+    CLONING=$tmp
+    git clone -- "$url" "$tmp" || die "could not clone $url into $dir"
+    # Re-tested here because a clone takes as long as a network does: mv into a
+    # directory that exists moves the source *inside* it, which would nest a
+    # whole clone one level down and satisfy every test after this one.
+    if [ -e "$dir" ] || [ -L "$dir" ]; then
+      CLONING=
+      die "$dir appeared while '$root' was being cloned" \
+        "the clone is at $tmp"
+    fi
+    mv "$tmp" "$dir"
+    # Judged by the filesystem rather than by mv's status: a rename that
+    # completed always leaves the source gone.
+    if [ ! -d "$dir" ] || [ -e "$tmp" ] || [ -L "$tmp" ]; then
+      # Kept rather than cleaned up: it is a whole clone, and fetching it again
+      # is the one cost in this script that is not shale's to spend twice.
+      CLONING=
+      die "could not move the clone into place at $dir" \
+        "the clone is at $tmp"
+    fi
+    CLONING=
+  done
+}
+
+# ---------------------------------------------------------------- the composer
 
 # The layer compose_dir is walking, for the messages it raises.  Threading four
 # more arguments through a recursion to reach them buys nothing.
@@ -521,6 +592,10 @@ cmd_build() {
   # the last thing this process does.
   shopt -s dotglob nullglob
 
+  # Before the check below, which is what makes a root with a url that shale
+  # can obtain no longer a missing layer at all.
+  clone_missing_roots
+
   # Every layer is verified before anything is written, so a missing one costs
   # nothing composed.  The wording branches on the cause because the cause is
   # what decides the remedy.
@@ -540,12 +615,9 @@ cmd_build() {
       emit "layer '$name' has no directory at $dir, but its clone at $DOTFILES/$root exists" \
         "check the path on line ${LAYER_LINES[$i]}"
       errors=$((errors + 1))
-    elif clone_url "$root"; then
-      emit "layer '$name' has no directory at $dir" \
-        "its clone root '$root' has a url: $CLONE_URL" \
-        "clone '$root' from it, or create the directory"
-      errors=$((errors + 1))
     else
+      # No branch for a root with a url: cloning has already run, and it either
+      # obtained that root or stopped the build.
       emit "layer '$name' has no directory at $dir and no url for '$root'" \
         "add a url on that line, or create the directory"
       errors=$((errors + 1))
@@ -571,8 +643,12 @@ cmd_build() {
   # Reaping whatever a killed run left behind.
   rm -rf "$NEW" || die "could not remove $NEW"
   { [ ! -e "$NEW" ] && [ ! -L "$NEW" ]; } || die "$NEW still exists"
-  mkdir "$NEW" || die "could not create $NEW"
+  # Before the mkdir, not after it: a signal delivered between the two would
+  # otherwise run cleanup with SCRATCH still empty and leave the scratch tree
+  # behind.  Naming a path that does not exist yet costs nothing - cleanup's
+  # rm -rf is a no-op on it - which is what makes this ordering free.
   SCRATCH=$NEW
+  mkdir "$NEW" || die "could not create $NEW"
 
   DIVERGED_PATHS=()
   DIVERGED_LAYERS=()

--- a/shale
+++ b/shale
@@ -361,6 +361,11 @@ clone_missing_roots() {
     # path component in the config must start with a letter, digit or '_', so
     # no configured layer can ever be called this.
     tmp=$DOTFILES/.$root.cloning
+    # Named before anything touches it, reaping included: a signal delivered
+    # partway through the rm would otherwise run cleanup with CLONING still
+    # empty and leave a half-removed tree behind.  Naming a path costs nothing,
+    # which is what makes doing it first free.
+    CLONING=$tmp
     rm -rf "$tmp" || die "could not remove $tmp"
     { [ ! -e "$tmp" ] && [ ! -L "$tmp" ]; } || die "$tmp still exists"
     report "cloning '$root' from $url into $dir"
@@ -368,25 +373,29 @@ clone_missing_roots() {
     # clone cannot leave a half-populated directory that looks like a layer.
     # git's stderr is neither captured nor reformatted: it is the progress of
     # the slowest part of a bootstrap, and the diagnosis when one fails.
-    CLONING=$tmp
     git clone -- "$url" "$tmp" || die "could not clone $url into $dir"
     # Re-tested here because a clone takes as long as a network does: mv into a
     # directory that exists moves the source *inside* it, which would nest a
     # whole clone one level down and satisfy every test after this one.
     if [ -e "$dir" ] || [ -L "$dir" ]; then
       CLONING=
+      # No build reaps it either: the reap runs only for a root that is about
+      # to be cloned, and this one no longer is.  So the message says so.
       die "$dir appeared while '$root' was being cloned" \
-        "the clone is at $tmp"
+        "the clone is at $tmp" \
+        "no build will touch it while $dir exists: use it, or remove it"
     fi
     mv "$tmp" "$dir"
     # Judged by the filesystem rather than by mv's status: a rename that
     # completed always leaves the source gone.
     if [ ! -d "$dir" ] || [ -e "$tmp" ] || [ -L "$tmp" ]; then
-      # Kept rather than cleaned up: it is a whole clone, and fetching it again
-      # is the one cost in this script that is not shale's to spend twice.
+      # Kept rather than cleaned up, and the message says what to do with it.
+      # The next build reaps it and fetches again, so keeping it silently would
+      # save nothing: what makes it worth keeping is being told it is there.
       CLONING=
       die "could not move the clone into place at $dir" \
-        "the clone is at $tmp"
+        "the clone is at $tmp" \
+        "move it into place with: mv $tmp $dir, or the next build fetches it again"
     fi
     CLONING=
   done
@@ -615,9 +624,19 @@ cmd_build() {
       emit "layer '$name' has no directory at $dir, but its clone at $DOTFILES/$root exists" \
         "check the path on line ${LAYER_LINES[$i]}"
       errors=$((errors + 1))
+    elif [ -e "$DOTFILES/$root" ] || [ -L "$DOTFILES/$root" ]; then
+      # Reached only by a layer path deeper than its root - a one-component path
+      # is the arm above - and it is why cloning does not make this state
+      # unreachable: shale removes nothing it did not create, so a root that is
+      # a file or a dangling symlink is never cloned over, whether or not the
+      # config gives a url for it.
+      emit "layer '$name' has no directory at $dir" \
+        "its clone root $DOTFILES/$root exists but is not a directory" \
+        'remove it, or move it aside'
+      errors=$((errors + 1))
     else
-      # No branch for a root with a url: cloning has already run, and it either
-      # obtained that root or stopped the build.
+      # No branch for a root with a url and nothing at its path: cloning has
+      # already run, and it either obtained that root or stopped the build.
       emit "layer '$name' has no directory at $dir and no url for '$root'" \
         "add a url on that line, or create the directory"
       errors=$((errors + 1))
@@ -848,9 +867,15 @@ cmd_doctor() {
     elif [ -d "$DOTFILES/$root" ]; then
       finding "layer '$name' has no directory at $dir, but its clone at $DOTFILES/$root exists" \
         "check the path on line ${LAYER_LINES[$i]}"
+    elif [ -e "$DOTFILES/$root" ] || [ -L "$DOTFILES/$root" ]; then
+      # Before the url arm, and counted: a url does not mean shale can obtain
+      # this root, because shale clones only where nothing is.
+      finding "layer '$name' has no directory at $dir" \
+        "its clone root $DOTFILES/$root exists but is not a directory" \
+        'remove it, or move it aside'
     elif clone_url "$root"; then
-      # A url means shale can obtain this one, so it is reported without
-      # counting: it is a state shale fixes, not a defect in the setup.
+      # A url and nothing in the way means shale can obtain this one, so it is
+      # reported without counting: a state shale fixes, not a defect.
       note "layer '$name' has no directory at $dir yet" \
         "its clone root '$root' has a url: $CLONE_URL"
     else

--- a/tests/run
+++ b/tests/run
@@ -470,6 +470,31 @@ conf() {
   sandbox_write "$HOME/.dotfiles" shale.conf ${1+"$@"}
 }
 
+# mkrepo NAME RELPATH... - a git repository at $CASE_DIR/repos/NAME holding one
+# commit of each RELPATH, with content NAME/RELPATH so an assertion pins where a
+# file came from.  Its path lands in repo_url: every clone case names a
+# repository it created itself, because a case that named a host would be
+# testing the network.
+#
+# Outside $HOME on purpose - a clone source is not part of the home being built,
+# and one under ~/.dotfiles would be a layer.  '-c init.defaultBranch' is not
+# cosmetic: without it git's advice block lands in every captured failure dump.
+mkrepo() {
+  local name=${1-} rel dir target
+  [ -n "$name" ] || fail 'mkrepo: no name given'
+  shift
+  sandbox_mkdir "$CASE_DIR/repos/$name"
+  dir=$sandbox_dir
+  git -c init.defaultBranch=main init -q "$dir" || fail "could not init $dir"
+  for rel in ${1+"$@"}; do
+    target=$dir/$rel
+    sandbox_write "${target%/*}" "${target##*/}" "$name/$rel"
+  done
+  (cd "$dir" && git add -A . && git commit -qm 'fixture') ||
+    fail "could not commit in $dir"
+  repo_url=$dir
+}
+
 # mklayer LAYER RELPATH [CONTENT] - LAYER is a path under $HOME/.dotfiles.
 # CONTENT defaults to LAYER/RELPATH, so an assertion pins which layer won
 # without the case having to state it.
@@ -1354,6 +1379,47 @@ stub_mv() {
   chmod 0755 "$sandbox_path" || fail 'could not make the stub executable'
 }
 
+# A mkdir on PATH that creates the directory and then interrupts shale, for the
+# one instant no timed test can aim at: the scratch tree exists and shale has
+# not yet recorded its name.  $PPID is shale itself - env execs bash in place,
+# so there is no shell of the stub's own in between - and bash defers the
+# handler to the next command boundary, which is where the window is.  Sets
+# stub_path, which the caller puts in front of PATH.
+stub_mkdir_interrupt() {
+  local match=$1 real
+  real=$(command -v mkdir) || fail 'mkdir is not on PATH'
+  sandbox_mkdir "$CASE_DIR/stub-bin"
+  stub_path=$sandbox_dir
+  # shellcheck disable=SC2016  # the body is written for the stub's shell
+  sandbox_write "$stub_path" mkdir \
+    '#!/usr/bin/env bash' \
+    "$real \"\$@\" || exit \$?" \
+    'case "$1" in' \
+    "  $match) kill -INT \"\$PPID\" ;;" \
+    'esac' \
+    'exit 0'
+  chmod 0755 "$sandbox_path" || fail 'could not make the stub executable'
+}
+
+# The scratch tree has to be named before it is created, not after: a signal
+# arriving between the two runs cleanup while SCRATCH is still empty, and the
+# tree survives a run that reported nothing.
+# shellcheck disable=SC2123
+test_build_an_interrupt_as_the_scratch_tree_appears_leaves_nothing() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  stub_mkdir_interrupt '*/current.new'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  # 128 + SIGINT: shale re-raises the signal rather than inventing a status.
+  assert_status 130 "$shale_status"
+  assert_missing "$HOME/.dotfiles/current.new"
+  assert_missing "$HOME/.dotfiles/current"
+}
+
 # Three states a failed install can leave, three messages.  The first-build one
 # is the case that used to leak mv's own 'cannot stat' line and then advise a
 # recovery command naming a directory that had never existed.
@@ -1564,8 +1630,11 @@ shale: composed layer 'local' from $HOME/.dotfiles/local" "$shale_out" 'stdout'
 # Every layer is verified before anything is written, and all of them in one
 # run.  Without this a missing layer directory composes nothing and reports
 # success, which is the silent half of a mistyped path.
+# Two causes, two wordings, one run.  A root with a url is not among them: by
+# the time this check runs, cloning has either obtained that root or stopped the
+# build, so there is no third thing a missing layer can be.
 test_build_a_missing_layer_directory_stops_the_build() {
-  conf 'base personal/base' 'work work' 'wsl personal/wsl2' 'web web url-one'
+  conf 'base personal/base' 'work work' 'wsl personal/wsl2'
   mklayer personal/base .zshrc
   run_shale build
   assert_status 1 "$shale_status"
@@ -1576,9 +1645,6 @@ test_build_a_missing_layer_directory_stops_the_build() {
     "shale: layer 'wsl' has no directory at $HOME/.dotfiles/personal/wsl2, but its clone at $HOME/.dotfiles/personal exists" \
     'stderr'
   assert_contains "$shale_err" 'shale:   check the path on line 3' 'stderr'
-  assert_contains "$shale_err" \
-    "shale: layer 'web' has no directory at $HOME/.dotfiles/web" 'stderr'
-  assert_contains "$shale_err" "shale:   its clone root 'web' has a url: url-one" 'stderr'
   assert_empty "$shale_out" 'stdout'
   assert_missing "$HOME/.dotfiles/current"
   assert_missing "$HOME/.dotfiles/current.new"
@@ -1593,6 +1659,331 @@ test_build_a_layer_path_that_is_not_a_directory_stops_the_build() {
   assert_contains "$shale_err" \
     "shale: layer 'local': $HOME/.dotfiles/local exists but is not a directory" 'stderr'
   assert_empty "$shale_out" 'stdout'
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# ---------------------------------------------------------------- clone cases
+#
+# Every url here is a path to a repository the case created; no case names a
+# host.  What the cases are about is what shale does around git, so the ones
+# that count clones put a recording git in front of the real one rather than
+# reading shale's own report back to itself.
+
+# A git on PATH that appends its arguments to a log and then runs the real one.
+# BEFORE is shell run first, which is the only way to reach the state where
+# something else created the clone root while the clone was in flight.  Sets
+# stub_path, which the caller puts in front of PATH, and git_log.
+stub_git() {
+  local before=${1-} real
+  real=$(command -v git) || fail 'git is not on PATH'
+  sandbox_leaf "$CASE_DIR" git-calls new
+  git_log=$sandbox_path
+  : >"$git_log" || fail "could not write $git_log"
+  sandbox_mkdir "$CASE_DIR/stub-bin"
+  stub_path=$sandbox_dir
+  # shellcheck disable=SC2016  # written for the stub's shell, not this one
+  sandbox_write "$stub_path" git \
+    '#!/usr/bin/env bash' \
+    "printf '%s\n' \"\$*\" >>\"$git_log\"" \
+    "${before:-:}" \
+    "exec $real \"\$@\""
+  chmod 0755 "$sandbox_path" || fail 'could not make the stub executable'
+}
+
+# The bootstrap this whole design exists for: a config, no layer, one command.
+# The assertion on stderr is git's own 'Cloning into' line, which pins both that
+# the clone runs into the temporary name and that nothing passes --quiet; the
+# path is asserted rather than the sentence, which git translates.
+test_clone_a_missing_root_is_cloned_and_composed() {
+  mkrepo personal .zshrc .config/git/config
+  conf "base personal $repo_url"
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: cloning 'personal' from $repo_url into $HOME/.dotfiles/personal" 'stdout'
+  assert_contains "$shale_err" "$HOME/.dotfiles/.personal.cloning" 'stderr'
+  assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/personal/.zshrc")" 'the clone'
+  assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+  assert_eq 'personal/.config/git/config' \
+    "$(cat "$HOME/.dotfiles/current/.config/git/config")" 'the built tree'
+  assert_exists "$HOME/.dotfiles/personal/.git" 'the checkout'
+  assert_missing "$HOME/.dotfiles/current/.git"
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+}
+
+# One clone per root, not per layer: this is the whole reason the url attaches
+# to the first path component rather than to the layer.
+# shellcheck disable=SC2123
+test_clone_one_clone_serves_every_layer_under_its_root() {
+  local saved clones
+  mkrepo personal base/.zshrc wsl/.zshrc work/.gitconfig
+  conf "base personal/base $repo_url" 'wsl personal/wsl' 'work personal/work'
+  stub_git
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 0 "$shale_status"
+  clones=$(grep -c '^clone ' "$git_log")
+  assert_eq 1 "$clones" 'git clone invocations'
+  assert_eq "shale: cloning 'personal' from $repo_url into $HOME/.dotfiles/personal
+shale: composed layer 'base' from $HOME/.dotfiles/personal/base
+shale: composed layer 'wsl' from $HOME/.dotfiles/personal/wsl
+shale: composed layer 'work' from $HOME/.dotfiles/personal/work" "$shale_out" 'stdout'
+  assert_eq 'personal/wsl/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+  assert_eq 'personal/work/.gitconfig' \
+    "$(cat "$HOME/.dotfiles/current/.gitconfig")" 'the built tree'
+}
+
+test_clone_every_missing_root_with_a_url_is_cloned() {
+  local personal_url
+  mkrepo personal .zshrc
+  personal_url=$repo_url
+  mkrepo work .gitconfig
+  conf "base personal $personal_url" "work work $repo_url"
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_eq "shale: cloning 'personal' from $personal_url into $HOME/.dotfiles/personal
+shale: cloning 'work' from $repo_url into $HOME/.dotfiles/work
+shale: composed layer 'base' from $HOME/.dotfiles/personal
+shale: composed layer 'work' from $HOME/.dotfiles/work" "$shale_out" 'stdout'
+  assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+  assert_eq 'work/.gitconfig' "$(cat "$HOME/.dotfiles/current/.gitconfig")" 'the built tree'
+}
+
+# The case that keeps a sync command cut from scope: shale obtains a layer it
+# has not got and never touches one it has.  git is not run at all on the second
+# build, which is the same claim the lazy prerequisite check makes.
+# shellcheck disable=SC2123
+test_clone_an_existing_checkout_is_left_alone() {
+  local saved
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_write "$HOME/.dotfiles/personal" UNTRACKED 'not in the repository'
+  sandbox_write "$HOME/.dotfiles/personal" .zshrc 'edited in the checkout'
+  stub_git
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 0 "$shale_status"
+  assert_empty "$(cat "$git_log")" 'git invocations'
+  assert_not_contains "$shale_out" 'cloning' 'stdout'
+  assert_eq 'not in the repository' \
+    "$(cat "$HOME/.dotfiles/personal/UNTRACKED")" 'the untracked marker'
+  assert_eq 'edited in the checkout' \
+    "$(cat "$HOME/.dotfiles/personal/.zshrc")" 'the edited file'
+  assert_eq 'edited in the checkout' \
+    "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+}
+
+# git's own diagnosis is what says why, so it is neither captured nor
+# reformatted.  Nothing is left at either name: a half-populated directory at
+# the layer path is a tree the composer would happily walk.
+#
+# All that is asserted of git's line is that it is there: a stderr line that is
+# not shale's, carrying git's 'fatal: ' prefix.  The sentence after that prefix
+# is git's to reword and gettext's to translate, and this runs against whatever
+# git the macOS runner ships as well as this one; the prefix is a plain literal
+# in git's usage.c and goes through no message catalogue.
+test_clone_a_url_that_is_not_a_repository_leaves_nothing_behind() {
+  local foreign
+  conf "base personal $CASE_DIR/repos/absent"
+  run_shale build
+  assert_status 1 "$shale_status"
+  foreign=$(printf '%s\n' "$shale_err" | grep -v '^shale:')
+  assert_contains "$foreign" 'fatal: ' "git's own stderr"
+  assert_contains "$shale_err" \
+    "shale: could not clone $CASE_DIR/repos/absent into $HOME/.dotfiles/personal" 'stderr'
+  assert_missing "$HOME/.dotfiles/personal"
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/current"
+  assert_missing "$HOME/.dotfiles/current.new"
+}
+
+# A clone that dies part-way is the realistic network failure, and the one a
+# url pointing at nothing never reaches: git has written a partial tree by then.
+# It must not survive under any name - at the layer path it is a tree the
+# composer would walk, and at the temporary one it would block the next build.
+# shellcheck disable=SC2123
+test_clone_a_partly_written_clone_is_removed() {
+  local saved
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  # $4 is the destination git was given: 'clone -- URL DEST'.
+  # shellcheck disable=SC2016  # the body runs in the stub, not here
+  stub_git 'mkdir -p "$4/objects" && printf half >"$4/HEAD"; exit 1'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: could not clone $repo_url into $HOME/.dotfiles/personal" 'stderr'
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/personal"
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# What a killed clone leaves is reaped, not cloned into: git refuses a
+# destination that is not empty, so without this the next build cannot recover.
+test_clone_a_stale_cloning_directory_is_reaped() {
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  sandbox_write "$HOME/.dotfiles/.personal.cloning" LEFTOVER 'from a killed run'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/personal/LEFTOVER"
+  assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+}
+
+# The clone lands and the layer is still missing, which is a mistyped path under
+# a real checkout and nothing shale can obtain.  Also the order: the clone has
+# to have happened before this check could reach that wording.
+test_clone_a_layer_missing_inside_a_fresh_clone_is_the_path_error() {
+  mkrepo personal base/.zshrc
+  conf "base personal/base $repo_url" 'wsl personal/wsl2'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: layer 'wsl' has no directory at $HOME/.dotfiles/personal/wsl2, but its clone at $HOME/.dotfiles/personal exists" \
+    'stderr'
+  assert_contains "$shale_err" 'shale:   check the path on line 2' 'stderr'
+  assert_exists "$HOME/.dotfiles/personal/base/.zshrc" 'the clone'
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# Anything already at a clone root is left alone whatever it is, and the layer
+# check names it: cloning over it would mean removing something shale did not
+# put there.
+test_clone_a_root_that_is_not_a_directory_is_not_cloned_over() {
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  sandbox_write "$HOME/.dotfiles" personal 'not a directory'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: layer 'base': $HOME/.dotfiles/personal exists but is not a directory" 'stderr'
+  assert_eq 'not a directory' "$(cat "$HOME/.dotfiles/personal")" 'the planted file'
+  assert_not_contains "$shale_out" 'cloning' 'stdout'
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+}
+
+# The variant no -e test can see, and the one a removed clone leaves behind.
+test_clone_a_dangling_symlink_at_a_root_is_not_cloned_over() {
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  sandbox_target "$HOME/.dotfiles" personal
+  ln -s "$HOME/.dotfiles/gone" "$sandbox_path" || fail 'could not link the root'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: layer 'base': $HOME/.dotfiles/personal exists but is not a directory" 'stderr'
+  assert_not_contains "$shale_out" 'cloning' 'stdout'
+  assert_missing "$HOME/.dotfiles/gone"
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+}
+
+# git is a prerequisite of cloning, not of building.  The url is deliberately
+# one no clone could succeed from: an implementation that cloned eagerly fails
+# this case rather than passing it slowly.
+# shellcheck disable=SC2123
+test_clone_git_is_needed_only_when_a_clone_is() {
+  local tool found stub saved
+  conf "base personal $CASE_DIR/repos/absent"
+  mklayer personal .zshrc
+  sandbox_mkdir "$CASE_DIR/stub-bin"
+  stub=$sandbox_dir
+  for tool in env bash cat sed rm mkdir cp mv; do
+    found=$(command -v "$tool") || fail "$tool is not on PATH"
+    sandbox_leaf "$stub" "$tool" new
+    ln -s "$found" "$sandbox_path" || fail "could not link $tool"
+  done
+  saved=$PATH
+  PATH=$stub
+  run_shale build
+  PATH=$saved
+  assert_status 0 "$shale_status"
+  assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+  assert_not_contains "$shale_out" 'cloning' 'stdout'
+}
+
+# shellcheck disable=SC2123
+test_clone_a_missing_git_stops_a_build_that_must_clone() {
+  local tool found stub saved
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  sandbox_mkdir "$CASE_DIR/stub-bin"
+  stub=$sandbox_dir
+  for tool in env bash cat sed rm mkdir cp mv; do
+    found=$(command -v "$tool") || fail "$tool is not on PATH"
+    sandbox_leaf "$stub" "$tool" new
+    ln -s "$found" "$sandbox_path" || fail "could not link $tool"
+  done
+  saved=$PATH
+  PATH=$stub
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: git is not installed, and $HOME/.dotfiles/personal must be cloned from $repo_url" 'stderr'
+  assert_contains "$shale_err" \
+    'shale:   install it with your system package manager: shale installs nothing' 'stderr'
+  assert_missing "$HOME/.dotfiles/personal"
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# A rename that fails after a whole clone has been fetched: the clone is kept
+# and named, because fetching it again is the one cost here that is not shale's
+# to spend twice.
+# shellcheck disable=SC2123
+test_clone_a_clone_that_cannot_be_moved_into_place_is_kept() {
+  local saved
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  stub_mv '*/.personal.cloning' 1
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: could not move the clone into place at $HOME/.dotfiles/personal" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   the clone is at $HOME/.dotfiles/.personal.cloning" 'stderr'
+  assert_eq 'personal/.zshrc' \
+    "$(cat "$HOME/.dotfiles/.personal.cloning/.zshrc")" 'the kept clone'
+  assert_missing "$HOME/.dotfiles/personal"
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# The window between the check that the root is missing and the rename that
+# fills it is as long as a network is.  mv into a directory that exists puts the
+# source inside it, so a clone that lost that race would otherwise land at
+# ~/.dotfiles/personal/.personal.cloning and nothing after it would notice.
+# shellcheck disable=SC2123
+test_clone_a_root_that_appears_during_the_clone_is_not_nested_into() {
+  local saved
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  # shellcheck disable=SC2016  # the body runs in the stub, not here
+  stub_git 'mkdir -p "$HOME/.dotfiles/personal"'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal appeared while 'personal' was being cloned" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   the clone is at $HOME/.dotfiles/.personal.cloning" 'stderr'
+  assert_missing "$HOME/.dotfiles/personal/.personal.cloning"
+  assert_eq 'personal/.zshrc' \
+    "$(cat "$HOME/.dotfiles/.personal.cloning/.zshrc")" 'the kept clone'
   assert_missing "$HOME/.dotfiles/current"
 }
 

--- a/tests/run
+++ b/tests/run
@@ -1379,25 +1379,40 @@ stub_mv() {
   chmod 0755 "$sandbox_path" || fail 'could not make the stub executable'
 }
 
-# A mkdir on PATH that creates the directory and then interrupts shale, for the
-# one instant no timed test can aim at: the scratch tree exists and shale has
-# not yet recorded its name.  $PPID is shale itself - env execs bash in place,
-# so there is no shell of the stub's own in between - and bash defers the
-# handler to the next command boundary, which is where the window is.  Sets
-# stub_path, which the caller puts in front of PATH.
-stub_mkdir_interrupt() {
-  local match=$1 real
-  real=$(command -v mkdir) || fail 'mkdir is not on PATH'
+# stub_interrupt NAME MATCH BODY - a NAME on PATH that runs BODY and then
+# interrupts shale, for the calls whose whole argument list matches MATCH;
+# every other call execs the real one.  BODY may use "$real" and the arguments.
+#
+# This is how a case aims at an instant no timed test can hit: the moment a
+# path exists, or half exists, and shale has not yet recorded its name.  $PPID
+# is shale itself - env execs bash in place, so there is no shell of the stub's
+# own in between - and bash defers the handler to the next command boundary,
+# which is where each of those windows is.  Sets stub_path, which the caller
+# puts in front of PATH.
+#
+# It fires once.  The handler it provokes runs the same tool against the same
+# path, so a stub that fired every time would defeat the cleanup it exists to
+# test and the case would fail against correct code.
+stub_interrupt() {
+  local name=$1 match=$2 body=$3 real
+  real=$(command -v "$name") || fail "$name is not on PATH"
   sandbox_mkdir "$CASE_DIR/stub-bin"
   stub_path=$sandbox_dir
   # shellcheck disable=SC2016  # the body is written for the stub's shell
-  sandbox_write "$stub_path" mkdir \
+  sandbox_write "$stub_path" "$name" \
     '#!/usr/bin/env bash' \
-    "$real \"\$@\" || exit \$?" \
-    'case "$1" in' \
-    "  $match) kill -INT \"\$PPID\" ;;" \
+    "real=$real" \
+    "fired=$stub_path/fired" \
+    'case "$*" in' \
+    "  $match)" \
+    '    [ ! -e "$fired" ] || exec "$real" "$@"' \
+    '    : >"$fired"' \
+    "    $body" \
+    '    kill -INT "$PPID"' \
+    '    exit 0' \
+    '    ;;' \
     'esac' \
-    'exit 0'
+    'exec "$real" "$@"'
   chmod 0755 "$sandbox_path" || fail 'could not make the stub executable'
 }
 
@@ -1409,7 +1424,8 @@ test_build_an_interrupt_as_the_scratch_tree_appears_leaves_nothing() {
   local saved
   conf 'base personal/base'
   mklayer personal/base .zshrc
-  stub_mkdir_interrupt '*/current.new'
+  # shellcheck disable=SC2016  # the body runs in the stub, not here
+  stub_interrupt mkdir '*/current.new' '"$real" "$@" || exit $?'
   saved=$PATH
   PATH=$stub_path:$PATH
   run_shale build
@@ -1783,11 +1799,12 @@ test_clone_an_existing_checkout_is_left_alone() {
 # reformatted.  Nothing is left at either name: a half-populated directory at
 # the layer path is a tree the composer would happily walk.
 #
-# All that is asserted of git's line is that it is there: a stderr line that is
-# not shale's, carrying git's 'fatal: ' prefix.  The sentence after that prefix
-# is git's to reword and gettext's to translate, and this runs against whatever
-# git the macOS runner ships as well as this one; the prefix is a plain literal
-# in git's usage.c and goes through no message catalogue.
+# What is asserted of git's line is that it is there, on stderr, carrying the
+# path it was given: any line that is not shale's.  Every word of it - the
+# 'fatal: ' prefix included, which is where the last version of this case was
+# wrong - is a catalogue string that a German environment replaces wholesale;
+# what makes both halves stable is run_case pinning LC_ALL, and asserting the
+# prefix here is what gives that pin a case that fails without it.
 test_clone_a_url_that_is_not_a_repository_leaves_nothing_behind() {
   local foreign
   conf "base personal $CASE_DIR/repos/absent"
@@ -1795,6 +1812,7 @@ test_clone_a_url_that_is_not_a_repository_leaves_nothing_behind() {
   assert_status 1 "$shale_status"
   foreign=$(printf '%s\n' "$shale_err" | grep -v '^shale:')
   assert_contains "$foreign" 'fatal: ' "git's own stderr"
+  assert_contains "$foreign" "$CASE_DIR/repos/absent" "git's own stderr"
   assert_contains "$shale_err" \
     "shale: could not clone $CASE_DIR/repos/absent into $HOME/.dotfiles/personal" 'stderr'
   assert_missing "$HOME/.dotfiles/personal"
@@ -1822,6 +1840,30 @@ test_clone_a_partly_written_clone_is_removed() {
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" \
     "shale: could not clone $repo_url into $HOME/.dotfiles/personal" 'stderr'
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/personal"
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# The clone in flight has to be named before the reap that clears it, for the
+# same reason the scratch tree does: a signal delivered partway through the
+# removal runs cleanup with CLONING still empty, and what is left is a tree
+# that is neither a clone nor gone.
+# shellcheck disable=SC2123
+test_clone_an_interrupt_while_a_stale_clone_is_reaped_leaves_nothing() {
+  local saved
+  mkrepo personal .zshrc
+  conf "base personal $repo_url"
+  sandbox_write "$HOME/.dotfiles/.personal.cloning/inner" DEEP 'from a killed run'
+  sandbox_write "$HOME/.dotfiles/.personal.cloning" TOP 'from a killed run'
+  # Half the reap, so the tree is still there when the interrupt lands.
+  # shellcheck disable=SC2016  # the body runs in the stub, not here
+  stub_interrupt rm '*/.*.cloning' '"$real" -rf "$2/inner" || exit $?'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 130 "$shale_status"
   assert_missing "$HOME/.dotfiles/.personal.cloning"
   assert_missing "$HOME/.dotfiles/personal"
   assert_missing "$HOME/.dotfiles/current"
@@ -1870,6 +1912,58 @@ test_clone_a_root_that_is_not_a_directory_is_not_cloned_over() {
   assert_eq 'not a directory' "$(cat "$HOME/.dotfiles/personal")" 'the planted file'
   assert_not_contains "$shale_out" 'cloning' 'stdout'
   assert_missing "$HOME/.dotfiles/.personal.cloning"
+}
+
+# A layer path deeper than its root is what makes this state reachable and
+# distinct: nothing is at the layer path, and the root is not a directory, so
+# every other arm of the check is false.  Told to add a url the line already
+# has, or to create a directory inside a regular file, you would do neither and
+# learn nothing; the defect is the file, and only this wording names it.
+#
+# Two layers, one with a url and one without, because the state does not depend
+# on the url: a url is not permission to clone over something already there.
+test_clone_a_file_at_a_clone_root_names_the_root_not_the_url() {
+  mkrepo personal base/.zshrc
+  conf "base personal/base $repo_url" 'work work/sub'
+  sandbox_write "$HOME/.dotfiles" personal 'not a directory'
+  sandbox_write "$HOME/.dotfiles" work 'not a directory either'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: layer 'base' has no directory at $HOME/.dotfiles/personal/base" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   its clone root $HOME/.dotfiles/personal exists but is not a directory" 'stderr'
+  assert_contains "$shale_err" \
+    "shale: layer 'work' has no directory at $HOME/.dotfiles/work/sub" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   its clone root $HOME/.dotfiles/work exists but is not a directory" 'stderr'
+  assert_contains "$shale_err" 'shale:   remove it, or move it aside' 'stderr'
+  # The remedy that is a no-op, and the claim that is false.
+  assert_not_contains "$shale_err" 'no url' 'stderr'
+  assert_not_contains "$shale_err" 'add a url on that line' 'stderr'
+  assert_eq 'not a directory' "$(cat "$HOME/.dotfiles/personal")" 'the planted file'
+  assert_not_contains "$shale_out" 'cloning' 'stdout'
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# The same state in the shape -e cannot see.
+test_clone_a_dangling_symlink_at_a_clone_root_names_the_root_not_the_url() {
+  mkrepo personal base/.zshrc
+  conf "base personal/base $repo_url"
+  sandbox_target "$HOME/.dotfiles" personal
+  ln -s "$HOME/.dotfiles/gone" "$sandbox_path" || fail 'could not link the root'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: layer 'base' has no directory at $HOME/.dotfiles/personal/base" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   its clone root $HOME/.dotfiles/personal exists but is not a directory" 'stderr'
+  assert_not_contains "$shale_err" 'no url' 'stderr'
+  assert_missing "$HOME/.dotfiles/gone"
+  assert_not_contains "$shale_out" 'cloning' 'stdout'
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/current"
 }
 
 # The variant no -e test can see, and the one a removed clone leaves behind.
@@ -1955,6 +2049,11 @@ test_clone_a_clone_that_cannot_be_moved_into_place_is_kept() {
     "shale: could not move the clone into place at $HOME/.dotfiles/personal" 'stderr'
   assert_contains "$shale_err" \
     "shale:   the clone is at $HOME/.dotfiles/.personal.cloning" 'stderr'
+  # Keeping it is only worth anything if the message says how to use it: the
+  # next build reaps this name and fetches the whole thing again.
+  assert_contains "$shale_err" \
+    "shale:   move it into place with: mv $HOME/.dotfiles/.personal.cloning $HOME/.dotfiles/personal, or the next build fetches it again" \
+    'stderr'
   assert_eq 'personal/.zshrc' \
     "$(cat "$HOME/.dotfiles/.personal.cloning/.zshrc")" 'the kept clone'
   assert_missing "$HOME/.dotfiles/personal"
@@ -1981,6 +2080,11 @@ test_clone_a_root_that_appears_during_the_clone_is_not_nested_into() {
     "shale: $HOME/.dotfiles/personal appeared while 'personal' was being cloned" 'stderr'
   assert_contains "$shale_err" \
     "shale:   the clone is at $HOME/.dotfiles/.personal.cloning" 'stderr'
+  # Nothing reaps this one: the reap runs only for a root about to be cloned,
+  # and a root that exists is skipped, so the message must say so.
+  assert_contains "$shale_err" \
+    "shale:   no build will touch it while $HOME/.dotfiles/personal exists: use it, or remove it" \
+    'stderr'
   assert_missing "$HOME/.dotfiles/personal/.personal.cloning"
   assert_eq 'personal/.zshrc' \
     "$(cat "$HOME/.dotfiles/.personal.cloning/.zshrc")" 'the kept clone'
@@ -2101,6 +2205,26 @@ test_doctor_an_uncloned_layer_with_a_url_is_noted_without_failing() {
     "shale: layer 'base' has no directory at $HOME/.dotfiles/personal/base yet" 'stdout'
   assert_contains "$shale_out" "shale:   its clone root 'personal' has a url: url-one" 'stdout'
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# A url does not mean shale can obtain the root: it clones only where nothing
+# is, so a root that is not a directory is a defect in the setup and not a
+# state shale fixes.  Uncounted, this reports 'no problems found' on a setup
+# where build cannot get past the layer check - the two commands disagreeing
+# about one state, which is the worst thing a checker can do.
+test_doctor_a_clone_root_that_is_not_a_directory_is_a_finding() {
+  conf "base personal/base $CASE_DIR/repos/absent"
+  sandbox_write "$HOME/.dotfiles" personal 'not a directory'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: layer 'base' has no directory at $HOME/.dotfiles/personal/base" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   its clone root $HOME/.dotfiles/personal exists but is not a directory" 'stdout'
+  assert_contains "$shale_out" 'shale:   remove it, or move it aside' 'stdout'
+  assert_not_contains "$shale_out" 'has a url' 'stdout'
+  assert_not_contains "$shale_out" 'no problems found' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
 }
 
 test_doctor_a_missing_dotfiles_directory_is_a_finding() {
@@ -3474,6 +3598,10 @@ run_case() {
     SHALE_RUNS=0
     HOME=$case_home
     export HOME
+    # Every message this suite asserts on comes from git or stow, and both
+    # translate theirs.  Without this the assertions pass or fail according to
+    # the locale of whoever is running them.
+    export LC_ALL=C
     export GIT_CONFIG_GLOBAL=/dev/null
     export GIT_CONFIG_SYSTEM=/dev/null
     export GIT_AUTHOR_NAME='shale tests'


### PR DESCRIPTION
Closes #7. Suite 124 → 139. This completes `build`: a fresh machine now needs only a config.

One clone serves however many layers derive from that root — the reason a url attaches to the first path component rather than to the layer. All clones finish before anything is composed, so a network failure costs nothing composed. `git` is checked only when a clone is actually required, so a machine holding every layer keeps working without git installed.

## Two results worth more than the feature

**A sweep proves absence only at the points it samples.** After #6 I told agents that hand-verifying a trap means sweeping the delivery time rather than sampling one point. This round did that — 111 points at 10 ms, two delivery modes, zero bad states — and then reported that **its own sweep missed the race it found**. 180 ms and 190 ms are both clean; the window sits between them. It surfaced only because an unrelated mutation run happened to fire at 185 ms.

What pins it instead is deterministic: a `mkdir` on `PATH` that runs the real one and then signals shale itself, landing delivery in the window by construction. `test_build_an_interrupt_as_the_scratch_tree_appears_leaves_nothing`.

**The race is in #6's code, merged hours earlier, and survived three review rounds.** `cmd_build` created the scratch tree and *then* recorded it, so a signal between the two ran `cleanup` with nothing recorded and orphaned `current.new` — 35 runs in 40 at 185 ms, 0 in 40 after. The clone code sets `CLONING` before anything can create the path, which is what made the asymmetry visible. Both now follow one ordering: name the path before creating it. Coordinator-verified by reverting the two lines — fails exactly that case.

## Also

The destination is re-tested between the clone and the rename: `mv` into an existing directory nests rather than replaces, and a clone is long enough that a root appearing mid-flight is not far-fetched. Same hazard the swap defends against, now defended the same way.

`cleanup` gains the cloning directory, gated by the analogue of the scratch tree's glob.

**The fourth missing-layer branch #6 added is deleted**, and proven dead by restoring it and finding the suite still green — evidence rather than an argument that it was unreachable.

**A brittle assertion was replaced.** The non-repo case matched git's `repository … does not exist`, which is a gettext catalogue string — reworded between versions, translated by locale. It now asserts on the `fatal: ` prefix, a plain C literal in git's `usage.c` that goes through no catalogue. Stated honestly as a source-level claim: no non-English locale is installed here to demonstrate it.

## Mutation

Every protection has a named case that fails without it: temp-then-rename, clone-before-compose, the `-e`/`-L` skip, the stale-`.cloning` reap, lazy git, no `--quiet`, unredirected git stderr, the pre-`mv` re-check, the post-`mv` state test, and `cleanup`'s cloning branch.

Two survivors, both stated rather than dressed up: `cleanup`'s `*/.*.cloning` gate is unfalsifiable for the same reason the `*/current.new` gate is, and the restored dead branch changes nothing.

Fixture repositories are local `git init` trees; no case names a host or a URL that resolves.