### PR TITLE
Fix the container's signing identity and ignore agent worktrees

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,5 +15,17 @@
 	// `docker exec` invocations that carry no environment of their own.
 	"containerEnv": {
 		"HOME": "/home/vscode"
+	},
+
+	// VS Code forwards the host's ssh-agent in, which on this developer's machine
+	// is 1Password.  git then signs through that socket rather than through the
+	// key file the image already holds, so every commit made in here blocks on an
+	// approval prompt on the host - including commits made by an agent running
+	// unattended, which simply fail.  OpenSSH treats an empty SSH_AUTH_SOCK as no
+	// agent at all, so this hands signing back to ~/.ssh, where github.com is
+	// already pinned to IdentitiesOnly with IdentityAgent none for the same
+	// reason.
+	"remoteEnv": {
+		"SSH_AUTH_SOCK": ""
 	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ PLAN.md
 # Machine-local dev container variant; mounts a personal credential.
 .devcontainer/local/
 
+# Where Claude Code puts a subagent's isolated checkout.  It is inside the repo,
+# so an agent staging with `git add -A` commits another agent's whole worktree.
+.claude/worktrees/
+
 .DS_Store
 *~
 *.swp


### PR DESCRIPTION
Two fixes to the agent working environment, found while running the v1 issue backlog.

The container holds its own signing key, but VS Code forwards the host ssh-agent in and git signs through that instead, so commits made in here block on a 1Password prompt on the host and unattended agents cannot commit at all.

Subagent worktrees are created inside the repository, where an agent staging with `git add -A` sweeps up every other running agent's working tree.

No issue for either: both surfaced during the run rather than being planned work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)