### PR TITLE
Document layer authoring and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ shale apply                        # clones what is missing, builds, links
 
 `examples/minimal.conf` is the smaller starting point — one repository layer and one local directory.
 
+Already stowing dotfiles by hand? Unstow the old packages before the first apply:
+[docs/migrating.md](docs/migrating.md).
+
 ## Configuration
 
 `~/.dotfiles/shale.conf` lists one layer per line, lowest precedence first:
@@ -99,6 +102,9 @@ it. Git, SSH and tmux have native include mechanisms and should use those direct
 That convention lives in your layers, not in shale — shale has no knowledge of it and treats a
 fragment as an ordinary file. A higher layer therefore *replaces* a fragment by reusing its exact
 filename, or *adds* alongside it with a new one.
+
+[docs/layers.md](docs/layers.md) writes the convention out in full, alongside the rest of what goes
+into authoring a layer.
 
 ## Uninstalling
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,0 +1,250 @@
+# Authoring a layer
+
+A layer is a directory tree that mirrors your home directory. Everything in it is copied, path for
+path, into `~/.dotfiles/current`, and everything in `current` is linked into `$HOME`. A file at
+`personal/base/.config/nvim/init.lua` becomes `~/.config/nvim/init.lua`. There is nothing else to
+learn about the mapping.
+
+Shale copies files. It never merges them, never templates them and never reads what is inside one.
+Fragment directories, numeric prefixes and shared helper files are conventions for *your* layers,
+expressed in the config formats themselves and implemented by the files you write. Shale has no
+knowledge of any of them and treats every one as an ordinary file.
+
+## Where a layer lives
+
+Give a layer a subdirectory of its repository rather than the repository root:
+
+```
+base    personal/base     git@github.com:you/dotfiles.git
+```
+
+Shale skips `.git` at every depth, and the built tree carries a `.stow-local-ignore` that keeps a
+top-level `README*`, `LICENSE*` and `COPYING` out of `$HOME`. Nothing else is filtered — a
+`.gitignore` at the top of the layer becomes `~/.gitignore`, and a `README.md` further down becomes
+a real link too. Name the repository root as the layer and `~/.github/`, `~/Makefile` and
+`~/CONTRIBUTING.md` join them. The subdirectory is what keeps the repository's own furniture out of
+the image.
+
+Several layers can come from one repository — `personal/base` and `personal/wsl` are two
+directories in one clone at `~/.dotfiles/personal`, so the url is given once, on the first of them.
+A layer needs no repository at all: `~/.dotfiles/local` with no url is this machine's own directory.
+Shale clones only what has a url, so create that one yourself — `mkdir -p ~/.dotfiles/local` —
+before the first build, which otherwise stops on it. An empty layer directory composes to nothing
+and is fine.
+
+## Replacing a file, and adding one
+
+Precedence is per path and whole file. A higher layer *replaces* a file by reusing its exact path,
+and *adds* alongside it by choosing a filename no lower layer uses. Directories are not replaced:
+where two layers both provide `.config/nvim/`, the directory merges and the contest happens file by
+file inside it.
+
+`shale which` answers who wins, before any build and without one:
+
+```
+$ shale which .zshrc
+winner    local  /home/you/.dotfiles/local/.zshrc
+shadowed  base   /home/you/.dotfiles/personal/base/.zshrc
+```
+
+A layer cannot replace a directory with a file, or a file with a directory. `build` calls that a
+conflict, names both layers and the two paths, and rebuilds nothing; `which` reports the same pair
+as a note. Rename one of them.
+
+## Fragment directories
+
+This is the convention, not a feature. The entry point in your base layer does the sourcing, so
+every fragment is an ordinary file that any layer can add, and shale is not involved.
+
+`~/.profile` in the base layer, POSIX `sh` only. Whichever login shell the machine hands you reads
+this file — `dash`, `ksh`, or `bash` where there is no `~/.bash_profile`, and zsh only through the
+`~/.zprofile` below — and the one thing they all understand is POSIX:
+
+```sh
+[ -r "$HOME/.config/shell/helpers.sh" ] && . "$HOME/.config/shell/helpers.sh"
+
+for _f in "$HOME"/.config/profile.d/*.sh; do
+  [ -r "$_f" ] || continue
+  . "$_f"
+done
+unset _f
+```
+
+The `[ -r "$_f" ] || continue` is what handles an empty `profile.d`: with no match the glob arrives
+as the literal pattern, which is not readable, and the loop does nothing.
+
+A login zsh does not read `~/.profile` at all: it reads `~/.zprofile`, then `~/.zshrc`. So the base
+layer ships a `~/.zprofile` too, and it sources `~/.profile` in sh emulation:
+
+```zsh
+[ -r "$HOME/.profile" ] && emulate sh -c '. "$HOME/.profile"'
+```
+
+`emulate sh -c` runs that one command under zsh's sh-compatible options and leaves the rest of the
+shell alone. It is what makes a POSIX file behave. Native zsh has `NOMATCH` set, so an empty
+`profile.d` turns the loop's glob into an error — `no matches found`, return 126 — and everything
+after it in `~/.profile` is skipped. Word splitting differs too: zsh does not split unquoted
+expansions, and a file written expecting it goes wrong without saying so.
+
+`~/.zshrc` in the base layer, where the whole of zsh is available and the `(N)` glob qualifier does
+the same job:
+
+```zsh
+[ -r "$HOME/.config/shell/helpers.sh" ] && . "$HOME/.config/shell/helpers.sh"
+
+for _f in "$HOME"/.config/zsh/rc.d/*.zsh(N); do
+  source "$_f"
+done
+unset _f
+```
+
+Any layer then drops a file into `.config/profile.d/` or `.config/zsh/rc.d/` and it is picked up.
+A higher layer replaces a fragment by reusing its exact filename and adds one by choosing a new
+filename, exactly as for any other file, because to shale that is all a fragment is.
+
+## Ordering, and the inversion PATH puts on it
+
+Zero-padded numeric prefixes fix the order the fragments run in: `10-path.sh` before `20-editor.sh`
+before `90-corp.sh`. Pad them, because `100-x.sh` sorts before `20-x.sh` otherwise.
+
+A fragment that *prepends* to `PATH` inverts that order into lookup precedence. The fragment that
+runs last leaves its directory at the front of `PATH` and so wins lookups. Give base layers low
+numbers and higher layers high ones, and the two orders agree: last to run, first to be found.
+
+```sh
+# .config/profile.d/10-path.sh, in the base layer
+prepend_path "$HOME/.local/bin"
+
+# .config/profile.d/90-corp.sh, in the work layer
+prepend_path /opt/corp/bin
+```
+
+leaves `PATH` as `/opt/corp/bin:$HOME/.local/bin:…`.
+
+## Shared helper functions
+
+Fragments that need the same function share one file rather than each defining it. It is sourced by
+both entry points before their loops, as above, so it has to be POSIX `sh` — `~/.profile` sources it
+too.
+
+```sh
+# .config/shell/helpers.sh, in the base layer
+prepend_path() {
+  case ":$PATH:" in
+    *":$1:"*) ;;
+    *) PATH="$1${PATH:+:$PATH}" ;;
+  esac
+}
+```
+
+## Tools that include natively
+
+Where a tool has its own include mechanism, use it instead of inventing a fragment directory for it.
+They do not all behave alike.
+
+Git's `include.path` takes one path and does not glob: `path = ~/.config/git/conf.d/*.conf` includes
+nothing at all, silently. The base layer therefore names each file it expects, and a higher layer
+supplies it; an include whose file does not exist is ignored without error, so naming a file no
+layer ships costs nothing.
+
+```
+[include]
+  path = ~/.config/git/conf.d/50-work.conf
+```
+
+SSH's `Include` does glob, and `Include ~/.ssh/config.d/*.conf` over a directory that does not exist
+is not an error. Put it at the *top* of `~/.ssh/config`, above any `Host` block: ssh keeps the first
+value it obtains for each keyword, so a `Host *` default written above the `Include` wins over
+everything the included files say.
+
+tmux's own is `source-file`, and the same shape applies: the base layer's `tmux.conf` names what it
+sources, and the layers supply those files.
+
+## Symlinks in a layer
+
+A symlink is copied as a symlink, target text unchanged, and it is a leaf: shale never recurses into
+one, so a layer's symlink to a directory collides with a lower layer's real directory rather than
+merging into it.
+
+The target is resolved from where the link ends up inside `current/`, not from `$HOME`. A link to a
+sibling works — `.exrc -> .vimrc` resolves inside `current/` and reading `~/.exrc` gets the file.
+A link written as though it started in `$HOME`, such as `.exrc -> .dotfiles/current/.vimrc`, dangles
+after a successful apply that reports nothing. Never point a layer symlink into `current/`.
+
+Keep links relative. Stow refuses an absolute one and abandons the whole apply:
+
+```
+WARNING! stowing current would cause conflicts:
+  * source is an absolute symlink .dotfiles/current/.viminfo-link => /home/you/.dotfiles/current/.vimrc
+All operations aborted.
+```
+
+## A layer, or a guard inside a file
+
+Both are right in different cases, and the deciding question is whether the file should exist at all
+on the other platform.
+
+A file that has no business on a platform goes in an OS layer — a `.config/systemd/` tree in the
+Linux layer, a `Library/LaunchAgents/` tree in the macOS one. Nothing on the other machine lists
+that layer, so nothing on the other machine has the file.
+
+A file that must exist everywhere but differs in one section ships once, in the base layer, with a
+runtime guard inside it. A second copy in an OS layer would replace the whole file, and the two
+copies would both need maintaining for the rest of the file's life.
+
+```sh
+case "$(uname -s)" in
+  Darwin) alias ls='ls -G' ;;
+  *) alias ls='ls --color=auto' ;;
+esac
+```
+
+## Empty directories
+
+Git cannot store an empty directory. Ship a `.gitkeep` in it, and expect it in `$HOME`: shale copies
+it like any other file and stow links it. `~/.config/zsh/rc.d/.gitkeep` is the price of a fragment
+directory that starts out empty.
+
+## What a layer must not ship
+
+Never a `.stow-local-ignore`. Shale writes the one in `current/` itself — it is the only file shale
+creates rather than copies — and a layer providing one fails the build, naming the layer.
+
+Never shale itself: applying a layer that ships it would replace the script with a link into
+`current/`. `shale doctor` reports that, judged against the path the running shale was invoked by.
+Run the installed copy — `~/.local/bin/shale doctor` — and the finding names the layer. Run the
+layer's own copy directly and you get `no problems found`, because no layer shadows *that* path.
+
+Watch for `~/.stowrc` and `~/.dotfiles/.stowrc`. Their `--ignore` patterns are *appended* to the
+ones stow is already using rather than overriding them, so a stray `--ignore=zshrc` leaves
+`~/.zshrc` silently unlinked with `shale apply` exiting 0. `shale doctor` notes a resource file if
+one exists.
+
+## Never edit `current/`
+
+`~/.dotfiles/current` is generated output and is disposable — a bad build is fixed by fixing a layer
+and building again. Editing it edits the only copy of that change, and `~/.zshrc` being a link into
+it makes that easy to do by accident. A build that finds a file in the built tree newer than the
+layer it came from warns and keeps the tree it displaced:
+
+```
+shale: /home/you/.dotfiles/current/.zshrc was newer than /home/you/.dotfiles/personal/base/.zshrc
+shale:   you edited the built tree; the layer wins
+shale:   your version is kept at /home/you/.dotfiles/current.old/.zshrc
+```
+
+Copy your version back into the layer from `current.old`. The next build reaps `current.old`, so do
+it before then. Never version `current/`, and never point a layer symlink into it.
+
+## Updating layers after the first run
+
+Shale clones a layer root that is missing and never touches it again; updating a checkout is git's
+job. Pull each clone root, then apply:
+
+```sh
+git -C ~/.dotfiles/personal pull
+git -C ~/.dotfiles/work pull
+shale apply
+```
+
+There is no `shale sync`.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,0 +1,175 @@
+# Migrating from a plain stow setup
+
+You have `~/.dotfiles/common` and `~/.dotfiles/local` as stow packages, and you stow them by hand.
+Shale composes the same trees into one package and stows that. The move is mechanical: unstow what
+is there, turn the packages into layers, list them, apply.
+
+Do it from a shell you can afford to lose. Unstowing removes `~/.zshrc`, `~/.profile` and everything
+else the package owns, and every shell opened between then and the apply falls back to the system
+defaults. Keep a second session already running, and do this over a connection you are not relying
+on the dotfiles to make.
+
+## Unstow first
+
+```sh
+stow -D -d ~/.dotfiles -t ~ common
+stow -D -d ~/.dotfiles -t ~ local
+```
+
+Name the stow directory the packages actually live in — `-d ~/dotfiles-old`, or wherever it is — and
+give `-t ~` explicitly. Both flags are worth passing even when the defaults would be right: stow
+reads `./.stowrc` and `~/.stowrc`, and a `--dir=` or `--target=` in either silently moves the
+operation somewhere else.
+
+`stow -D` removes the links it made, and what is left depends on how the package went in. A folded
+`~/.config` is itself a link, so it goes with the rest and nothing remains; a package stowed with
+`--no-folding` leaves the directories stow created behind it, empty. Either one is expected and
+harmless.
+
+## Turn the packages into layers
+
+A stow package and a layer are the same shape — a tree mirroring `$HOME` — so this is a rename. The
+checkout becomes the *clone root*, and the layer becomes a subdirectory inside the repository:
+
+```sh
+git -C ~/.dotfiles/common remote -v          # if it was a checkout, note where from
+mv ~/.dotfiles/common ~/.dotfiles/personal
+cd ~/.dotfiles/personal
+mkdir base
+git mv .config .profile .zshrc base/         # every entry that belongs in $HOME
+git commit -m "Move the layer under base/"
+git push
+```
+
+`git mv` moves what git tracks. Move anything untracked you want to keep with plain `mv`.
+
+Then write `~/.dotfiles/shale.conf`, lowest precedence first:
+
+```
+base    personal/base     git@github.com:you/dotfiles.git
+local   local
+```
+
+The url says how to obtain `personal`, the clone root — not how to obtain the layer. That is why the
+repository has to *hold* `base/` rather than *be* it. Rename the checkout straight to
+`personal/base` and leave the url on the line, and this machine tells you nothing: shale clones only
+where nothing exists, so the url is never used, and `doctor` sees two real directories and reports
+clean. The next machine clones the repository to `~/.dotfiles/personal`, finds no `base` inside it,
+and stops on the config line rather than on the repository:
+
+```
+shale: layer 'base' has no directory at /home/you/.dotfiles/personal/base, but its clone at /home/you/.dotfiles/personal exists
+shale:   check the path on line 1
+```
+
+If `common` was never a checkout there is nothing to move inside and nothing to push: `mkdir -p
+~/.dotfiles/personal`, `mv ~/.dotfiles/common ~/.dotfiles/personal/base`, and leave the third field
+off the line. Add a url once a repository exists that holds the layer in a subdirectory.
+
+Check what shale makes of the config before touching `$HOME`:
+
+```sh
+shale doctor
+shale build
+shale which .zshrc
+```
+
+`doctor` reports any package left in `~/.dotfiles` that no config line claims, which is how a
+package you forgot to convert shows up:
+
+```
+shale: /home/you/.dotfiles/common is not a configured layer
+shale:   it may be a leftover stow package, a stray clone, or a layer you removed from the config
+```
+
+Then `shale apply`.
+
+Expect `$HOME` to look different afterwards. Where hand-stowing a single package often leaves
+`~/.config` as one symlink into it, shale's apply leaves `~/.config` a real directory holding one
+link per file. Files that other tools write into those directories then land in `$HOME` rather than
+inside the built tree, where the next build would discard them.
+
+## What a first apply refuses, and why
+
+Stow plans the whole operation and abandons all of it if any part conflicts, so a failed apply
+changes nothing in `$HOME`. The built tree is fine; clear what stow named and apply again. Apply
+restows, so stow runs an unstow phase and then a stow phase, and a collision both phases see is
+named once for each.
+
+An old package still stowed over a path the built tree also provides:
+
+```
+WARNING! stowing current would cause conflicts:
+  * existing target is stowed to a different package: .profile => .dotfiles/common/.profile
+All operations aborted.
+```
+
+Unstow that package. Every path both packages provide collides this way, and stow has no notion of
+one package outranking another.
+
+A folded directory owned by a package outside `~/.dotfiles` — the old setup's `~/.config` being a
+single link into it:
+
+```
+WARNING! unstowing current would cause conflicts:
+  * existing target is not owned by stow: .config => dotfiles-old/common/.config
+WARNING! stowing current would cause conflicts:
+  * existing target is not owned by stow: .config
+All operations aborted.
+```
+
+Stow can split a folded directory apart when the link points inside the stow directory it was given,
+and it cannot when the link points anywhere else. Unstow the old package and the fold goes with it.
+
+An ordinary file, not a link, already sitting at the path:
+
+```
+WARNING! unstowing current would cause conflicts:
+  * existing target is neither a link nor a directory: .profile
+WARNING! stowing current would cause conflicts:
+  * existing target is neither a link nor a directory: .profile
+All operations aborted.
+```
+
+That file is not in any layer and shale will not overwrite it. Move it aside, or copy its contents
+into the layer that should own it and then delete it.
+
+Do not reach for `stow --adopt` to clear any of these. It moves the file from `$HOME` into the
+package — which here means into `~/.dotfiles/current`, generated output — and the next `shale build`
+composes over it. Whether you get the content back depends on a timestamp: if the adopted file was
+newer than the layer's copy the build warns and keeps it in `current.old`, and the build after that
+reaps it; if it was older the build says nothing and there is nothing left to recover. Copy the file
+into a layer instead.
+
+## Links left behind after layers change
+
+When a file leaves a layer, the next `shale apply` prunes its link. When an entire directory leaves
+every layer, the links inside it are left dangling and the apply still exits 0: stow's unstow phase
+only visits directories the package still has.
+
+Find them, and delete the ones that point into `~/.dotfiles/current`:
+
+```sh
+chkstow -b -t ~
+readlink ~/.config/foo/a.conf
+rm ~/.config/foo/a.conf
+```
+
+`chkstow` ships with GNU stow and `-b` reports every symlink under the target whose target does not
+exist, as `Bogus link: /home/you/.config/foo/a.conf`. Every one, not only stow's: it walks the whole
+of `$HOME`, which includes `~/.dotfiles`, so a deliberately dangling link inside one of your own
+layers and anything under `current.old` are on the list beside the links an apply orphaned. Check
+each with `readlink` and delete only those whose target is under `~/.dotfiles/current`. The walk is
+not quick. `stow -D` will not clear them either — it visits only the directories the package still
+has.
+
+## Uninstalling
+
+```sh
+stow -D -d ~/.dotfiles -t ~ current
+```
+
+This is also the escape hatch when an apply leaves `$HOME` in a state you would rather back out of.
+It removes only the links into `current`; your layers, your config and the built tree are untouched,
+and `shale apply` puts everything back. Directories stow created on the way in are left behind
+empty.


### PR DESCRIPTION
Closes #12.

Two user-facing documents, plus the two README links the issue asks for and
nothing else — finalising the README is #13.

Every command, path, flag and message quoted was taken from a run in a sandboxed
`HOME`, not from the issue's prose. The stow output is stow **2.3.1**'s, which is
what the dev container has, not the 2.4.1 some issues cite. `apply` was exercised
from `origin/8-apply-with-stow` (PR #42), since it is still a stub on `main`; the
documents describe its behaviour by observable result rather than by naming
`--no-folding`, so they survive a change to the flag list.

Two places the issue's prose disagreed with what the code does, where the code
won:

- The issue says a first apply over an existing stow package in `~/.dotfiles`
  hits collisions "because the existing package holds folded directory links
  across `~/.config`". Reproduced: it does not. Stow unfolds `~/.config` by
  itself when the link points inside the stow directory it was given, and the
  apply succeeds. The collisions that actually stop it are a path both packages
  provide (`existing target is stowed to a different package`) and a fold into
  some *other* directory (`existing target is not owned by stow`). Both are
  quoted verbatim in `docs/migrating.md`.
- `shale doctor` does not yet audit `$HOME` for broken links — that is #10 — so
  the document points at `chkstow -b -t ~` for the dangling links a vanished
  directory leaves behind, which was reproduced along with `stow -D` declining
  to clear them.

`./tests/run`: 177 passed, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
