### PR TITLE
Name the stow version that misses a nested absolute symlink

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -171,7 +171,9 @@ sibling works — `.exrc -> .vimrc` resolves inside `current/` and reading `~/.e
 A link written as though it started in `$HOME`, such as `.exrc -> .dotfiles/current/.vimrc`, dangles
 after a successful apply that reports nothing. Never point a layer symlink into `current/`.
 
-Keep links relative. Stow refuses an absolute one and abandons the whole apply:
+Keep links relative. Stow refuses an absolute one and abandons the whole apply, and stow 2.3.1
+misses one below the top of the tree — an absolute link that appears to work there stops working
+the day stow is upgraded:
 
 ```
 WARNING! stowing current would cause conflicts:


### PR DESCRIPTION
docs/layers.md tells layer authors that stow refuses an absolute symlink and abandons the whole apply. That is true at the top of a layer tree and false one directory down on stow 2.3.1 — the version `apt-get install stow` gives on Debian and Ubuntu, and so the version in this project's dev container and its Linux CI job. The line now names the split and the trap it leaves: a nested absolute link appears to work on 2.3.1 and stops working the day stow is upgraded.

Verified by running both versions against a sandbox home with `-R --no-folding`, as apply does, with 2.4.1 built from the GNU release tarball. Absolute at the top: refused by both. Absolute one directory down: stowed by 2.3.1, refused by 2.4.1. Relative: taken by both at both depths.

This corrects a claim in a shipped document, found while fixing a macOS-only failure on #10. There is no issue for it.

`./tests/run`: 208 passed, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)