### PR TITLE
Name the resource-file options that change an apply

### DIFF
--- a/shale
+++ b/shale
@@ -990,6 +990,162 @@ shell_quote() {
   QUOTED="'${s//$q/$r}'"
 }
 
+# The options the stow resource file $1 sets that bear on an apply, in
+# STOWRC_OPTIONS as one 'line N: --opt' per occurrence in the order the file
+# holds them.  Non-zero when it names none, which is also the answer for a file
+# that is not a regular file and for one that cannot be read: stow reads a
+# resource file under '-r' and shale runs as the same user, so a file shale
+# cannot open is one stow does not read either.  STOWRC_PATHS is 1 when one of
+# them is --dir or --target, which is the one group apply's own command line
+# overrides and therefore the one the note has something more to say about.
+#
+# The set is stow's own option list minus what cannot reach an apply at all:
+# --no-folding, which apply's command line already carries, and -D, -S, -R and
+# package names, which stow documents as ignored in a resource file.  Everything
+# else is in.  --version, --help and --simulate stop the apply linking anything;
+# --ignore, --defer and --override drop or replace individual links; --dotfiles
+# renames them.  --compat makes the unstow phase sweep the whole target tree
+# instead of the directories the package holds, which takes back links a plain
+# apply leaves behind - and on 2.3.1 fails the apply outright at the first file
+# in the target that is neither a link nor a directory, which a ~/.stowrc is, so
+# there it refuses on the strength of its own existence.  --adopt is documented
+# to move a file in the way
+# from the target into the package, and on 2.3.1 it never gets to: the unstow
+# phase of apply's -R refuses that file as a conflict first, leaving the tree
+# byte for byte as it would be with no resource file at all.  It is named for
+# the option it is, since nothing here should turn on one version's ordering.
+# --verbose changes no link at all and is still here: apply reports a
+# stow that wrote to either stream, so a --verbose in one of these files puts a
+# warning and a wall of LINK: lines on every apply for ever, and this note is
+# the only thing that would lead its reader to the cause.  --dir and --target
+# are overridden by apply's own -d and -t, and are named because the user who
+# wrote one meant it, and it is live in every other stow they run.
+#
+# The parsing is stow's, checked against 2.3.1 and 2.4.1.  A line is split on
+# whitespace, and there is no comment syntax at all: a '#' is a token like any
+# other and the options after one on the same line take effect, so no line may
+# be skipped for looking like a comment.  The whole file is parsed as a single
+# argument list, so an option and its value may be separate tokens and may even
+# fall on different lines, which is what the skip below is for, and a '--' ends
+# the options for the whole of the rest of the file.  Options are Getopt::Long's,
+# so an unambiguous abbreviation - '--ign' for --ignore - is accepted, hence the
+# prefix match; the token is reported as the file spells it rather than resolved,
+# because an ambiguous prefix has no one answer and shale's job here is to point
+# at the line.
+#
+# The versions differ in one thing, and it decides how a quoted token is read:
+# 2.4.1 splits with shellwords and 2.3.1 with perl's split " ".  So a line of
+# '"--ignore=x"' is a live --ignore on 2.4.1 - the macOS floor - and on 2.3.1 is
+# a token that begins with a quote rather than a dash, which Getopt::Long hands
+# on as a package name and the resource-file parse discards.  The quotes are
+# stripped before the token is classified, which names it under the version
+# where it silently takes effect and over-names under the one where it does
+# nothing.  That is the direction to be wrong in: the other way round is silence
+# on the version that bites.
+stowrc_options() {
+  local file=${1-} line lineno tok word rest ch eq skip matched name toks
+  STOWRC_OPTIONS=()
+  STOWRC_PATHS=0
+  { [ -f "$file" ] && [ -r "$file" ]; } || return 1
+  lineno=0
+  skip=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    # A carriage return is whitespace to both versions' splitters, so it
+    # separates tokens here too rather than being glued to the one before it.
+    line=${line//$CR/ }
+    # read -a rather than an unquoted expansion: this splits on IFS without the
+    # pathname expansion that would turn a '*' in an ignore pattern into the
+    # names of the files in whatever directory doctor was run from.
+    toks=()
+    read -r -a toks <<EOF
+$line
+EOF
+    for tok in ${toks[@]+"${toks[@]}"}; do
+      if [ "$skip" -eq 1 ]; then
+        skip=0
+        continue
+      fi
+      eq=0
+      # One quote off each end, which is what shellwords takes off a token that
+      # is quoted whole.  An option quoted in halves - '--ignore="a b"' - is two
+      # tokens here whichever version reads it, and the first of them classifies
+      # on its '=' with the quote left inside the value.
+      case "$tok" in
+        \"* | \'*) tok=${tok#?} ;;
+      esac
+      case "$tok" in
+        *\" | *\') tok=${tok%?} ;;
+      esac
+      case "$tok" in
+        # Getopt::Long stops here, and stow reads everything after it as a
+        # package name - which a resource file has none of that it may use.
+        --) break 2 ;;
+        --*=*)
+          word=${tok%%=*}
+          word=${word#--}
+          eq=1
+          ;;
+        --*) word=${tok#--} ;;
+        -?*)
+          # A single dash is a bundle of one-letter options, and the two that
+          # take a value take the rest of the bundle as it.
+          rest=${tok#-}
+          while [ -n "$rest" ]; do
+            ch=${rest:0:1}
+            rest=${rest:1}
+            case "$ch" in
+              d | t)
+                STOWRC_OPTIONS[${#STOWRC_OPTIONS[@]}]="line $lineno: -$ch"
+                STOWRC_PATHS=1
+                [ -n "$rest" ] || skip=1
+                rest=
+                ;;
+              h | n | p | v | V)
+                STOWRC_OPTIONS[${#STOWRC_OPTIONS[@]}]="line $lineno: -$ch"
+                ;;
+            esac
+          done
+          continue
+          ;;
+        # A package name, or the value of an option written '--opt value' whose
+        # own token has already set skip.
+        *) continue ;;
+      esac
+      [ -n "$word" ] || continue
+      matched=0
+      # The five that take a value first, because the token after one of those
+      # is that value rather than an option.  The rest are flags, 'no' among
+      # them as the long alias of --simulate.
+      for name in dir target ignore override defer; do
+        case "$name" in
+          "$word"*)
+            matched=1
+            [ "$eq" -eq 1 ] || skip=1
+            case "$name" in
+              dir | target) STOWRC_PATHS=1 ;;
+            esac
+            break
+            ;;
+        esac
+      done
+      if [ "$matched" -eq 0 ]; then
+        for name in adopt compat dotfiles help no simulate verbose version; do
+          case "$name" in
+            "$word"*)
+              matched=1
+              break
+              ;;
+          esac
+        done
+      fi
+      [ "$matched" -eq 1 ] || continue
+      STOWRC_OPTIONS[${#STOWRC_OPTIONS[@]}]="line $lineno: --$word"
+    done
+  done <"$file"
+  [ "${#STOWRC_OPTIONS[@]}" -gt 0 ]
+}
+
 # Every link under $HOME that points into the built tree at a path the built tree
 # no longer holds: one finding each, and the remedy once under them.  This is the
 # only report of the design's known edge case - stow's unstow phase sweeps the
@@ -1792,7 +1948,7 @@ cmd_apply() {
 # short-circuits: every check runs whatever the ones before it found, and only
 # the finding count decides the exit status.
 cmd_doctor() {
-  local tool i name path root dir entry leaf known remedy qlock
+  local tool i name path root dir entry leaf known remedy qlock lines
 
   FINDINGS=0
 
@@ -2027,11 +2183,30 @@ cmd_doctor() {
   # runs stow inside 'cd "$DOTFILES"' - which is what makes the second file a
   # known one rather than whichever directory the user happened to be in.  Move
   # that cd and this check silently stops covering the file that takes effect.
+  #
+  # The options in it are named and nothing more: which of them took effect, and
+  # on which files, is stow's to say and shale would be guessing.  That is also
+  # why the line above them says only that the file sets them - a claim that they
+  # all change an apply is false of --dir and --target, which apply's own -d and
+  # -t override, and the test that asserts the override would contradict the note
+  # shale printed.  Uncounted like every other note, because a resource file is
+  # the user's own and holding one is not a defect.
   for entry in "${HOME-}/.stowrc" "$DOTFILES/.stowrc"; do
     if [ -e "$entry" ] || [ -L "$entry" ]; then
-      note "a stow resource file exists at $entry" \
-        "stow adds its --ignore patterns to the ones shale passes rather than replacing them" \
-        "so it can silently drop files from an apply"
+      lines=("a stow resource file exists at $entry"
+        "stow adds its --ignore patterns to the ones shale passes rather than replacing them"
+        "so it can silently drop files from an apply")
+      if stowrc_options "$entry"; then
+        lines[${#lines[@]}]='it sets these stow options, which shale names and does not act on:'
+        i=0
+        while [ "$i" -lt "${#STOWRC_OPTIONS[@]}" ]; do
+          lines[${#lines[@]}]=${STOWRC_OPTIONS[$i]}
+          i=$((i + 1))
+        done
+        [ "$STOWRC_PATHS" -eq 0 ] ||
+          lines[${#lines[@]}]='apply passes its own -d and -t, so a --dir or a --target set here does not redirect it'
+      fi
+      note ${lines[@]+"${lines[@]}"}
     fi
   done
 

--- a/tests/run
+++ b/tests/run
@@ -5026,6 +5026,232 @@ test_doctor_a_dangling_stow_resource_file_is_still_noted() {
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
 }
 
+# What is in the file, on the line it is on.  An --ignore drops a file from the
+# apply with exit 0 and both of stow's streams empty, so there is nothing for
+# apply to report the presence of and this note is the only place it can be
+# said.  --version and -n are the same defect at full size: a resource file
+# carrying either makes stow print and link nothing at all, still exit 0.  A
+# --verbose changes no link and is still named, because apply reports a stow
+# that wrote anything, so this file is what a warning on every apply for ever
+# leads back to.
+#
+# The line above the list says the file sets them and stops there.  --target is
+# in the same list and does not redirect this apply - the case above asserts it
+# does not - so a list introduced as options that change an apply would have
+# doctor contradicting the suite.
+#
+# The exit status is asserted because the whole of it stays a note: naming an
+# option counts nothing, and a doctor that started exiting 1 on a file the user
+# put there deliberately would be unusable.
+test_doctor_a_stow_resource_file_has_its_options_named() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .stowrc \
+    '--ignore=secret' '' '--target=/tmp' '--dotfiles' '-n' '--version' '--verbose'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" "shale: a stow resource file exists at $HOME/.stowrc" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   it sets these stow options, which shale names and does not act on:' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 1: --ignore' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 3: --target' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 4: --dotfiles' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 5: -n' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 6: --version' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 7: --verbose' 'stdout'
+  # Said once, about the two options it is true of, rather than folded into a
+  # claim about all of them.
+  assert_contains "$shale_out" \
+    'shale:   apply passes its own -d and -t, so a --dir or a --target set here does not redirect it' \
+    'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The other half: an option that cannot reach an apply at all is not named, so
+# the note that names nothing is the note doctor printed before it could name
+# anything.  --no-folding is already on the command line apply builds, and man
+# stow, RESOURCE FILES says -D, -R, -S and package names are ignored in one of
+# these files.  The -d and -t line is absent too, since nothing here sets either.
+test_doctor_a_stow_resource_file_of_harmless_options_names_none() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .stowrc '--no-folding' '-R' '-D' '-S' 'somepackage'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" "shale: a stow resource file exists at $HOME/.stowrc" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   so it can silently drop files from an apply' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   line ' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   it sets these stow options' 'stdout'
+  assert_not_contains "$shale_out" "shale:   apply passes its own -d and -t" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# stow reads a '--' as the end of its options and everything after it as a
+# package name, which a resource file has none of that it may use: an rc file of
+# '-- --ignore=.foo' leaves .foo linked.  Naming an option there would point the
+# reader at a line that does nothing.  The --dotfiles before it is what shows
+# the scan ran at all, and the --adopt on the next line is what shows a '--'
+# ends the options for the rest of the file rather than for its own line.
+test_doctor_a_stow_resource_file_ends_at_a_double_dash() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .stowrc '--dotfiles -- --ignore=secret' '--adopt'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale:   line 1: --dotfiles' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   line 1: --ignore' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   line 2: --adopt' 'stdout'
+}
+
+# The one place the two versions of stow disagree about this file, and it is the
+# direction that matters.  2.4.1 splits with shellwords, which strips the quotes
+# and leaves one live option, so a fully quoted line takes effect on the macOS
+# floor; 2.3.1 splits with perl's split " " and the token keeps its quotes, so it
+# begins with a quote rather than a dash and is discarded as a package name -
+# verified against 2.3.1, where '"--ignore=plain"' left plain linked and exited
+# 0.  Naming it is right under the version where it silently bites, and names a
+# line that does nothing under the other.
+test_doctor_a_quoted_stow_resource_option_is_named() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .stowrc '"--ignore=secret"' "'--dotfiles'"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale:   line 1: --ignore' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 2: --dotfiles' 'stdout'
+}
+
+# No resource file, nothing said about one.  Most other cases would fail loudly
+# on a stray line, but none of them would fail on this note appearing for a file
+# that is not there.
+test_doctor_says_nothing_about_a_resource_file_that_is_not_there() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'stow resource file' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The spellings stow's own parser accepts, because a note that misses one is
+# silent exactly where its reader needs it.  Read against both versions of
+# bin/stow.in: the whole file is parsed as one argument list, so a value may be
+# a separate token and may fall on the next line; Getopt::Long resolves an
+# unambiguous abbreviation, so '--dotf' is --dotfiles and '--ign' is --ignore;
+# and a single dash is a bundle of one-letter options.  The token is reported as
+# the file spells it, since an ambiguous prefix has no one answer.
+#
+# Both abbreviations are here because the two are resolved by separate loops -
+# one for the options that take a value and one for the flags - and a case
+# carrying only a flag leaves the other loop free to match exactly and still
+# pass.  Line 3 is --defer's value and must not be a line of its own, though
+# that alone would not notice a scan that ignored values: a token with no
+# leading dash is passed over either way.  The case below is what pins that.
+test_doctor_a_stow_resource_file_is_read_the_way_stow_reads_it() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .stowrc \
+    '--ign secret' '--defer' 'bin' '--dotf' '-nV' '--tar=/tmp'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale:   line 1: --ign' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 2: --defer' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 4: --dotf' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 5: -n' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 5: -V' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 6: --tar' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   line 3:' 'stdout'
+}
+
+# An option's value is not an option, even when it looks exactly like one and
+# even across a line ending: stow parses the whole file as one argument list, so
+# the '--dotfiles' below is what --target and -t were given and nothing is
+# renamed by either.  Naming it would send the reader to edit a line that does
+# nothing, which is the same user-visible error as missing a live option and
+# reached from the opposite side.
+#
+# Both spellings, because the two are held by separate code: a long option's
+# value is claimed where the option is matched, and a bare '-t' claims the next
+# token only because the bundle it sits in ended.
+test_doctor_a_stow_resource_option_value_is_not_read_as_an_option() {
+  local spelling
+  for spelling in --target -t; do
+    conf 'base personal/base'
+    mklayer personal/base .zshrc
+    sandbox_write "$HOME" .stowrc "$spelling" '--dotfiles'
+    run_shale doctor
+    assert_status 0 "$shale_status" "$spelling exit status"
+    assert_contains "$shale_out" "shale:   line 1: $spelling" "$spelling stdout"
+    assert_not_contains "$shale_out" 'shale:   line 2:' "$spelling stdout"
+  done
+}
+
+# A carriage return is whitespace to both versions' splitters, so a CRLF file
+# applies every option in it and the note has to name every option in it.
+# Without the substitution that turns one into a separator, a '--dotfiles\r'
+# matches no option name and the note goes silent on a file stow acts on in
+# full - and the reader cannot see the character that caused it.  Written
+# directly rather than through sandbox_write, which writes '\n' endings.
+test_doctor_a_crlf_stow_resource_file_has_every_option_named() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_target "$HOME" .stowrc
+  printf -- '--dotfiles\r\n--ignore=secret\r\n' >"$sandbox_path" ||
+    fail "could not write $sandbox_path"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale:   line 1: --dotfiles' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 2: --ignore' 'stdout'
+}
+
+# Both versions read a last line with no newline after it, so the note must too.
+# read reports that line as a failure having already assigned it, and a loop
+# that believed the status would drop the option a user most likely just typed -
+# the last one in the file.
+test_doctor_a_stow_resource_file_with_no_final_newline_is_read_whole() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_target "$HOME" .stowrc
+  printf -- '--dotfiles\n--ignore=secret' >"$sandbox_path" ||
+    fail "could not write $sandbox_path"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale:   line 1: --dotfiles' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 2: --ignore' 'stdout'
+}
+
+# Neither version of stow has a comment syntax in a resource file: '#' is a
+# token like any other, and both split the line and go on parsing, so the
+# options after one on the same line take effect.  A reader who assumed
+# otherwise would skip the line and leave the note silent about a live option -
+# which is the failure this whole note exists to prevent.
+test_doctor_a_stow_resource_file_has_no_comment_syntax() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .stowrc '# --ignore=secret'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale:   line 1: --ignore' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# Splitting a line into tokens must not expand them as globs.  run_case leaves
+# the case in $CASE_DIR, so an unquoted expansion would read the names of the
+# files there as options - and a user's own directory is where a file named
+# after one is likeliest to be.  The '*' is a stow package name, which stow
+# ignores in a resource file.
+test_doctor_a_stow_resource_file_is_not_globbed() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$CASE_DIR" --version 'not an option'
+  sandbox_write "$HOME" .stowrc '--dotfiles *'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale:   line 1: --dotfiles' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   line 1: --version' 'stdout'
+}
+
 # The reason doctor calls parse_config bare where every other command exits on
 # it: a broken config is when you most need the rest of the report.
 test_doctor_a_broken_config_does_not_stop_the_later_checks() {


### PR DESCRIPTION
Closes #58.

A `~/.stowrc` line can silently change what `apply` does and nothing shale printed revealed it — `--ignore` drops a file with exit 0 and both streams empty, so #44's mechanism cannot reach it. Doctor already noted that the file exists; it now names the options in it that matter, and the line each is on. It stays a note: no finding, no change to the exit status, verified with two real findings present.

**Both resource files are named, not one.** `apply` runs stow inside `cd "$DOTFILES"`, so `$DOTFILES/.stowrc` is as live as `~/.stowrc` — doctor already noted both, and naming options in only one would be a hole with nothing marking it.

The set was derived from `GetOptionsFromArray`'s spec and then **every member run against real stow**: `--ignore`, `--override`, `--defer`, `--dotfiles`, `--adopt`, `--compat`, `--simulate`, `--version`, `--help`, `--target`, `--dir`, `--verbose`. The exclusions were run too: `--no-folding` is already on apply's command line, and `-D`/`-S`/`-R` and bare package names are documented as ignored in a resource file and were confirmed inert.

**`--version` and `--help` make stow link nothing at all, exit 0.** The whole apply does not happen. (It is not *silent* since #44 landed — stow writes to stdout, so shale's warning block fires. The genuinely invisible ones are `--ignore`, `--override`, `--defer` and `--dotfiles`.)

Three things about the file's syntax a contributor would get wrong, each pinned by a case:

- **There is no comment syntax.** `# --ignore=plain` really drops `plain` from a real apply — demonstrated, not reasoned.
- Getopt::Long abbreviation and bundling are live, and a value may sit on the following line, so `--target` followed by `--dotfiles` eats the second as its value. The token is reported as written rather than resolved.
- 2.3.1 splits on whitespace, 2.4.1 uses `shellwords`, so quoting behaves differently between the two CI runners. The option *list* is identical in both.