### PR TITLE
Bring the docs up to what doctor now checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ shale.
 
 A pass contains `N passed, 0 failed, 0 skipped`. **A skip is a failure**, and CI fails on any skip
 rather than trusting the count. A case skips only for a missing or wrong-versioned `shellcheck`, a
-missing `mkfifo`, or a run as root — and root is the one that costs you thirteen cases about mode
-bits, silently, in the containers where it is the default. A missing `git`, `stow` or `chkstow`
-aborts the run instead, before any case executes.
+missing `mkfifo`, or a run as root — and root is the one that costs you every case about mode bits,
+silently, in the containers where it is the default. A missing `git`, `stow` or `chkstow` aborts the
+run instead, before any case executes.
 
 ## The shape of the thing
 
@@ -35,14 +35,21 @@ so there is no `fixtures/` tree to add one to.
 - Shale knows nothing of `profile.d`, `rc.d` or `helpers.sh` — `test_meta_no_fragment_conventions`.
   `docs/layers.md` teaches that convention at length to layer authors, so a contributor arrives
   believing the tool implements it. It must not, and the grep is what says so.
-- The portability floor — `test_meta_no_banned_constructs` greps thirteen patterns.
+- The portability floor — `test_meta_no_banned_constructs` greps for the constructs off it by name.
 
 ## Where those greps do not reach
 
 They enforce **constructs, not meanings**. Identical source behaves differently on the bash 3.2 floor
 and on the container's bash 5.2, and no grep can see it — `"$dir"/.*` skips `.` and `..` under 5.2's
-`globskipdots` and matches them under 3.2, which is issue #40. Treating a clean meta run as
-portability evidence is the mistake; the macOS CI job is what catches this class, after you push.
+`globskipdots` and matches them under 3.2. The standing answer, stated once at `dir_is_empty`, is
+that every glob listing a directory drops those two names by hand;
+`test_meta_dot_globs_answer_the_same_under_both_glob_meanings` runs the script under the older
+meaning on both jobs. Treating a clean meta run as portability evidence is the mistake; the macOS CI
+job is what catches the rest of this class, after you push.
+
+A new external command joins `cmd_doctor`'s tool list and the harness's `stub_path_without`, or its
+absence goes unreported and nothing fails to say so. The enforcement runs the other way only: adding
+to doctor's list alone reddens doctor cases, adding to neither reddens nothing.
 
 The same trap runs outward. The container has GNU Stow 2.3.1 and the macOS runner 2.4.1; they differ
 in conflict wording, in whether an unmanaged file is an unstow conflict, and in whether an absolute

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ is the machine's business, not the repos'.
 
 ## Requirements
 
-`bash`, `git` and GNU `stow`, installed with your system package manager. Shale installs nothing,
+`bash`, `git` and GNU `stow`, installed with your system package manager, and the coreutils any
+system already has — `cp`, `mv`, `rm`, `mkdir`, `rmdir` and `readlink`. Shale installs nothing,
 including itself. `git` is used only to clone a layer repository the machine does not have yet.
 `chkstow` ships with GNU stow and is what `doctor` audits `$HOME` with; without it `doctor` says so
-and skips that one check.
+and skips that one check. `shale doctor` names every one of these it cannot find, so it is the
+fastest answer to a machine where something will not run.
 
 Shale is written to a floor of bash 3.2 and POSIX utility flags, which is what macOS ships. The test
 suite runs in CI on Linux and on macOS, the macOS job under `/bin/bash` so that the floor is
@@ -132,7 +134,7 @@ nothing:
 ```
 shale: another shale has the lock at /home/you/.dotfiles/.lock
 shale:   build and apply take it so that two of them cannot rebuild /home/you/.dotfiles/current at once
-shale:   if no other shale is running, this lock is stale: remove it with: rmdir /home/you/.dotfiles/.lock
+shale:   if no other shale is running, this lock is stale: remove it with: rmdir '/home/you/.dotfiles/.lock'
 ```
 
 `~/.dotfiles/current` is generated output. It is disposable — a bad build is fixed by fixing a layer
@@ -204,10 +206,12 @@ build.
 
 ## Checking the setup
 
-`shale doctor` checks that git and stow are installed, that the config parses, that every configured
-layer directory is there, that nothing in `~/.dotfiles` is a stray, that no layer ships shale
-itself, that no `.stowrc` is in a position to drop files from an apply, and that no link in `$HOME`
-points into the built tree at a path it no longer provides. It changes nothing.
+`shale doctor` checks that every tool shale runs is installed, that the config parses, that every
+configured layer directory is there, that the build lock is neither held nor uncreatable, that
+nothing in `~/.dotfiles` is a stray, that no layer ships shale itself, and that no link in `$HOME`
+points into the built tree at a path it no longer provides. Where a `.stowrc` exists it names the
+stow options that file sets, because several of them change an apply and three of them make it do
+nothing at all. It changes nothing itself.
 
 ```
 $ shale doctor
@@ -259,8 +263,10 @@ your layers, your config and the built tree alone; `shale apply` puts them back.
   dangling by an apply that still exits 0. `shale doctor` finds them and prints what to do about
   them; [docs/migrating.md](docs/migrating.md) covers the case in full.
 - A shale that is killed outright — `kill -9`, or the machine losing power — leaves its lock
-  directory behind, and a `~/.dotfiles/current.new` as well if it died mid-build. `doctor` reports
-  neither. Shale never reclaims a lock; the refusal above names the command that clears it.
+  directory behind, and a `~/.dotfiles/current.new` as well if it died mid-build. Shale never
+  reclaims a lock, because nothing it can read tells a live holder from a dead one. `doctor` reports
+  the lock and names the command that clears it; it says nothing about `current.new`, which the next
+  build removes once the lock is gone.
 - Git cannot store an empty directory, so a layer that needs one ships a `.gitkeep`, which will
   appear in `$HOME`.
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -220,7 +220,7 @@ layer's own copy directly and you get `no problems found`, because no layer shad
 Watch for `~/.stowrc` and `~/.dotfiles/.stowrc`. Their `--ignore` patterns are *appended* to the
 ones stow is already using rather than overriding them, so a stray `--ignore=zshrc` leaves
 `~/.zshrc` silently unlinked with `shale apply` exiting 0. `shale doctor` notes a resource file if
-one exists.
+one exists, and names the stow options it sets.
 
 ## Never edit `current/`
 


### PR DESCRIPTION
Follow-up to #38, #40, #41, #44, #48, #49, #51 and #58, all merged today.

Three lines had become **false** rather than merely incomplete, which two review gates flagged as blocking on their PRs:

- `README.md` said doctor checks that git and stow are installed. It checks seven tools.
- `README.md` said a killed shale leaves a lock behind and doctor reports neither it nor `current.new`. It reports the lock and names the command that clears it.
- `README.md`'s requirements list named three tools where doctor will now fail a user for six more.

`AGENTS.md` counted the mode-bit cases a root run silently drops. That count moved twice today; the point of the sentence is that root loses them without saying so. Its dot-glob paragraph cited #40 as an open example — now closed, and what a contributor needs is the rule it produced and where that rule is written.

The new `AGENTS.md` line is the one residual from this run that nothing enforces: a tool added to `shale` but not to doctor's list is unreported and no test fails. The enforcement runs the other way only.