### PR TITLE
Report an unobtainable layer before the first clone

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -54,8 +54,10 @@ The url says how to obtain `personal`, the clone root — not how to obtain the 
 repository has to *hold* `base/` rather than *be* it. Rename the checkout straight to
 `personal/base` and leave the url on the line, and this machine tells you nothing: shale clones only
 where nothing exists, so the url is never used, and `doctor` sees two real directories and reports
-clean. The next machine clones the repository to `~/.dotfiles/personal`, finds no `base` inside it,
-and stops on the config line rather than on the repository:
+clean. `~/.dotfiles/local` has to exist on the next machine before any of this: a layer with no url
+is one shale cannot obtain, and the build stops on it before it clones anything. With it there, that
+machine clones the repository to `~/.dotfiles/personal`, finds no `base` inside it, and stops on the
+config line rather than on the repository:
 
 ```
 shale: layer 'base' has no directory at /home/you/.dotfiles/personal/base, but its clone at /home/you/.dotfiles/personal exists

--- a/shale
+++ b/shale
@@ -554,6 +554,19 @@ acquire_lock() {
 
 # ------------------------------------------------------------------ the clones
 
+# Non-zero unless this build is going to fetch clone root $1: it has a url, and
+# nothing of any kind is at its path.  The layer checks ask this too, so that
+# they and the clone loop cannot drift over which roots a build obtains.
+will_clone() {
+  local root=$1 dir
+  clone_url "$root" || return 1
+  dir=$DOTFILES/$root
+  # -L as well as -e: a dangling symlink is something someone else put there,
+  # and the layer check names it rather than this cloning over it.
+  { [ ! -e "$dir" ] && [ ! -L "$dir" ]; } || return 1
+  return 0
+}
+
 # Clones every configured clone root that has a url and nothing at its path,
 # before anything is composed, so a clone that fails costs nothing composed.
 # One clone per root, however many layers derive from it.
@@ -566,9 +579,7 @@ clone_missing_roots() {
     url=${CLONE_URLS[$i]}
     dir=$DOTFILES/$root
     i=$((i + 1))
-    # -L as well as -e: a dangling symlink is something someone else put there,
-    # and the layer check below names it rather than this cloning over it.
-    { [ ! -e "$dir" ] && [ ! -L "$dir" ]; } || continue
+    will_clone "$root" || continue
     # Lazily, and once: a machine holding every layer builds with no git at all.
     if [ "$have_git" -eq 0 ]; then
       command -v git >/dev/null 2>&1 ||
@@ -577,7 +588,11 @@ clone_missing_roots() {
       have_git=1
     fi
     # The leading dot keeps this name out of the layer namespace: a configured
-    # path component must start with a letter, digit or '_'.
+    # path component must start with a letter, digit or '_'.  git names it in
+    # its own 'Cloning into' line, which is a path nobody wrote and which is
+    # gone by the time it is looked for; that stays as it is.  Redirecting git's
+    # stderr to hide it would take the network error, the bad host key and the
+    # wrong url with it, which is every reason a clone fails.
     tmp=$DOTFILES/.$root.cloning
     # Named before anything touches it, reaping included: a signal delivered
     # partway through the rm would otherwise run cleanup with CLONING still
@@ -1257,29 +1272,24 @@ which_describe() {
 
 # ---------------------------------------------------------------- the commands
 
-cmd_build() {
-  local i name path root dir errors n had_current qcur qold
-
-  parse_config || exit 1
-
-  # After the parse and before everything that writes: taking it first would
-  # answer a missing config with a message about a lock.
-  acquire_lock
-
-  # dotglob because dotfiles are the ordinary case here, nullglob because an
-  # empty layer directory - the day-one state of a local layer - must expand to
-  # nothing rather than to a literal '*'.  Never restored.
-  shopt -s dotglob nullglob
-
-  clone_missing_roots
-
+# Reports every layer that has no usable directory, and returns non-zero when it
+# reported any.  With $1 'settled' it passes over the layers under a root this
+# build is about to fetch, whose state nothing can tell until the clone has run;
+# with 'all' it checks every layer.
+check_layers() {
+  local mode=${1-} i name path lineno root dir errors
   errors=0
   i=0
   while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
     name=${LAYER_NAMES[$i]}
     path=${LAYER_PATHS[$i]}
+    lineno=${LAYER_LINES[$i]}
+    i=$((i + 1))
     root=${path%%/*}
     dir=$DOTFILES/$path
+    if [ "$mode" = settled ] && will_clone "$root"; then
+      continue
+    fi
     if [ -d "$dir" ]; then
       :
     elif obscured_ancestor "$DOTFILES" "$path"; then
@@ -1294,25 +1304,49 @@ cmd_build() {
       errors=$((errors + 1))
     elif [ -d "$DOTFILES/$root" ]; then
       emit "layer '$name' has no directory at $dir, but its clone at $DOTFILES/$root exists" \
-        "check the path on line ${LAYER_LINES[$i]}"
+        "check the path on line $lineno"
       errors=$((errors + 1))
     elif [ -e "$DOTFILES/$root" ] || [ -L "$DOTFILES/$root" ]; then
-      # Reachable despite the clone above: shale removes nothing it did not
-      # create, so a root that is not a directory is never cloned over.
+      # Reachable despite the clone: shale removes nothing it did not create, so
+      # a root that is not a directory is never cloned over.
       emit "layer '$name' has no directory at $dir" \
         "its clone root $DOTFILES/$root exists but is not a directory" \
         'remove it, or move it aside'
       errors=$((errors + 1))
     else
-      # No branch for a root with a url and nothing at its path: cloning has
-      # already run, and it either obtained that root or stopped the build.
+      # No branch for a root with a url and nothing at its path: the settled
+      # pass passes such a layer over, and by the second the clone has either
+      # obtained the root or stopped the build.
       emit "layer '$name' has no directory at $dir and no url for '$root'" \
         "add a url on that line, or create the directory"
       errors=$((errors + 1))
     fi
-    i=$((i + 1))
   done
-  [ "$errors" -eq 0 ] || exit 1
+  [ "$errors" -eq 0 ] || return 1
+  return 0
+}
+
+cmd_build() {
+  local i dir n had_current qcur qold
+
+  parse_config || exit 1
+
+  # After the parse and before everything that writes: taking it first would
+  # answer a missing config with a message about a lock.
+  acquire_lock
+
+  # dotglob because dotfiles are the ordinary case here, nullglob because an
+  # empty layer directory - the day-one state of a local layer - must expand to
+  # nothing rather than to a literal '*'.  Never restored.
+  shopt -s dotglob nullglob
+
+  # Every layer no clone can affect is already in the state it will be in when
+  # the last one has finished, so it is reported before the first one starts.
+  check_layers settled || exit 1
+
+  clone_missing_roots
+
+  check_layers all || exit 1
 
   if [ -L "$CUR" ]; then
     die "$CUR is a symlink" \

--- a/tests/run
+++ b/tests/run
@@ -3605,6 +3605,37 @@ shale: composed layer 'work' from $HOME/.dotfiles/work" "$shale_out" 'stdout'
   assert_eq 'work/.gitconfig' "$(cat "$HOME/.dotfiles/current/.gitconfig")" 'the built tree'
 }
 
+# The config error that costs most to learn late: a layer whose root has no url
+# is in the state it will still be in when every clone has finished, and the
+# reader was made to wait through two of them to hear about a mkdir.  The
+# assertions are on the filesystem and on the recording git, not on the absence
+# of shale's own line: the roots are not there and git was never run, which
+# 'cloning' being missing from stdout on its own would not say.
+# shellcheck disable=SC2123  # PATH is prefixed on purpose and restored below
+test_clone_a_layer_that_cannot_be_cloned_stops_the_build_before_any_clone() {
+  local personal_url saved
+  mkrepo personal .zshrc
+  personal_url=$repo_url
+  mkrepo work .gitconfig
+  conf "base personal $personal_url" "work work $repo_url" 'local local'
+  stub_git
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: layer 'local' has no directory at $HOME/.dotfiles/local and no url for 'local'" 'stderr'
+  assert_contains "$shale_err" 'shale:   add a url on that line, or create the directory' 'stderr'
+  assert_empty "$(cat "$git_log")" 'git invocations'
+  assert_empty "$shale_out" 'stdout'
+  assert_missing "$HOME/.dotfiles/personal"
+  assert_missing "$HOME/.dotfiles/work"
+  assert_missing "$HOME/.dotfiles/.personal.cloning"
+  assert_missing "$HOME/.dotfiles/.work.cloning"
+  assert_missing "$HOME/.dotfiles/current"
+}
+
 # The case that keeps a sync command cut from scope: shale obtains a layer it
 # has not got and never touches one it has.  git is not run at all on the second
 # build, which is the same claim the lazy prerequisite check makes.


### PR DESCRIPTION
Closes #68.

Reviewed by both gates: the code gate traced `will_clone` through every clone-root state and confirmed the moved loop index produces correct line numbers; the functional gate ran an 18-state matrix against `main` and got byte-identical output in every state, and confirmed git is invoked zero times for the failing config.

The deliberate narrowing and the `.cloning` decision are in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)