### PR TITLE
Fix wsl-work.conf naming a repository root as a layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ root and leave it off the other lines that share it. Blank lines and `#` comment
 ```
 base    personal/base     git@github.com:you/dotfiles.git
 wsl     personal/wsl
-work    work              git@github-work:employer/dotfiles.git
+work    work/base         git@github-work:employer/dotfiles.git
 local   local
 ```
 
-Here `personal/base` and `personal/wsl` are two layers from one clone at `~/.dotfiles/personal`, and
+Here `personal/base` and `personal/wsl` are two layers from one clone at `~/.dotfiles/personal`,
+`work/base` is a layer from a second clone at `~/.dotfiles/work` on a second GitHub account, and
 `local` is this machine's own unversioned directory. Reordering the lines changes precedence;
 nothing else does.
 
@@ -160,7 +161,7 @@ shale apply
 
 ```
 $ shale which .zshrc
-winner    work   /home/you/.dotfiles/work/.zshrc
+winner    work   /home/you/.dotfiles/work/base/.zshrc
 shadowed  base   /home/you/.dotfiles/personal/base/.zshrc
 ```
 
@@ -168,7 +169,7 @@ Directories merge rather than shadow, and the report says so instead of naming a
 
 ```
 $ shale which .config/profile.d
-merged    work   /home/you/.dotfiles/work/.config/profile.d/
+merged    work   /home/you/.dotfiles/work/base/.config/profile.d/
 merged    wsl    /home/you/.dotfiles/personal/wsl/.config/profile.d/
 merged    base   /home/you/.dotfiles/personal/base/.config/profile.d/
 ```
@@ -191,11 +192,11 @@ directory; `build` names both layers and rebuilds nothing:
 $ shale build
 shale: composed layer 'base' from /home/you/.dotfiles/personal/base
 shale: composed layer 'wsl' from /home/you/.dotfiles/personal/wsl
-shale: composed layer 'work' from /home/you/.dotfiles/work
+shale: composed layer 'work' from /home/you/.dotfiles/work/base
 shale: composed layer 'local' from /home/you/.dotfiles/local
 shale: conflict at .config/profile.d
 shale:   layer 'local' provides a file        /home/you/.dotfiles/local/.config/profile.d
-shale:   layer 'work'  provides a directory   /home/you/.dotfiles/work/.config/profile.d
+shale:   layer 'work'  provides a directory   /home/you/.dotfiles/work/base/.config/profile.d
 shale:   a layer cannot replace a directory with a file, or a file with a directory
 shale:   remove or rename one of them
 shale: 1 conflict; /home/you/.dotfiles/current not rebuilt

--- a/examples/wsl-work.conf
+++ b/examples/wsl-work.conf
@@ -9,11 +9,16 @@
 
 base    personal/base     git@github.com:you/dotfiles.git
 wsl     personal/wsl
-work    work              git@github-work:employer/dotfiles.git
+work    work/base         git@github-work:employer/dotfiles.git
 local   local
 
 # personal/base and personal/wsl are two layers from one clone at
 # ~/.dotfiles/personal — hence one url, on the first of them.
+#
+# work/base is a subdirectory of its own clone at ~/.dotfiles/work, for the
+# same reason personal/base is a subdirectory of ~/.dotfiles/personal: name
+# the clone root itself as the layer and everything the repository keeps for
+# its own sake — .gitignore, .github, Makefile — is linked into $HOME too.
 #
 # `github-work` is an ssh config Host alias pointing at github.com with a
 # different IdentityFile; that is how two accounts coexist.

--- a/tests/run
+++ b/tests/run
@@ -6240,6 +6240,96 @@ test_examples_every_shipped_config_parses() {
   [ "$found" -gt 0 ] || fail "no examples found at $REPO_ROOT/examples/*.conf"
 }
 
+# docs/layers.md warns that naming a repository root as a layer links the
+# repository's own furniture - .gitignore, .github, Makefile - into $HOME, and
+# examples/minimal.conf spells the warning out.  This is the regression case:
+# every layer whose root a line in the same file gives a url for must have a
+# subdirectory below that root.  A root nobody gives a url for is a
+# machine-local directory instead - 'local local' in both shipped examples -
+# and one component there is correct, so the rule below only ever looks at
+# roots this same file clones.
+#
+# Two passes over each file rather than one, because the url for a root can
+# appear on any line that shares it, not only the first: the second pass has
+# to know every cloned root before it can judge the first layer path.
+#
+# 'records' answers the same vacuous-pass hazard test_examples_every_shipped_config_parses
+# guards against with doctor's own "layer '" check, without coupling this case
+# to shale's parser: a line whose fields are not separated the way 'read'
+# expects - commas in place of the spaces the format requires, say - leaves
+# $p empty, so nothing is ever added to 'roots' and the loop below has nothing
+# to compare against.  Without this check that file reports 'ok' having
+# examined zero layer paths.  A shipped example with no layer records at all is
+# exactly that failure, whether every line is a comment or every line is
+# unparsable, so nothing here exempts either cause.
+test_examples_no_layer_path_names_a_cloned_root_directly() {
+  local example name line found bad report
+  local n p u root roots r _ records
+  found=0
+  bad=0
+  report=()
+  for example in "$REPO_ROOT"/examples/*.conf; do
+    [ -f "$example" ] || continue
+    name=${example##*/}
+    found=$((found + 1))
+    roots=()
+    records=0
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        '' | '#'*) continue ;;
+      esac
+      n=
+      p=
+      u=
+      _=
+      read -r n p u _ <<EOF
+$line
+EOF
+      case "$p" in '#'*) p= ;; esac
+      case "$u" in '#'*) u= ;; esac
+      [ -n "$p" ] || continue
+      records=$((records + 1))
+      [ -n "$u" ] || continue
+      roots[${#roots[@]}]=${p%%/*}
+    done <"$example"
+    if [ "$records" -eq 0 ]; then
+      report[${#report[@]}]="$name: no layer records were extracted from this file"
+      bad=$((bad + 1))
+      continue
+    fi
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        '' | '#'*) continue ;;
+      esac
+      n=
+      p=
+      u=
+      _=
+      read -r n p u _ <<EOF
+$line
+EOF
+      case "$p" in '#'*) p= ;; esac
+      [ -n "$p" ] || continue
+      case "$p" in
+        */*) continue ;;
+      esac
+      root=$p
+      for r in ${roots[@]+"${roots[@]}"}; do
+        if [ "$r" = "$root" ]; then
+          report[${#report[@]}]="$name: layer $n names the cloned root $root directly: $p"
+          bad=$((bad + 1))
+          break
+        fi
+      done
+    done <"$example"
+  done
+  if [ "$bad" -gt 0 ]; then
+    fail "$bad layer(s) in $REPO_ROOT/examples name a cloned repository root as their own path" \
+      ${report[@]+"${report[@]}"}
+  fi
+  [ "$found" -gt 0 ] || fail "no examples found at $REPO_ROOT/examples/*.conf"
+}
+
 # ---------------------------------------------------------------- which cases
 #
 # The answer is on stdout with no 'shale: ' prefix - it is the command's result,


### PR DESCRIPTION
Closes #65.

Reviewed by both gates. The functional gate reproduced the original harm and showed it gone, and verified the three hand-edited README transcripts are byte-identical to real output. It also built GNU Stow 2.4.1 from source to check the ignore-list behaviour against both supported versions; the mechanism correction is a comment on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)