### PR TITLE
Report a built tree older than its layers, not just a newer one

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ shale:   if no other shale is running, this lock is stale: remove it with: rmdir
 
 `~/.dotfiles/current` is generated output. It is disposable — a bad build is fixed by fixing a layer
 and building again — and it should never be edited or versioned. Edit the layer, not the result. A
-build that finds a file in `current` newer than the layer's copy says so and keeps the tree it
-replaced at `~/.dotfiles/current.old`, so the edit is recoverable until the next build, which
-removes it. A build composes into `~/.dotfiles/current.new` and renames that into place, so a
+build that finds a file in `current` differing in age from the layer's copy says so and keeps the
+tree it replaced at `~/.dotfiles/current.old`, so what was there is recoverable until the next build,
+which removes it. Newer means something edited the built tree; older means either that something
+moved a file into it, which is what `stow --adopt` does, or that a layer has moved on and this is the
+first build since. A build composes into `~/.dotfiles/current.new` and renames that into place, so a
 `current.new` left lying about is a run that died mid-build and is safe to delete.
 
 One file in there is shale's own rather than a copy: `current/.stow-local-ignore`, which keeps a

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -238,6 +238,19 @@ shale:   your version is kept at /home/you/.dotfiles/current.old/.zshrc
 Copy your version back into the layer from `current.old`. The next build reaps `current.old`, so do
 it before then. Never version `current/`, and never point a layer symlink into it.
 
+A file that arrives in the built tree from somewhere else keeps its own timestamp rather than
+gaining a new one, so it can be *older* than the layer copy that replaces it — which is what
+`stow --adopt` does, and it is the shape a lost file usually has. A build reports those together:
+
+```
+shale: 2 files in /home/you/.dotfiles/current were older than the layer copies that replaced them
+shale:   either something moved them into the built tree, which is what stow --adopt does, or a layer changed and this is the first build since
+shale:   what was in /home/you/.dotfiles/current before this build is kept at /home/you/.dotfiles/current.old
+```
+
+Shale cannot tell that from a built tree its layers have moved past, and does not guess. Look in
+`current.old` if you were not expecting it.
+
 ## Updating layers after the first run
 
 Shale clones a layer root that is missing and never touches it again; updating a checkout is git's
@@ -249,4 +262,6 @@ git -C ~/.dotfiles/work pull
 shale apply
 ```
 
-There is no `shale sync`.
+The first build after a pull that changed anything reports the files in `current` that were older
+than their new layer copies, and keeps `current.old`. That is expected here and nothing to act on;
+the build after it is quiet again. There is no `shale sync`.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -9,6 +9,13 @@ else the package owns, and every shell opened between then and the apply falls b
 defaults. Keep a second session already running, and do this over a connection you are not relying
 on the dotfiles to make.
 
+One thing to know before you start, rather than after: do not use `stow --adopt`. Your first apply
+will refuse a pile of conflicts, `--adopt` is what a search turns up for clearing them, and here it
+moves your file out of `$HOME` and into `~/.dotfiles/current`, which is generated output that the
+next `shale build` overwrites. That build says so and keeps the whole previous tree at `current.old`,
+so an adopted file survives one build and no more — the build after it reaps `current.old`. Copy the
+file into a layer instead. The refusals themselves are covered below, each with what to do about it.
+
 ## Unstow first
 
 ```sh
@@ -136,12 +143,21 @@ All operations aborted.
 That file is not in any layer and shale will not overwrite it. Move it aside, or copy its contents
 into the layer that should own it and then delete it.
 
-Do not reach for `stow --adopt` to clear any of these. It moves the file from `$HOME` into the
-package — which here means into `~/.dotfiles/current`, generated output — and the next `shale build`
-composes over it. Whether you get the content back depends on a timestamp: if the adopted file was
-newer than the layer's copy the build warns and keeps it in `current.old`, and the build after that
-reaps it; if it was older the build says nothing and there is nothing left to recover. Copy the file
-into a layer instead.
+Do not reach for `stow --adopt` to clear any of these, for the reason given at the top. It moves the
+file from `$HOME` into the package — which here means into `~/.dotfiles/current`, generated output —
+and the next `shale build` composes over it. That build reports it:
+
+```
+shale: 1 file in /home/you/.dotfiles/current was older than the layer copy that replaced it
+shale:   either something moved it into the built tree, which is what stow --adopt does, or a layer changed and this is the first build since
+shale:   what was in /home/you/.dotfiles/current before this build is kept at /home/you/.dotfiles/current.old
+```
+
+Both readings, because shale cannot tell them apart: an adopted file keeps its own timestamp, and so
+does a `current` the layers have moved past since it was built. You will see the same message the
+first time you build after pulling a layer, and it is nothing to act on there. Either way the
+previous tree is at `current.old` and your file is in it, until the next clean build reaps it. Copy
+the file into a layer instead and there is nothing to recover.
 
 ## Links left behind after layers change
 

--- a/shale
+++ b/shale
@@ -691,25 +691,46 @@ conflict() {
   CONFLICT_OTHER+=("$other_label provides a $other_kind   $other_path")
 }
 
+# Non-zero when a layer after this one also provides $1, so one changed file is
+# one record.
+wins_this_path() {
+  local srel=$1 i
+  i=$((SRC_INDEX + 1))
+  while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
+    if [ -e "$DOTFILES/${LAYER_PATHS[$i]}/$srel" ] ||
+      [ -L "$DOTFILES/${LAYER_PATHS[$i]}/$srel" ]; then
+      return 1
+    fi
+    i=$((i + 1))
+  done
+  return 0
+}
+
 # Something wrote to the built tree through its $HOME symlink instead of to the
 # layer, which is this design's one silent data-loss path: ~/.zshrc is a link
 # into current/ and an editor writes straight through it.  cp -p is what keeps
 # a legitimate layer update from tripping this.  Recorded, not printed: the
 # message names current.old, which an aborted build never creates.
+#
+# Recorded only for the layer that wins the path, which is what makes the layer
+# named in the message the one whose copy actually lands.
 diverged() {
-  local srel=$1 path=$2 i
-  # Silent for every layer but the last one providing this path, so one edited
-  # file is one record and it names the layer whose copy actually lands.
-  i=$((SRC_INDEX + 1))
-  while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
-    if [ -e "$DOTFILES/${LAYER_PATHS[$i]}/$srel" ] ||
-      [ -L "$DOTFILES/${LAYER_PATHS[$i]}/$srel" ]; then
-      return 0
-    fi
-    i=$((i + 1))
-  done
+  local srel=$1 path=$2
+  wins_this_path "$srel" || return 0
   DIVERGED_PATHS+=("$srel")
   DIVERGED_LAYERS+=("$path")
+}
+
+# The other half of that data-loss path, and the half no timestamp can name: a
+# file moved into the built tree keeps its own mtime, so one older than the layer
+# copy about to overwrite it is either an adopted file or a copy the layers have
+# moved past.  Counted rather than listed, because a pull that changed fifty
+# files must not print a hundred and fifty lines about it, and counted only for
+# the layer that wins the path, so the count is a count of files.
+older_than_layer() {
+  local srel=$1
+  wins_this_path "$srel" || return 0
+  OLDER_COUNT=$((OLDER_COUNT + 1))
 }
 
 # Copies one layer directory over the composed tree, entry by entry, last write
@@ -755,8 +776,12 @@ compose_dir() {
         conflict "$srel" file "$e"
         continue
       fi
-      if [ -f "$CUR/$srel" ] && [ "$CUR/$srel" -nt "$e" ]; then
-        diverged "$srel" "$e"
+      if [ -f "$CUR/$srel" ]; then
+        if [ "$CUR/$srel" -nt "$e" ]; then
+          diverged "$srel" "$e"
+        elif [ "$e" -nt "$CUR/$srel" ]; then
+          older_than_layer "$srel"
+        fi
       fi
       # cp writes *through* a destination symlink that points at an existing
       # file, rewriting a lower layer's link target; GNU's
@@ -1327,7 +1352,7 @@ check_layers() {
 }
 
 cmd_build() {
-  local i dir n had_current qcur qold
+  local i dir n had_current qcur qold files was them copies
 
   parse_config || exit 1
 
@@ -1370,6 +1395,7 @@ cmd_build() {
 
   DIVERGED_PATHS=()
   DIVERGED_LAYERS=()
+  OLDER_COUNT=0
   CONFLICT_PATHS=()
   CONFLICT_MINE=()
   CONFLICT_OTHER=()
@@ -1485,10 +1511,11 @@ cmd_build() {
   # Reported here rather than during the walk: until the swap has happened there
   # is no current.old for the message to point at.  Before the re-raise below,
   # because a signal ending the run here must not take the only notice that
-  # current.old holds an edit with it - the next build reaps current.old and
-  # cannot re-detect the divergence, cp -p having left the copy no newer.
+  # current.old holds a replaced file with it - the next build reaps current.old
+  # and cannot re-detect either divergence, this build having left every copy in
+  # $CUR the same age as the layer file it came from.
   n=${#DIVERGED_PATHS[@]}
-  if [ "$n" -eq 0 ]; then
+  if [ "$n" -eq 0 ] && [ "$OLDER_COUNT" -eq 0 ]; then
     rm -rf "$OLD" || warn "could not remove $OLD"
   else
     i=0
@@ -1498,6 +1525,24 @@ cmd_build() {
         "your version is kept at $OLD/${DIVERGED_PATHS[$i]}"
       i=$((i + 1))
     done
+    if [ "$OLDER_COUNT" -gt 0 ]; then
+      files='files'
+      was='were'
+      them='them'
+      copies='the layer copies that replaced them'
+      if [ "$OLDER_COUNT" -eq 1 ]; then
+        files='file'
+        was='was'
+        them='it'
+        copies='the layer copy that replaced it'
+      fi
+      # One group however many files, and it states both readings rather than
+      # naming one: nothing shale can read tells a file moved into the built
+      # tree from a built tree the layers have moved past.
+      warn "$OLDER_COUNT $files in $CUR $was older than $copies" \
+        "either something moved $them into the built tree, which is what stow --adopt does, or a layer changed and this is the first build since" \
+        "what was in $CUR before this build is kept at $OLD"
+    fi
   fi
 
   if [ -n "$DEFERRED" ]; then

--- a/tests/run
+++ b/tests/run
@@ -2158,6 +2158,75 @@ test_build_warns_when_the_built_tree_was_edited() {
   assert_missing "$HOME/.dotfiles/current.old/junk"
 }
 
+# The half of that path an mtime comparison cannot name.  stow --adopt moves the
+# user's own file into the built tree keeping its mtime, so a five-year-old
+# .zshrc lands there *older* than the layer copy about to overwrite it and the
+# newer-direction check above never fires.  The message may not say the tree was
+# edited: an older copy is equally a build the layers have moved past.
+test_build_warns_when_the_built_tree_is_older_than_its_layer() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the first build stderr'
+  assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  # '>|': the build above put this file here, and replacing it is the point.
+  # Dated into the past because that is what an adopted file arrives with.
+  printf 'FIVE YEARS OF ZSH\n' >|"$sandbox_path" || fail 'could not adopt into the built tree'
+  touch -t 200001010000 "$sandbox_path" || fail 'could not date the adopted file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: 1 file in $HOME/.dotfiles/current was older than the layer copy that replaced it" \
+    'stderr'
+  assert_contains "$shale_err" 'which is what stow --adopt does' 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   what was in $HOME/.dotfiles/current before this build is kept at $HOME/.dotfiles/current.old" \
+    'stderr'
+  assert_not_contains "$shale_err" 'you edited' 'stderr'
+  assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
+  assert_eq 'FIVE YEARS OF ZSH' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
+}
+
+# One group however many files: a pull that changed fifty of them must not print
+# a hundred and fifty lines.  The count is a count of files, so .zshrc coming
+# from two layers still counts once, and the two untouched files count not at
+# all.  Retention is one build deep - the rebuild leaves every copy the age of
+# the layer file it came from, so the next build has nothing left to re-detect.
+test_build_summarises_older_files_in_one_group_and_forgets_them_next_build() {
+  local name groups
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  mklayer personal/base .vimrc
+  mklayer personal/base .inputrc
+  mklayer personal/base .netrc
+  mklayer personal/base .gitconfig
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the first build stderr'
+  for name in .zshrc .vimrc .inputrc; do
+    sandbox_mkdir "$HOME/.dotfiles/current"
+    sandbox_leaf "$sandbox_dir" "$name"
+    touch -t 200001010000 "$sandbox_path" || fail "could not date $name"
+  done
+  run_shale build
+  assert_status 0 "$shale_status"
+  groups=$(printf '%s\n' "$shale_err" | grep -c 'were older than')
+  assert_eq 1 "$groups" 'summary lines'
+  assert_contains "$shale_err" \
+    "shale: 3 files in $HOME/.dotfiles/current were older than the layer copies that replaced them" \
+    'stderr'
+  assert_not_contains "$shale_err" 'you edited' 'stderr'
+  assert_exists "$HOME/.dotfiles/current.old/.zshrc" 'the previous tree'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the next build stderr'
+  assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
+}
+
 # The warning names current.old, which only the swap creates.  Reported during
 # the walk it would promise a path that an aborted build never makes - or worse,
 # point at a stale current.old holding something else entirely.
@@ -3277,6 +3346,11 @@ test_doctor_a_lock_left_behind_is_a_finding_naming_builds_remedy() {
   for shape in empty occupied; do
     conf 'base personal/base'
     mklayer personal/base .zshrc
+    # Both passes share one $HOME, so without a fixed date the second pass's
+    # rewrite of this file leaves the tree the first pass built older than the
+    # layer, and the build below reports that rather than nothing.
+    sandbox_mkdir "$HOME/.dotfiles/personal/base"
+    touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
     case "$shape" in
       empty)
         sandbox_mkdir "$HOME/.dotfiles/.lock"
@@ -4041,13 +4115,28 @@ test_apply_a_layer_root_readme_does_not_reach_home() {
 test_apply_a_content_change_is_seen_through_the_existing_link() {
   conf 'base personal/base'
   mklayer personal/base .zshrc 'first'
+  # Dated into the past so the comparison below cannot come down to filesystem
+  # timestamp granularity: this file's mtime is what the first apply copies into
+  # the built tree, and the rewrite of it two lines down has to be strictly
+  # newer than that copy in whole seconds - which is all bash 3.2's -nt compares.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
   run_shale apply
   assert_status 0 "$shale_status"
   assert_eq 'first' "$(cat "$HOME/.zshrc")" 'the linked file'
   mklayer personal/base .zshrc 'second'
   run_shale apply
   assert_status 0 "$shale_status"
-  assert_empty "$shale_err" 'the second apply stderr'
+  # The price of the adopted-file guard, paid here: an edited layer leaves the
+  # tree it replaces older than itself, which is indistinguishable from a file
+  # moved into that tree, so the first build after an edit says so.  It is a
+  # line on stderr and a retained current.old, not a failure.
+  assert_contains "$shale_err" \
+    "shale: 1 file in $HOME/.dotfiles/current was older than the layer copy that replaced it" \
+    'the second apply stderr'
+  # Nothing else on stderr: the tree was not edited, and a diverged record
+  # firing alongside the summary would otherwise pass unnoticed here.
+  assert_not_contains "$shale_err" 'you edited' 'the second apply stderr'
   assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
   assert_eq 'second' "$(cat "$HOME/.zshrc")" 'the linked file'
 }
@@ -7034,6 +7123,8 @@ test_meta_noclobber_overrides_are_allow_listed() {
     # shale's own build put this file there, and editing it is what the case is
     # about.
     'HAND EDITED'
+    # The same, for the file an adopt would have put there in its place.
+    'FIVE YEARS OF ZSH'
   )
   found=0
   report=()


### PR DESCRIPTION
Closes #66.

The design decision and the knowingly-overridden criterion are in the commit message.

The functional gate established that bash `-nt` is exact-nanosecond and GNU `cp -RPp` preserves it exactly, with six consecutive builds of a 601-file tree producing no output. The open question is whether BSD `cp -p` on the macOS runner preserves sub-second mtimes; if it truncates, the existing rebuild-is-silent cases will go red there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)