### PR TITLE
Make doctor's broken-link audit linear and bound its report

### DIFF
--- a/shale
+++ b/shale
@@ -865,6 +865,34 @@ normalise_path() {
   NORMALISED=${out:-/}
 }
 
+# The deepest directory holding both the file $1 and everything ANCESTOR already
+# stands for, in ANCESTOR; an empty ANCESTOR takes the directory holding $1.
+#
+# $1 is a link's path as chkstow printed it, which is the spelling the findings
+# name, and the answer has to agree with them: fed the normalised form of what a
+# link points at instead, this would name a directory in the built tree and be
+# wrong without looking wrong.  Text only, and nothing it returns need exist.
+common_ancestor() {
+  local dir=${1-}
+  dir=${dir%/*}
+  [ -n "$dir" ] || dir=/
+  if [ -z "$ANCESTOR" ]; then
+    ANCESTOR=$dir
+    return 0
+  fi
+  # The quoted expansion in the case pattern is what keeps a '[' or a '*' in a
+  # path a character rather than a glob.
+  while [ "$ANCESTOR" != / ]; do
+    [ "$ANCESTOR" != "$dir" ] || return 0
+    case "$dir" in
+      "$ANCESTOR"/*) return 0 ;;
+    esac
+    ANCESTOR=${ANCESTOR%/*}
+    [ -n "$ANCESTOR" ] || ANCESTOR=/
+  done
+  return 0
+}
+
 # $1 wrapped so that a shell reading the line shale printed gets the path back
 # exactly, in QUOTED.  Single quotes around the whole of it, with an embedded
 # quote spelled '\'' - the one form that survives a space, a bracket, a dollar
@@ -1001,7 +1029,9 @@ EOF
 }
 
 # Every link under $HOME that points into the built tree at a path the built
-# tree no longer holds: one finding each, and the remedy once under them.
+# tree no longer holds: one finding each, and the remedy once.  Up to $cap of
+# them the remedy follows the findings; past it the count, the directory they
+# are under and the remedy come first and only $cap of the links are named.
 #
 # chkstow's exit status carries no information - run against a target it cannot
 # reach it prints "Can't stat ...: No such file or directory" and still exits 0,
@@ -1015,6 +1045,7 @@ EOF
 # own dangling symlink judged against itself would be reported for ever.
 audit_broken_links() {
   local out err marker line link dest target cur dots home qdots qhome n lines
+  local stream cap rest msg samples remedy where
 
   # Uncounted, and before every other check here, which all need a built tree to
   # mean anything.
@@ -1060,25 +1091,47 @@ audit_broken_links() {
   # everything after it is stderr with no interleaving possible.
   marker="chkstow-stderr-$$-${RANDOM-0}"
   out=$( { err=$(chkstow -b -t "$home" 2>&1 1>&3 3>&-); printf '%s\n%s' "$marker" "$err"; } 3>&1 )
-  err=${out#*"$marker"}
-  out=${out%%"$marker"*}
-  if [ -n "$err" ]; then
-    # The newline the marker was printed with.
-    err=${err#?}
-    lines=("chkstow could not walk all of $HOME, so this audit did not reach everything under it:")
-    while IFS= read -r line; do
-      [ -n "$line" ] || continue
-      lines[${#lines[@]}]="  $line"
-    done <<EOF
-$err
-EOF
-    note ${lines[@]+"${lines[@]}"}
-  fi
 
   n=0
-  # A heredoc rather than a pipe: a pipeline would run this loop in a subshell
-  # and every finding it counted would be lost with it.
+  lines=()
+  samples=()
+  stream=out
+  # Above this many, the report changes shape rather than growing: the count and
+  # the directory holding them are what a home full of orphans can be acted on
+  # with, and a remedy printed under 1700 paths is one nobody reads.  Ten keeps
+  # the whole block inside a short terminal and well above the three that a
+  # directory leaving one layer produces.
+  cap=10
+  ANCESTOR=
+  # One pass over both streams, switching at the marker, rather than cutting the
+  # capture in two around it: ${out#*"$marker"} rescans from the anchored end for
+  # every candidate position, so its cost is quadratic in the bytes before the
+  # marker - which is the whole of chkstow's output, and this audit exists for
+  # the trees where that is large.  Reading the marker as a line costs nothing.
+  # No stdout line can equal it: under -b every one of them begins 'Bogus
+  # link: '.
+  #
+  # A heredoc rather than a pipe: a pipeline would run this loop in a subshell,
+  # and the count, the sample, the stderr lines and the ancestor would all go
+  # with it.
   while IFS= read -r line; do
+    if [ "$stream" = err ]; then
+      [ -n "$line" ] || continue
+      lines+=("  $line")
+      continue
+    fi
+    # The marker is on a line of its own only because chkstow's stdout ends in a
+    # newline and it is printed after it - true of every stdout write in 2.3.1's
+    # chkstow and in 2.4.1's, which differ in nothing but a shebang placeholder
+    # and an editor comment.  A chkstow that ever stopped doing that would glue
+    # the marker to a partial line, this switch would never fire, and the audit
+    # would lose the last finding and the whole of the truncated-walk note
+    # without saying so.  Not defended against: a substring test per line buys
+    # nothing against a failure the tool cannot produce.
+    if [ "$line" = "$marker" ]; then
+      stream=err
+      continue
+    fi
     # Not exhaustive, and chkstow's format cannot be made to be: it prints one
     # unquoted path per line, so a link whose name holds a newline arrives as
     # two lines and is dropped.  Nothing is fabricated; some links are missed.
@@ -1113,28 +1166,80 @@ EOF
     # -L as well as -e: a dangling symlink a layer ships deliberately is still
     # provided by the built tree, and only an unprovided path is an orphan.
     { [ ! -e "$target" ] && [ ! -L "$target" ]; } || continue
-    finding "$link points at $target, which the built tree no longer provides"
+    # Collected rather than printed: how it is reported depends on how many
+    # there turn out to be, and nothing has counted them yet.  Only the first
+    # $cap are kept - growing an array to 1700 entries is the other way to make
+    # this quadratic - and the ancestor is folded in one link at a time.
     n=$((n + 1))
+    [ "$n" -gt "$cap" ] || samples+=("$link points at $target, which the built tree no longer provides")
+    common_ancestor "$link"
   done <<EOF
 $out
 EOF
 
+  # Still ahead of the findings, as it was when it was printed on the way past:
+  # a truncated walk qualifies everything below it.
+  if [ "${#lines[@]}" -gt 0 ]; then
+    note "chkstow could not walk all of $HOME, so this audit did not reach everything under it:" \
+      ${lines[@]+"${lines[@]}"}
+  fi
+
   [ "$n" -gt 0 ] || return 0
-  # Uncounted: this is the remedy for the findings above rather than another of
-  # them, and delete leads because it works on every version of stow.  Both
-  # halves were run: 2.3.1 abandons the -p sweep at the first file in the target
-  # that is neither a link nor a directory - one ~/notes.txt is enough - and
-  # 2.4.1 takes the orphan back with it.  Nothing here probes for the version;
-  # the line says which one it needs.
+  # Uncounted: this is the remedy for the findings rather than another of them,
+  # and delete leads because it works on every version of stow.  Both halves
+  # were run: 2.3.1 abandons the -p sweep at the first file in the target that
+  # is neither a link nor a directory - one ~/notes.txt is enough - and 2.4.1
+  # takes the orphan back with it.  Nothing here probes for the version; the
+  # line says which one it needs.
   shell_quote "$DOTFILES"
   qdots=$QUOTED
   shell_quote "$HOME"
   qhome=$QUOTED
-  note 'stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links' \
-    'remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
-    'stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
+  remedy=('stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links')
+  if [ "$n" -le "$cap" ]; then
+    remedy+=('remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying')
+  else
+    # The findings are below the remedy in this shape, and most of them are not
+    # printed at all, so there is nothing 'named above' to point at.
+    remedy+=('remove them; the built tree is correct, and nothing needs rebuilding or reapplying')
+  fi
+  remedy+=('stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
     "  stow -D -p --no-folding -d $qdots -t $qhome current && shale apply" \
-    'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory'
+    'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory')
+
+  if [ "$n" -le "$cap" ]; then
+    for msg in ${samples[@]+"${samples[@]}"}; do
+      finding "$msg"
+    done
+    note ${remedy[@]+"${remedy[@]}"}
+    return 0
+  fi
+
+  # Named on its own line unless it is $HOME, which the line above it has
+  # already said: the same trailing slash $home carries, so the two spellings
+  # compare rather than the strings as they arrived.
+  where=()
+  target=$ANCESTOR
+  case "$target" in
+    */) ;;
+    *) target=$target/ ;;
+  esac
+  [ "$target" = "$home" ] || where=("all of them are under $ANCESTOR")
+
+  # Above the cap the count and the directory lead, and the remedy sits under
+  # them where it can be read without scrolling past the sample.
+  note "$n links under $HOME point into the built tree at paths it no longer provides" \
+    ${where[@]+"${where[@]}"} \
+    ${remedy[@]+"${remedy[@]}"}
+  for msg in ${samples[@]+"${samples[@]}"}; do
+    finding "$msg"
+  done
+  rest=$((n - cap))
+  note "and $rest more, not named here"
+  # Every one of them is a link that has to go, so every one of them is a
+  # finding: the cap changes what is printed and never what is wrong.  The loop
+  # above counted $cap of them.
+  FINDINGS=$((FINDINGS + rest))
 }
 
 # ------------------------------------------------------------------- the query

--- a/tests/run
+++ b/tests/run
@@ -5658,6 +5658,166 @@ EOF
   assert_eq ' finding remedy summary' "$seen" 'the order of the report'
 }
 
+# plant_orphans DIR N - N links in $HOME/DIR into the built tree at paths it has
+# not got, named f0 upwards; an empty DIR puts them in $HOME itself.  A directory
+# that left every layer leaves as many of these as it held files, which is the
+# volume the cases below are about.
+plant_orphans() {
+  local dir=${1-} n=${2-} i rel
+  rel=${dir:+$dir/}
+  sandbox_mkdir "$HOME${dir:+/$dir}"
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    sandbox_leaf "$sandbox_dir" "f$i" new
+    ln -s "$HOME/.dotfiles/current/${rel}f$i" "$sandbox_path" ||
+      fail "could not plant ${rel}f$i"
+    i=$((i + 1))
+  done
+}
+
+# report_shape - the order of the parts of doctor's report in report_seen, one
+# word per part and one word per run of adjacent finding lines, and the number of
+# finding lines in report_findings.
+report_shape() {
+  local line
+  report_seen=
+  report_findings=0
+  while IFS= read -r line; do
+    case "$line" in
+      *'which the built tree no longer provides')
+        report_findings=$((report_findings + 1))
+        case "$report_seen" in
+          *finding) ;;
+          *) report_seen="$report_seen finding" ;;
+        esac
+        ;;
+      'shale: '*' links under '*' point into the built tree at paths it no longer provides')
+        report_seen="$report_seen count"
+        ;;
+      'shale:   all of them are under '*) report_seen="$report_seen where" ;;
+      'shale:   remove '*) report_seen="$report_seen remedy" ;;
+      'shale: and '*' more, not named here') report_seen="$report_seen rest" ;;
+      'shale: '*' problems found') report_seen="$report_seen summary" ;;
+    esac
+  done <<EOF
+$1
+EOF
+}
+
+# The volume the audit was written for and the shape it has to take there: a
+# directory that left every layer leaves one orphan per file it held, and 1700
+# of them printed above their remedy is a report nobody can act on.  Above the
+# cap the count and the directory lead, the remedy is on screen with them, and
+# the links themselves are a sample under it.
+#
+# Twelve, in two sibling directories: the cap is ten, so this is the smallest
+# tree that both crosses it and has an ancestor that is neither directory.
+test_doctor_many_broken_links_lead_with_the_count_and_where_they_are() {
+  local report_seen report_findings
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status"
+  plant_orphans .config/nvim/pack/start 6
+  plant_orphans .config/nvim/pack/opt 6
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 12 links under $HOME point into the built tree at paths it no longer provides" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   all of them are under $HOME/.config/nvim/pack" 'stdout'
+  # The remedy is the same remedy, and it no longer says 'above': what is above
+  # it is the count, and ten of the twelve are printed nowhere at all.
+  assert_contains "$shale_out" \
+    'shale:   remove them; the built tree is correct, and nothing needs rebuilding or reapplying' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' 'stdout'
+  assert_contains "$shale_out" 'shale: and 2 more, not named here' 'stdout'
+  # Counted one per link either side of the cap: the cap decides what is printed
+  # and never what is wrong with the setup.
+  assert_contains "$shale_out" 'shale: 12 problems found' 'stdout'
+  report_shape "$shale_out"
+  assert_eq 10 "$report_findings" 'the number of links named'
+  assert_eq ' count where remedy finding rest summary' "$report_seen" 'the order of the report'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# The one ancestor the line naming it says nothing about, because the line above
+# it has already named $HOME.  Every other directory in the report is worth a
+# line; this one is the count line again, in the block a user reads first.
+test_doctor_many_broken_links_directly_in_home_do_not_name_home_twice() {
+  local report_seen report_findings
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status"
+  plant_orphans '' 11
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 11 links under $HOME point into the built tree at paths it no longer provides" 'stdout'
+  assert_not_contains "$shale_out" 'all of them are under' 'stdout'
+  assert_contains "$shale_out" 'shale: and 1 more, not named here' 'stdout'
+  report_shape "$shale_out"
+  assert_eq 10 "$report_findings" 'the number of links named'
+  assert_eq ' count remedy finding rest summary' "$report_seen" 'the order of the report'
+}
+
+# The other side of the cap, and the promise that goes with it: below it nothing
+# about this report has changed, so the three-orphan case above and this one at
+# exactly ten read the same way - every link named, then the remedy under them.
+test_doctor_broken_links_up_to_the_cap_are_all_named_with_the_remedy_under_them() {
+  local report_seen report_findings
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status"
+  plant_orphans .config/nvim/pack 10
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    'shale:   remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' 'stdout'
+  assert_not_contains "$shale_out" 'point into the built tree at paths it no longer provides' 'stdout'
+  assert_not_contains "$shale_out" 'not named here' 'stdout'
+  assert_contains "$shale_out" 'shale: 10 problems found' 'stdout'
+  report_shape "$shale_out"
+  assert_eq 10 "$report_findings" 'the number of links named'
+  assert_eq ' finding remedy summary' "$report_seen" 'the order of the report'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# chkstow's stderr arrives after the whole of its stdout, so the note that the
+# walk was short is now held back and printed rather than written on the way
+# past.  It has to come out ahead of the findings all the same: it says the list
+# below it is not the whole list, which after the list is no use.
+test_doctor_says_the_walk_was_short_before_the_links_it_did_find() {
+  local line seen
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.cache"
+  sandbox_write "$HOME/.cache" .stow
+  plant_orphans .config/nvim/pack 3
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  seen=
+  while IFS= read -r line; do
+    case "$line" in
+      'shale: chkstow could not walk all of '*) seen="$seen walk" ;;
+      *'which the built tree no longer provides')
+        case "$seen" in
+          *finding*) ;;
+          *) seen="$seen finding" ;;
+        esac
+        ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq ' walk finding' "$seen" 'the order of the report'
+}
+
 test_doctor_an_applied_tree_with_no_orphans_reports_no_problems() {
   conf 'base personal/base'
   mklayer personal/base .zshrc


### PR DESCRIPTION
Closes #64.

The measured diagnosis is a comment on the issue. Both gates passed: byte-identity below the ten-link cap verified at N=0/1/2/3/9/10, common ancestor exercised over 22 adversarial inputs, and 1700 links under a 259-character HOME measured at 2.57s against main 105s with no regression on the large-stderr case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)