### PR TITLE
Document the everyday loop, plain files, and the way out

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ Shale clones a layer that has a url and creates no layer that has not, so every 
 to exist before the first apply — `local`, in both shipped examples. `examples/minimal.conf` is the
 smaller starting point: one repository layer and that same local directory.
 
-Already stowing dotfiles by hand? Unstow the old packages before the first apply:
-[docs/migrating.md](docs/migrating.md).
+Dotfiles already in `$HOME`? Whether they are ordinary files or stow packages you stow by hand, they
+have to stop being files at those paths before the first apply, and anything of yours worth keeping
+has to be copied into a layer by hand — shale merges nothing.
+[docs/migrating.md](docs/migrating.md) takes both starting points step by step.
 
 ## Configuration
 
@@ -112,6 +114,17 @@ above. The four commands in it are the whole surface: there are no others, and n
 | `shale doctor` | Checks the prerequisites, the config, the layers and `$HOME`, and reports what it finds |
 | `shale which PATH` | Names every layer providing `PATH`, winner first, and when `build` would refuse the set |
 
+After editing a file a layer already has, `build` is the whole loop: `~/.zshrc` is a link into
+`current`, so rebuilding the tree it points at makes the edit live at that instant. `apply` is for
+when a *path* appears or disappears — a file or directory added to a layer has nothing in `$HOME`
+pointing at it until stow makes the link, and one deleted from every layer leaves a link behind
+until stow prunes it. Apply when unsure: it builds first, so it is never less than a build.
+[docs/layers.md](docs/layers.md) has the boundary case by case.
+
+Every build after an edit also reports the file as one the built tree held an older copy of, and
+names `stow --adopt` while doing so; that is the built tree having been out of date, not an
+accusation, and [docs/layers.md](docs/layers.md) says why shale cannot tell the two apart.
+
 Shale chooses between three exit codes, and no others:
 
 - **0** — shale did what was asked.
@@ -166,6 +179,12 @@ $ shale which .zshrc
 winner    work   /home/you/.dotfiles/work/base/.zshrc
 shadowed  base   /home/you/.dotfiles/personal/base/.zshrc
 ```
+
+Spell the path however you have it to hand: `.zshrc`, `./.zshrc`, `~/.zshrc`, an absolute path and a
+trailing slash all name the same thing, as do the copies of it in the built tree and inside a layer
+when those are spelled from `~` or absolutely — `~/.dotfiles/current/.zshrc` answers for `.zshrc`,
+while `.dotfiles/current/.zshrc` is just a path no layer provides. A path outside `$HOME`, a path
+containing `..`, and `$HOME` or the built tree itself are refused with a diagnosis and exit 1.
 
 Directories merge rather than shadow, and the report says so instead of naming a winner:
 
@@ -251,17 +270,34 @@ into authoring a layer.
 
 ## Uninstalling
 
+Removing the links leaves `$HOME` with no dotfiles at all, which is what you want between an apply
+you regret and the next one:
+
 ```sh
 stow -D -d ~/.dotfiles -t ~ current
 ```
 
-This is also the escape hatch if an apply goes wrong. It removes the links into `current` and leaves
-your layers, your config and the built tree alone; `shale apply` puts them back.
+It leaves your layers, your config and the built tree alone; `shale apply` puts the links back. To
+leave shale altogether and keep your dotfiles as ordinary files, copy the built tree back over them
+first:
+
+```sh
+stow -D -d ~/.dotfiles -t ~ current    # every link into current/ goes
+cp -RL ~/.dotfiles/current/. ~/        # the built tree lands as real files
+rm ~/.stow-local-ignore                # the one file in that tree that is shale's own
+rm -rf ~/.dotfiles                     # layers, config and built tree, once the repos are pushed
+```
+
+What the copy deposits is exactly what `ls -a ~/.dotfiles/current` lists. The order matters, and
+[docs/migrating.md](docs/migrating.md) says what `cp` here does and does not preserve.
 
 ## Known limits
 
 - Rebuilding replaces `~/.dotfiles/current` in place, so there is a brief window in which the
   symlinks in `$HOME` point at nothing. Apply relinks immediately afterwards.
+- No build is incremental: every one composes every layer from scratch, so a one-character edit
+  costs what a first build costs. Roughly two milliseconds a file — 4.1 seconds for a 2000-file
+  tree, 31 milliseconds for a seven-file one, on the container these were measured in.
 - When a whole directory leaves every layer, stow does not visit it and the links inside it are left
   dangling by an apply that still exits 0. `shale doctor` finds them and prints what to do about
   them; [docs/migrating.md](docs/migrating.md) covers the case in full.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -47,6 +47,40 @@ winner    local  /home/you/.dotfiles/local/.zshrc
 shadowed  base   /home/you/.dotfiles/personal/base/.zshrc
 ```
 
+Give it the path however you have it to hand: `.zshrc`, `./.zshrc`, `~/.zshrc`, `/home/you/.zshrc`
+and a trailing slash all name the same thing, and so do the copies of it in the built tree and in a
+layer — `~/.dotfiles/current/.zshrc` and `~/.dotfiles/personal/base/.zshrc` both answer for `.zshrc`,
+spelled from `~` or absolutely. It refuses, with a diagnosis and exit 1, a path outside `$HOME`, a
+path containing `..`, and `$HOME` or the built tree itself rather than something in it.
+
+Whole file is worth taking literally, because the loss is silent. A four-line `.gitconfig` in `local`
+displaces every line of the one below it, and the apply that installs it says nothing, since nothing
+is wrong:
+
+```
+$ shale which .gitconfig
+winner    local  /home/you/.dotfiles/local/.gitconfig
+shadowed  base   /home/you/.dotfiles/personal/base/.gitconfig
+
+$ diff -u /home/you/.dotfiles/personal/base/.gitconfig /home/you/.dotfiles/local/.gitconfig
+--- /home/you/.dotfiles/personal/base/.gitconfig
++++ /home/you/.dotfiles/local/.gitconfig
+@@ -1,7 +1,2 @@
+-[include]
+-	path = ~/.config/git/conf.d/50-work.conf
+-[alias]
+-	st = status
+-	lg = log --oneline
+-[core]
+-	excludesfile = ~/.gitignore
++[user]
++	email = me@example.com
+```
+
+The include, both aliases and the excludesfile are gone, and only that diff says so. Run it between
+the two paths `which` printed before adding a small override, not after. Where you wanted the four
+lines *as well*, use the tool's own include mechanism below rather than a second copy of the file.
+
 A layer cannot replace a directory with a file, or a file with a directory. `build` calls that a
 conflict, names both layers and the two paths, and rebuilds nothing; `which` reports the same pair
 as a note. Rename one of them.
@@ -251,7 +285,39 @@ shale:   what was in /home/you/.dotfiles/current before this build is kept at /h
 Shale cannot tell that from a built tree its layers have moved past, and does not guess. Look in
 `current.old` if you were not expecting it.
 
-## Updating layers after the first run
+## The everyday loop: build, and when to apply
+
+Edit a file a layer already has, and `shale build` is the whole loop. `~/.zshrc` is a link into
+`current/`, so rebuilding the tree it points at makes the edit live at that instant — there is
+nothing for stow to do, because the link is already right.
+
+That build also reports the file you just edited as one the built tree held an older copy of, and
+says `stow --adopt` in the same breath. It is not accusing you of anything: the built copy carries
+the layer's timestamp from the build before, your edit made the layer's copy newer, and shale cannot
+tell that apart from a file something moved into the tree. Expect it after every edit, and read it
+as *the built tree was out of date*, which it was.
+
+`shale apply` is what you need when a **path** appears or disappears, since making and unmaking links
+is stow's job and nothing else does it:
+
+- **A new file in a layer.** After a build it is in `current/` and no link in `$HOME` points at it.
+  The apply creates one.
+- **A new directory.** The same, and the apply creates the directory in `$HOME` as well.
+- **A file deleted from every layer.** The build takes it out of `current/` and leaves the link in
+  `$HOME` pointing at nothing. The apply prunes it.
+- **A file that changes hands between layers.** No apply. The path is unchanged, so the link is
+  unchanged, and the build alone changes what it resolves to — which is also how a `local` override
+  takes effect the moment you build it.
+
+Apply when you are unsure: it builds first, so it is never less than a build, and the cost is one
+stow run. The one case it does not cover is a whole directory leaving every layer, whose links stow
+never visits — `shale doctor` finds those, and `docs/migrating.md` says what to do about them.
+
+Nothing about a build is incremental. Every one of them composes every layer from scratch, so a
+one-character edit costs what a first build costs: on this machine 4.1 seconds for a 2000-file tree,
+against 31 milliseconds for a seven-file one, and the edited build was 4.08 seconds — roughly two
+milliseconds a file, on whatever your disk does. There is nothing to tune and no cache to warm; keep
+the trees the size the dotfiles actually are.
 
 Shale clones a layer root that is missing and never touches it again; updating a checkout is git's
 job. Pull each clone root, then apply:
@@ -262,6 +328,8 @@ git -C ~/.dotfiles/work pull
 shale apply
 ```
 
-The first build after a pull that changed anything reports the files in `current` that were older
-than their new layer copies, and keeps `current.old`. That is expected here and nothing to act on;
-the build after it is quiet again. There is no `shale sync`.
+The first build after anything changes a layer — a pull, or your own edit a moment ago — reports
+the files in `current` that were older than their new layer copies, and keeps `current.old`. It is
+expected there and nothing to act on. A build with nothing changed since the last one is the quiet
+one; in an edit loop that is not the next build, it is the one you run twice in a row. There is no
+`shale sync`.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,13 +1,16 @@
-# Migrating from a plain stow setup
+# Migrating to shale
 
-You have `~/.dotfiles/common` and `~/.dotfiles/local` as stow packages, and you stow them by hand.
-Shale composes the same trees into one package and stows that. The move is mechanical: unstow what
-is there, turn the packages into layers, list them, apply.
+There are two starting points. If your dotfiles are ordinary files sitting in `$HOME`, which is the
+commoner one, go straight to *Coming from plain files*. If you already have stow packages such as
+`~/.dotfiles/common` and stow them by hand, start at *Unstow first*: shale composes the same trees
+into one package and stows that, so the move is mechanical — unstow what is there, turn the packages
+into layers, list them, apply. Both paths meet at *What a first apply refuses, and why*, and the way
+back out is the same for both.
 
-Do it from a shell you can afford to lose. Unstowing removes `~/.zshrc`, `~/.profile` and everything
-else the package owns, and every shell opened between then and the apply falls back to the system
-defaults. Keep a second session already running, and do this over a connection you are not relying
-on the dotfiles to make.
+Do it from a shell you can afford to lose. Either path takes `~/.zshrc`, `~/.profile` and everything
+beside them out of `$HOME` for a while — unstowed, or moved aside — and every shell opened between
+then and the apply falls back to the system defaults. Keep a second session already running, and do
+this over a connection you are not relying on the dotfiles to make.
 
 One thing to know before you start, rather than after: do not use `stow --adopt`. Your first apply
 will refuse a pile of conflicts, `--adopt` is what a search turns up for clearing them, and here it
@@ -16,7 +19,139 @@ next `shale build` overwrites. That build says so and keeps the whole previous t
 so an adopted file survives one build and no more — the build after it reaps `current.old`. Copy the
 file into a layer instead. The refusals themselves are covered below, each with what to do about it.
 
+## Coming from plain files
+
+`~/.zshrc`, `~/.profile`, `~/.gitconfig` and a `~/.config/nvim/init.lua`, ordinary files that nothing
+manages. There is no package to unstow, so this section is the whole of the move.
+
+Two things to know before the first command. Shale never merges: where a layer provides a path, its
+file replaces yours whole, and nothing reads what is inside either copy. And shale will not overwrite
+your file in order to do it — stow refuses at any path holding a real file, which is the wall further
+down. Every line of reconciliation between your version and a layer's is yours to do by hand.
+
+If **your own files are to be the layer** — you are starting shale from your dotfiles rather than
+adopting anyone else's — the move is a `mv` and an apply, and there is nothing to reconcile:
+
+```
+$ mkdir -p ~/.dotfiles/local/.config
+$ printf "local  local\n" > ~/.dotfiles/shale.conf
+$ mv ~/.zshrc ~/.profile ~/.gitconfig ~/.dotfiles/local/
+$ mv ~/.config/nvim ~/.dotfiles/local/.config/
+$ shale apply
+shale: composed layer 'local' from /home/you/.dotfiles/local
+```
+
+`mv` rather than `cp`: each file has to be gone from `$HOME` before the apply, or it collides with
+the link stow wants to put in its place. Make `~/.dotfiles/local` a git repository whenever you want
+one — to shale it is a directory either way.
+
+If **a layer already provides those paths**, from a repository you are adopting, then your file and
+the layer's are two versions of one path and exactly one of them can win. Write `shale.conf` and
+create the url-less layers as the README's bootstrap has it, then apply with your files still in
+place, and stow refuses the lot. On stow 2.3.1 that means every path named twice, once for the
+unstow phase and once for the stow phase:
+
+```
+$ shale apply
+shale: composed layer 'base' from /home/you/.dotfiles/personal/base
+shale: composed layer 'local' from /home/you/.dotfiles/local
+WARNING! unstowing current would cause conflicts:
+  * existing target is neither a link nor a directory: .config/nvim/init.lua
+  * existing target is neither a link nor a directory: .gitconfig
+  * existing target is neither a link nor a directory: .profile
+  * existing target is neither a link nor a directory: .zshrc
+WARNING! stowing current would cause conflicts:
+  * existing target is neither a link nor a directory: .config/nvim/init.lua
+  * existing target is neither a link nor a directory: .gitconfig
+  * existing target is neither a link nor a directory: .profile
+  * existing target is neither a link nor a directory: .zshrc
+All operations aborted.
+shale: stow failed; nothing in /home/you was relinked
+shale:   stow plans the whole operation and abandons all of it rather than half-applying one
+shale:   /home/you/.dotfiles/current is built and correct: fix what stow reported above, in /home/you or in a layer, then apply again
+```
+
+Stow 2.4.1 refuses exactly the same set in half the lines: one `stowing current would cause
+conflicts` block rather than two, each path named once, and each line ending `since neither a link
+nor a directory and --adopt not specified`. Read the intent rather than the shape, because the shape
+is what moved between the versions — and read that last clause as a suggestion from a program that
+knows nothing about shale. `--adopt` moves your file into `~/.dotfiles/current`, which the next build
+overwrites, for the reason at the top of this page. The five steps below are the version of that
+suggestion which keeps your file.
+
+Nothing in `$HOME` changed either way, and no file of yours was read or altered. The list is your
+work queue. Take it in this order.
+
+1. **Build, which touches nothing in `$HOME`.** `shale build` writes only `~/.dotfiles/current`, so
+   it is safe to run with your files where they are, and it gives you the layers' version of each
+   path to compare against.
+
+2. **Compare, path by path.** `shale which` names the layer a version came from, and `diff` says what
+   adopting it would cost you:
+
+   ```
+   $ shale which .zshrc
+   winner    base   /home/you/.dotfiles/personal/base/.zshrc
+
+   $ diff -u ~/.zshrc ~/.dotfiles/current/.zshrc
+   --- /home/you/.zshrc
+   +++ /home/you/.dotfiles/current/.zshrc
+   @@ -1,2 +1 @@
+   -export EDITOR=vim
+   -alias gs="git status"
+   +export EDITOR=nvim
+   ```
+
+   A path whose diff is empty needs nothing — `~/.config/nvim/init.lua` here — and goes straight in
+   the pile at step 4. Everywhere else the diff is the reconciliation, and it is manual: five years
+   of accumulated aliases do not come across on their own, and nothing but that diff will tell you
+   they went.
+
+3. **Move what you are keeping into a layer, and build again.** Your line goes in the layer that
+   should own it — usually `local`, above the repository you are adopting — and the diff is how you
+   know when you are finished:
+
+   ```
+   $ diff -u ~/.zshrc ~/.dotfiles/current/.zshrc
+   --- /home/you/.zshrc
+   +++ /home/you/.dotfiles/current/.zshrc
+   @@ -1,2 +1,2 @@
+   -export EDITOR=vim
+   +export EDITOR=nvim
+    alias gs="git status"
+   ```
+
+   The alias survived because it was copied into `~/.dotfiles/local/.zshrc` by hand; `EDITOR` differs
+   because that difference was the point of adopting the layer.
+
+   The build you run here reports one file in `current` older than the layer copy that replaced it,
+   and its first clause names `--adopt` again. It is describing the file you just wrote, which is
+   newer than the built tree it is about to replace, and it says so of every layer edit — see *The
+   everyday loop* in [layers.md](layers.md). Nothing has adopted anything.
+
+4. **Move the originals out of `$HOME`.** They are what stow named, and they only have to stop being
+   files at those paths. Keep them until you have lived with the result for a week:
+
+   ```
+   $ mkdir -p ~/pre-shale/.config/nvim
+   $ mv ~/.zshrc ~/.profile ~/.gitconfig ~/pre-shale/
+   $ mv ~/.config/nvim/init.lua ~/pre-shale/.config/nvim/
+   ```
+
+5. **Apply.**
+
+   ```
+   $ shale apply
+   shale: composed layer 'base' from /home/you/.dotfiles/personal/base
+   shale: composed layer 'local' from /home/you/.dotfiles/local
+   ```
+
+   Nothing more is printed and nothing more is needed: `~/.zshrc` is now a link into the built tree.
+   `~/pre-shale` stays an ordinary directory that shale neither reads nor reports.
+
 ## Unstow first
+
+Only where the old setup is stow packages; from plain files there is nothing to unstow.
 
 ```sh
 stow -D -d ~/.dotfiles -t ~ common
@@ -103,7 +238,10 @@ inside the built tree, where the next build would discard them.
 Stow plans the whole operation and abandons all of it if any part conflicts, so a failed apply
 changes nothing in `$HOME`. The built tree is fine; clear what stow named and apply again. Apply
 restows, so stow runs an unstow phase and then a stow phase, and a collision both phases see is
-named once for each.
+named once for each. Every transcript below is stow 2.3.1's. Match the intent rather than the shape,
+because the shape is what moves between stow versions: on 2.4.1 two of these three arrive as one
+block rather than two, one of them loses the `=> package/path` half of the line, and the third is
+reworded into advice to use `--adopt` — see *Coming from plain files*.
 
 An old package still stowed over a path the built tree also provides:
 
@@ -130,18 +268,10 @@ All operations aborted.
 Stow can split a folded directory apart when the link points inside the stow directory it was given,
 and it cannot when the link points anywhere else. Unstow the old package and the fold goes with it.
 
-An ordinary file, not a link, already sitting at the path:
-
-```
-WARNING! unstowing current would cause conflicts:
-  * existing target is neither a link nor a directory: .profile
-WARNING! stowing current would cause conflicts:
-  * existing target is neither a link nor a directory: .profile
-All operations aborted.
-```
-
-That file is not in any layer and shale will not overwrite it. Move it aside, or copy its contents
-into the layer that should own it and then delete it.
+An ordinary file, not a link, already sitting at the path — `existing target is neither a link nor a
+directory`, quoted in full under *Coming from plain files*. That file is not in any layer and shale
+will not overwrite it. Move it aside, or copy what you want from it into the layer that should own it
+and then move it aside anyway.
 
 Do not reach for `stow --adopt` to clear any of these, for the reason given at the top. It moves the
 file from `$HOME` into the package — which here means into `~/.dotfiles/current`, generated output —
@@ -204,13 +334,73 @@ longer holds. It also says when `chkstow` could not walk all of `$HOME` — a `.
 marker makes it skip a directory — because a walk that stopped early has nothing to say about what it
 did not reach. Either way the walk is not quick.
 
-## Uninstalling
+## Backing out one apply
 
 ```sh
 stow -D -d ~/.dotfiles -t ~ current
 ```
 
-This is also the escape hatch when an apply leaves `$HOME` in a state you would rather back out of.
-It removes only the links into `current`; your layers, your config and the built tree are untouched,
-and `shale apply` puts everything back. Directories stow created on the way in are left behind
-empty.
+The escape hatch when an apply leaves `$HOME` in a state you would rather back out of. It removes
+only the links into `current`; your layers, your config and the built tree are untouched, and
+`shale apply` puts everything back. Directories stow created on the way in are left behind empty.
+
+On its own it leaves you with no dotfiles at all, which is the right state only if you are about to
+apply again.
+
+## Leaving shale, with your dotfiles
+
+Four commands, in this order. The first two are the whole of it; the last two are cleanup you can put
+off:
+
+```sh
+stow -D -d ~/.dotfiles -t ~ current    # every link into current/ goes; $HOME keeps the directories
+cp -RL ~/.dotfiles/current/. ~/        # the built tree lands as ordinary files, filling them again
+rm ~/.stow-local-ignore                # shale's own file, copied back with everything else
+rm -rf ~/.dotfiles                     # layers, config and built tree, once the repos are pushed
+```
+
+`.` in `~/.dotfiles/current/.` is what makes the copy the *contents* of the tree rather than a
+`~/current` directory, and it takes the dotfiles with it. `-L` reads through a symlink a layer ships
+and writes a real file, so nothing you keep points into a tree you are about to delete. The price of
+`-L` is that a layer symlink pointing at nothing has nothing to read: `cp` copies everything else,
+reports that one and exits 1 —
+
+```
+cp: cannot stat '/home/you/.dotfiles/current/./.danglink': No such file or directory
+```
+
+— and the fourth command would then delete the only copy of it. Deal with the named entry before you
+delete anything.
+
+What lands is exactly what the built tree holds, and shale generates one file of its own in there:
+`~/.stow-local-ignore`, the third command. Run `ls -a ~/.dotfiles/current` before the copy and that
+listing is what you are about to get — worth doing, because this copy pays no attention to
+`.stow-local-ignore` and so brings out whatever it was suppressing. Give a layer a subdirectory of
+its repository, as `docs/layers.md` says to, and that is nothing at all. Name a repository root as a
+layer instead and its `README.md` and `LICENSE` have been in the built tree all along, kept out of
+`$HOME` only by that ignore file; the copy puts them in `$HOME` beside your dotfiles.
+
+Modes come across for the bit that matters: an executable stays executable, and a `~/.netrc` at 600
+arrives at 600. Two smaller things `cp` does here without `-p`, which are why `-p` is deliberately
+absent: a new file is created subject to your `umask`, so a 666 file in the tree arrives 644 under
+the usual 022 — and a directory that already exists in `$HOME`, such as a `~/.ssh` you keep at 700,
+keeps its own mode rather than being widened to the tree's. Add `-p` only if you want the tree's
+modes and timestamps exactly, and know that it will chmod those existing directories.
+
+Order matters. Copy before the unstow and every destination is still a link back into the source, so
+GNU coreutils 9.4 refuses each of those and exits 1:
+
+```
+cp: '/home/you/.dotfiles/current/./.zshrc' and '/home/you/./.zshrc' are the same file
+```
+
+Nothing of yours is overwritten, but the run is not a no-op: `.stow-local-ignore` is the one entry in
+the built tree stow never linked, so it has no link to collide with and it lands in `$HOME` anyway —
+the file the third command exists to delete. That refusal is `cp`'s doing rather than stow's or
+shale's, so treat it as a mess to avoid and not as a guard. Unstow first. Delete `~/.dotfiles` before
+the copy and there is nothing left to copy from; take that last line seriously, because
+`~/.dotfiles/local` is the layer that was never anywhere else.
+
+That is the whole of shale's footprint: it writes nothing outside `~/.dotfiles`, and the script is
+the copy you made yourself, at `~/.local/bin/shale` or wherever you put it. Delete that too and
+shale is gone.


### PR DESCRIPTION
Closes #67.

Both gates ran every documented command and transcript. The conflict wall diffs byte for byte against real stow 2.3.1 output, all six build-versus-apply boundaries were confirmed, and the stow 2.3.1-versus-2.4.1 difference in the refusal transcripts was measured against a 2.4.1 built from source rather than inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)