### PR TITLE
Move the older-than report from build to doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ above. The four commands in it are the whole surface: there are no others, and n
 |---|---|
 | `shale build` | Clones any missing clone root that has a url, then composes the layers into `~/.dotfiles/current` |
 | `shale apply` | Builds, then stows `current` over `$HOME`, replacing the last apply's links |
-| `shale doctor` | Checks the prerequisites, the config, the layers and `$HOME`, and reports what it finds |
+| `shale doctor` | Checks the prerequisites, the config, the layers, the built tree and `$HOME`, and reports what it finds |
 | `shale which PATH` | Names every layer providing `PATH`, winner first, and when `build` would refuse the set |
 
 After editing a file a layer already has, `build` is the whole loop: `~/.zshrc` is a link into
@@ -121,9 +121,11 @@ pointing at it until stow makes the link, and one deleted from every layer leave
 until stow prunes it. Apply when unsure: it builds first, so it is never less than a build.
 [docs/layers.md](docs/layers.md) has the boundary case by case.
 
-Every build after an edit also reports the file as one the built tree held an older copy of, and
-names `stow --adopt` while doing so; that is the built tree having been out of date, not an
-accusation, and [docs/layers.md](docs/layers.md) says why shale cannot tell the two apart.
+Builds are quiet. A build that finds `current` holding a copy older than the layer file replacing it
+keeps the previous tree at `~/.dotfiles/current.old` and says nothing, because an edited layer leaves
+exactly that state and a message there would be a message on every edit. `shale doctor` is what
+reports it, as a note rather than a problem, and only before the build that overwrites it — see
+[docs/layers.md](docs/layers.md).
 
 Shale chooses between three exit codes, and no others:
 
@@ -153,12 +155,14 @@ shale:   if no other shale is running, this lock is stale: remove it with: rmdir
 
 `~/.dotfiles/current` is generated output. It is disposable — a bad build is fixed by fixing a layer
 and building again — and it should never be edited or versioned. Edit the layer, not the result. A
-build that finds a regular file in `current` differing in age from the layer's copy says so and keeps
-the tree it replaced at `~/.dotfiles/current.old`, so what was there is recoverable until the next
-build, which removes it. Newer means something edited the built tree; older means either that
-something moved a file into it, which is what `stow --adopt` does, or that a layer has moved on and
-this is the first build since. A symlink is never itself compared: a build copies the link rather
-than what it points at, so an age comparison there would be about a file the build never touches. A
+build that finds a regular file in `current` differing in age from the layer's copy keeps the tree it
+replaced at `~/.dotfiles/current.old`, so what was there is recoverable until the next build, which
+removes it. Newer means something edited the built tree, and the build says so per file. Older means
+either that something moved a file into it, which is what `stow --adopt` does, or that a layer has
+moved on and there has been no build since; the build is silent on that direction, and `shale doctor`
+names the files instead, up to ten of them with a count above that. A symlink is never itself
+compared: a build copies the link rather than what it points at, so an age comparison there would be
+about a file the build never touches. A
 build composes into `~/.dotfiles/current.new` and renames that into place, so a `current.new` left
 lying about is a run that died mid-build and is safe to delete.
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -280,16 +280,29 @@ goes unreported.
 
 A file that arrives in the built tree from somewhere else keeps its own timestamp rather than
 gaining a new one, so it can be *older* than the layer copy that replaces it — which is what
-`stow --adopt` does, and it is the shape a lost file usually has. A build reports those together:
+`stow --adopt` does, and it is the shape a lost file usually has. A build says nothing about that
+direction, because an edited layer leaves every path it provides in exactly the same state and the
+message would be on the loop you run all day. What the build does is keep `current.old`, and
+`shale doctor` is where the files are named:
 
 ```
-shale: 2 files in /home/you/.dotfiles/current were older than the layer copies that replaced them
-shale:   either something moved them into the built tree, which is what stow --adopt does, or a layer changed and this is the first build since
-shale:   what was in /home/you/.dotfiles/current before this build is kept at /home/you/.dotfiles/current.old
+shale: 2 files in /home/you/.dotfiles/current do not match the layer copies that provide them
+shale:   either something moved them into the built tree, which is what stow --adopt does, or a layer changed and there has been no build since
+shale:   the next build replaces them with the layer copies, keeping what is there now at /home/you/.dotfiles/current.old
+shale:   the build after that removes /home/you/.dotfiles/current.old, so a file moved into the built tree is recoverable for one build and no longer
+shale:   /home/you/.dotfiles/current/.zshrc
+shale:   /home/you/.dotfiles/current/.vimrc
 ```
 
-Shale cannot tell that from a built tree its layers have moved past, and does not guess. Look in
-`current.old` if you were not expecting it.
+Shale cannot tell an adopted file from a built tree its layers have moved past, and does not guess:
+the note states both readings and it is a note, not a problem — `doctor` still exits 0 on it. Above
+ten files it leads with the count and the directory they are under and names ten of them, so a
+`git pull` that changed two hundred is a dozen lines rather than two hundred.
+
+`doctor` sees this only in the window between the file arriving and the next build. Afterwards the
+built copy is the layer's again and there is nothing left to notice, so recovery is `current.old`
+and one build deep. If you use `stow --adopt` against `current/`, run `shale doctor` before you
+build.
 
 ## The everyday loop: build, and when to apply
 
@@ -297,11 +310,11 @@ Edit a file a layer already has, and `shale build` is the whole loop. `~/.zshrc`
 `current/`, so rebuilding the tree it points at makes the edit live at that instant — there is
 nothing for stow to do, because the link is already right.
 
-That build also reports the file you just edited as one the built tree held an older copy of, and
-says `stow --adopt` in the same breath. It is not accusing you of anything: the built copy carries
-the layer's timestamp from the build before, your edit made the layer's copy newer, and shale cannot
-tell that apart from a file something moved into the tree. Expect it after every edit, and read it
-as *the built tree was out of date*, which it was.
+That build says nothing. It keeps `current.old` — the built copy your edit replaced was older than
+the layer copy, which is the state a file moved into the tree also leaves, and shale keeps the
+previous tree either way — but it prints no message about it, because a message there is a message
+on every edit. `shale doctor` is where a built tree its layers have moved past is reported, and
+after a build there is nothing left for it to report.
 
 `shale apply` is what you need when a **path** appears or disappears, since making and unmaking links
 is stow's job and nothing else does it:
@@ -334,8 +347,7 @@ git -C ~/.dotfiles/work pull
 shale apply
 ```
 
-The first build after anything changes a layer — a pull, or your own edit a moment ago — reports
-the files in `current` that were older than their new layer copies, and keeps `current.old`. It is
-expected there and nothing to act on. A build with nothing changed since the last one is the quiet
-one; in an edit loop that is not the next build, it is the one you run twice in a row. There is no
-`shale sync`.
+The first build after anything changes a layer — a pull, or your own edit a moment ago — keeps
+`current.old` without saying so, and the build after it removes it. Every build is quiet; what a
+`shale doctor` in between the pull and the build reports is the built tree not yet matching the
+layers, which is what that pull just did. There is no `shale sync`.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -15,9 +15,11 @@ this over a connection you are not relying on the dotfiles to make.
 One thing to know before you start, rather than after: do not use `stow --adopt`. Your first apply
 will refuse a pile of conflicts, `--adopt` is what a search turns up for clearing them, and here it
 moves your file out of `$HOME` and into `~/.dotfiles/current`, which is generated output that the
-next `shale build` overwrites. That build says so and keeps the whole previous tree at `current.old`,
-so an adopted file survives one build and no more — the build after it reaps `current.old`. Copy the
-file into a layer instead. The refusals themselves are covered below, each with what to do about it.
+next `shale build` overwrites. That build says nothing about it — it keeps the whole previous tree
+at `current.old`, so an adopted file survives one build and no more, and the build after that
+removes `current.old`. The command that tells you is `shale doctor`, and only while the file is
+still there: run it before you build, or copy the file into a layer instead and there is nothing to
+recover. The refusals themselves are covered below, each with what to do about it.
 
 ## Coming from plain files
 
@@ -124,10 +126,10 @@ work queue. Take it in this order.
    The alias survived because it was copied into `~/.dotfiles/local/.zshrc` by hand; `EDITOR` differs
    because that difference was the point of adopting the layer.
 
-   The build you run here reports one file in `current` older than the layer copy that replaced it,
-   and its first clause names `--adopt` again. It is describing the file you just wrote, which is
-   newer than the built tree it is about to replace, and it says so of every layer edit — see *The
-   everyday loop* in [layers.md](layers.md). Nothing has adopted anything.
+   The build you run here says nothing. A `shale doctor` between the edit and the build would have
+   named the file, because the built tree no longer matches the layer that provides it — that is
+   the state every layer edit leaves, and it clears the moment you build. See *The everyday loop* in
+   [layers.md](layers.md).
 
 4. **Move the originals out of `$HOME`.** They are what stow named, and they only have to stop being
    files at those paths. Keep them until you have lived with the result for a week:
@@ -275,19 +277,30 @@ and then move it aside anyway.
 
 Do not reach for `stow --adopt` to clear any of these, for the reason given at the top. It moves the
 file from `$HOME` into the package — which here means into `~/.dotfiles/current`, generated output —
-and the next `shale build` composes over it. That build reports it:
+and the next `shale build` composes over it, silently. `shale doctor`, run before that build, is
+what names it:
 
 ```
-shale: 1 file in /home/you/.dotfiles/current was older than the layer copy that replaced it
-shale:   either something moved it into the built tree, which is what stow --adopt does, or a layer changed and this is the first build since
-shale:   what was in /home/you/.dotfiles/current before this build is kept at /home/you/.dotfiles/current.old
+shale: 1 file in /home/you/.dotfiles/current does not match the layer copy that provides it
+shale:   either something moved it into the built tree, which is what stow --adopt does, or a layer changed and there has been no build since
+shale:   the next build replaces it with the layer copy, keeping what is there now at /home/you/.dotfiles/current.old
+shale:   the build after that removes /home/you/.dotfiles/current.old, so a file moved into the built tree is recoverable for one build and no longer
+shale:   /home/you/.dotfiles/current/.zshrc
 ```
 
 Both readings, because shale cannot tell them apart: an adopted file keeps its own timestamp, and so
-does a `current` the layers have moved past since it was built. You will see the same message the
-first time you build after pulling a layer, and it is nothing to act on there. Either way the
-previous tree is at `current.old` and your file is in it, until the next clean build reaps it. Copy
-the file into a layer instead and there is nothing to recover.
+does a `current` the layers have moved past since it was built. What shale compares is those
+timestamps and nothing else, so it is blind when the two are equal at the resolution the shell
+compares them at — whole seconds on the bash macOS ships, finer on a newer one. An adopted file
+whose timestamp matches the layer copy that closely is composed over by the next build with no note,
+and with no `current.old` kept either, because nothing looked different. It is unlikely and it is
+not detectable — one more reason to copy the file into a layer rather than adopt it. You will see the
+same note from a `doctor` run any time after pulling a layer and before building, and it is nothing
+to act on there —
+which is why it is a note and `doctor` still exits 0. Either way the previous tree is at
+`current.old` and your file is in it, until the next clean build removes it. After that build
+`doctor` cannot see it any more, because the built copy matches the layer again. Copy the file into
+a layer instead and there is nothing to recover.
 
 ## Links left behind after layers change
 

--- a/shale
+++ b/shale
@@ -724,9 +724,13 @@ diverged() {
 # The other half of that data-loss path, and the half no timestamp can name: a
 # file moved into the built tree keeps its own mtime, so one older than the layer
 # copy about to overwrite it is either an adopted file or a copy the layers have
-# moved past.  Counted rather than listed, because a pull that changed fifty
-# files must not print a hundred and fifty lines about it, and counted only for
-# the layer that wins the path, so the count is a count of files.
+# moved past.  Counted and never reported here: an edited layer leaves every path
+# it provides in exactly this state, so build - the everyday loop - would say it
+# on every edit.  doctor's audit_built_tree is where that is reported, and the
+# count is only what makes this build keep current.old, so the file an adopt
+# moved in is still recoverable for the one build after it.
+#
+# Counted only for the layer that wins the path, so it is a count of files.
 older_than_layer() {
   local srel=$1
   wins_this_path "$srel" || return 0
@@ -1042,6 +1046,264 @@ EOF
     done
   done <"$file"
   [ "${#STOWRC_OPTIONS[@]}" -gt 0 ]
+}
+
+# Records the directory $1 that this check could not enter, once each and up to
+# $2 of them, setting UNREACHABLE_MORE when it stops keeping them.  Either half
+# of the comparison can be behind one, and either way the walk has seen less than
+# it appears to, so both go in one list.
+#
+# Deduplicated against the list, which is the whole of it: one unsearchable layer
+# directory is met once per directory of the built tree below it, and a list of
+# the same path fifty times is not a report.  Above the cap the dedup stops
+# working, which is why the line that replaces the names says only 'and more'.
+unreachable() {
+  local dir=$1 cap=$2 i
+  i=0
+  while [ "$i" -lt "${#UNREACHABLE_PATHS[@]}" ]; do
+    [ "${UNREACHABLE_PATHS[$i]}" != "$dir" ] || return 0
+    i=$((i + 1))
+  done
+  if [ "${#UNREACHABLE_PATHS[@]}" -ge "$cap" ]; then
+    UNREACHABLE_MORE=1
+    return 0
+  fi
+  UNREACHABLE_PATHS+=("$dir")
+}
+
+# The highest-precedence layer whose copy of anything in the built-tree directory
+# $1 is behind a directory that cannot be searched, in BLOCKED_LAYER as an index
+# into LAYER_PATHS, or -1 when every layer can be reached.  $3 is the answer for
+# the directory holding $1, which this one is never lower than: an unsearchable
+# directory stays unsearchable for everything below it.  Records each such
+# directory, up to $2 of them.
+#
+# Once per directory rather than once per file: one unsearchable directory
+# obscures every path below it equally, and asking per file would put a walk of
+# the layer path into the inner loop of the whole tree.
+#
+# Once per *directory* is not enough on its own, either.  Walking from $DOTFILES
+# at every one of them re-tests the ancestors the parent already tested, which is
+# quadratic in depth - a shape #64 exists because of - so only the deepest
+# directory is tested here and the rest is inherited.  That is the same answer:
+# where the parent chain was clear the directory itself is all that was left
+# untested, and where it was not, this layer is blocked already and the directory
+# naming it is in the list.  The top of the walk has no parent to inherit from,
+# and is the one call that tests $DOTFILES and the layer path above it; the
+# trailing '/' is there because obscured_ancestor never tests the last component,
+# and the layer root itself has to be one of the tested ones.
+blocked_layers() {
+  local rel=$1 cap=$2 inherited=$3 i dir
+  BLOCKED_LAYER=$inherited
+  i=0
+  while [ "$i" -lt "${#LAYER_PATHS[@]}" ]; do
+    if [ -z "$rel" ]; then
+      dir=
+      ! obscured_ancestor "$DOTFILES" "${LAYER_PATHS[$i]}/" || dir=$OBSCURED
+    else
+      dir=$DOTFILES/${LAYER_PATHS[$i]}/$rel
+      # -d is false for a directory below one that cannot be searched, which is
+      # the case this arm need say nothing about: that ancestor blocked this
+      # layer when it was met, and is already in the list.
+      { [ -d "$dir" ] && [ ! -x "$dir" ]; } || dir=
+    fi
+    if [ -n "$dir" ]; then
+      [ "$i" -le "$BLOCKED_LAYER" ] || BLOCKED_LAYER=$i
+      unreachable "$dir" "$cap"
+    fi
+    i=$((i + 1))
+  done
+}
+
+# The copy of the path $1 - relative to the built tree - that a build would
+# compose last, in WINNER; non-zero when no configured layer provides it or when
+# no answer can be trusted.  Highest precedence first, which is the reverse of
+# the config order and the same rule cmd_which answers with.
+#
+# $2 is blocked_layers' index for the directory holding $1.  A layer at or below
+# it cannot be told from a layer that simply has not got this path, and it may be
+# the one that wins, so the search stops there rather than naming a lower layer
+# as the winner - the same refusal cmd_which makes, for the same reason.  Layers
+# above it are unaffected: one that provides the path wins whatever is below.
+winning_layer() {
+  local rel=$1 blocked=$2 i path
+  WINNER=
+  i=${#LAYER_PATHS[@]}
+  while [ "$i" -gt 0 ]; do
+    i=$((i - 1))
+    [ "$i" -gt "$blocked" ] || return 1
+    path=$DOTFILES/${LAYER_PATHS[$i]}/$rel
+    if [ -e "$path" ] || [ -L "$path" ]; then
+      WINNER=$path
+      return 0
+    fi
+  done
+  return 1
+}
+
+# The built tree under $1, relative to $CUR and '' for the whole of it, walked
+# for files older than the layer copy that provides them.  Counts them into
+# MISMATCH_COUNT, keeps the first $2 in MISMATCH_PATHS and folds each into
+# ANCESTOR.  $3 is blocked_layers' answer for the directory holding $1, and -1
+# at the top of the walk.
+#
+# The comparison is build's, so that what doctor reports is what the next build
+# will act on: mtime rather than content, because content cannot separate the two
+# readings either - a built copy holding the previous layer content matches no
+# layer now, exactly as an adopted file does not.  Neither side is compared when
+# that side is a symlink, for the reason at compose_dir: a build copies the link
+# rather than what it points at, so an age comparison there is about two files
+# nothing touches.  A directory in a layer at a path the built tree holds a file
+# at is a conflict, which build reports and this must not read a timestamp from.
+#
+# One direction only.  A built copy *newer* than its layer is build's to report,
+# per file and with a remedy, and it never went silent; saying it here as well
+# would duplicate an accurate message in words that are wrong for it, this note
+# stating two readings neither of which is 'you edited the built tree'.
+scan_built_tree() {
+  local rel=$1 cap=$2 inherited=$3 here e base srel winner blocked
+  here=$CUR${rel:+/$rel}
+  # A directory that cannot be listed answers every glob with nothing, exactly as
+  # an empty one does, so without this the subtree drops out of the check and the
+  # report reads as a complete answer.
+  if [ ! -r "$here" ] || [ ! -x "$here" ]; then
+    unreachable "$here" "$cap"
+    return 0
+  fi
+  blocked_layers "$rel" "$cap" "$inherited"
+  blocked=$BLOCKED_LAYER
+  # Neither dotglob nor nullglob is set in doctor, so both patterns are spelled
+  # out and an unmatched one arrives as itself.  '.' and '..' are dropped by
+  # name, whatever the glob options say about them.
+  for e in "$here"/* "$here"/.*; do
+    base=${e##*/}
+    case "$base" in
+      . | ..) continue ;;
+      '*' | '.*')
+        { [ -e "$e" ] || [ -L "$e" ]; } || continue
+        ;;
+    esac
+    # At every depth, as in the composer: a build never copies a .git, so a note
+    # promising that the next build will replace this one would be false, and so
+    # would the current.old it promises with it.
+    [ "$base" = .git ] && continue
+    srel=${rel:+$rel/}$base
+    # A symlink to a directory is a leaf here as it is in the composer, and
+    # descending one would walk out of the built tree.
+    if [ -d "$e" ] && [ ! -L "$e" ]; then
+      scan_built_tree "$srel" "$cap" "$blocked"
+      continue
+    fi
+    { [ -f "$e" ] && [ ! -L "$e" ]; } || continue
+    # A path no layer provides at all is a different thing entirely - a built
+    # tree holding a file every layer dropped - and nothing here reports it.
+    winning_layer "$srel" "$blocked" || continue
+    winner=$WINNER
+    { [ ! -L "$winner" ] && [ ! -d "$winner" ]; } || continue
+    if [ "$winner" -nt "$e" ]; then
+      MISMATCH_COUNT=$((MISMATCH_COUNT + 1))
+      # Only the first $cap are kept: growing an array to one entry per file a
+      # pull touched is the way to make this walk quadratic.
+      [ "$MISMATCH_COUNT" -gt "$cap" ] || MISMATCH_PATHS+=("$e")
+      common_ancestor "$e"
+    fi
+  done
+}
+
+# The report #66 put in build, moved here because build is the loop a user runs
+# all day and doctor is not: an edited layer leaves every path it provides older
+# than its layer copy, which is the same condition an adopted file leaves, so in
+# build the message that exists to save a five-year-old .zshrc fired whenever
+# nothing was wrong.
+#
+# A note and never a finding.  A built tree the layers have moved past is the
+# ordinary state between editing a layer and rebuilding, and making that exit 1
+# would move the fatigue rather than remove it.
+#
+# It states both readings and picks neither, because nothing shale can read
+# separates them without remembering what the last build wrote.  Both are
+# readings of one direction: build reports the other one itself.
+audit_built_tree() {
+  local cap n i rest lines files matches moved replaces where directories
+  [ -d "$CUR" ] || return 0
+  # Every line below says what the next build will do with what it found, and
+  # against a symlink here no build does anything: it refuses the tree outright.
+  # That this walk would follow the link is the smaller half; promising an
+  # outcome for a build that will not run is the half that would be false.
+  [ ! -L "$CUR" ] || return 0
+  [ "${#LAYER_PATHS[@]}" -gt 0 ] || return 0
+
+  MISMATCH_COUNT=0
+  MISMATCH_PATHS=()
+  UNREACHABLE_PATHS=()
+  UNREACHABLE_MORE=0
+  ANCESTOR=
+  # audit_broken_links' cap, for its reasons: enough of them to act on, few
+  # enough to stay inside a short terminal.
+  cap=10
+  scan_built_tree '' "$cap" -1
+
+  # Ahead of the note below, which it qualifies, and printed whether or not there
+  # is one: silence from a walk that did not reach everything reads as a complete
+  # answer, which is the failure this exists to stop.
+  if [ "${#UNREACHABLE_PATHS[@]}" -gt 0 ]; then
+    lines=("shale could not read everything this check compares, so what it says about the built tree at $CUR is not the whole answer:")
+    i=0
+    while [ "$i" -lt "${#UNREACHABLE_PATHS[@]}" ]; do
+      denied_verb "${UNREACHABLE_PATHS[$i]}"
+      lines[${#lines[@]}]="$DENIED_VERB ${UNREACHABLE_PATHS[$i]}"
+      i=$((i + 1))
+    done
+    directories='those directories'
+    [ "${#UNREACHABLE_PATHS[@]}" -gt 1 ] || directories='that directory'
+    [ "$UNREACHABLE_MORE" -eq 0 ] ||
+      lines[${#lines[@]}]='and more, not named here'
+    lines[${#lines[@]}]="check the permissions on $directories"
+    note ${lines[@]+"${lines[@]}"}
+  fi
+
+  n=$MISMATCH_COUNT
+  [ "$n" -gt 0 ] || return 0
+
+  files='files'
+  matches='do not match the layer copies that provide them'
+  moved='moved them into'
+  replaces='replaces them with the layer copies'
+  if [ "$n" -eq 1 ]; then
+    files='file'
+    matches='does not match the layer copy that provides it'
+    moved='moved it into'
+    replaces='replaces it with the layer copy'
+  fi
+
+  # Named only above the cap, and only when it says something the count line has
+  # not: below it every path is printed anyway.  The trailing slash on both sides
+  # so that the two spellings compare rather than the strings as they arrived.
+  where=()
+  if [ "$n" -gt "$cap" ]; then
+    rest=$ANCESTOR
+    case "$rest" in
+      */) ;;
+      *) rest=$rest/ ;;
+    esac
+    [ "$rest" = "$CUR/" ] || where=("all of them are under $ANCESTOR")
+  fi
+
+  lines=("$n $files in $CUR $matches"
+    "either something $moved the built tree, which is what stow --adopt does, or a layer changed and there has been no build since"
+    ${where[@]+"${where[@]}"}
+    "the next build $replaces, keeping what is there now at $OLD"
+    "the build after that removes $OLD, so a file moved into the built tree is recoverable for one build and no longer")
+  i=0
+  while [ "$i" -lt "${#MISMATCH_PATHS[@]}" ]; do
+    lines[${#lines[@]}]=${MISMATCH_PATHS[$i]}
+    i=$((i + 1))
+  done
+  if [ "$n" -gt "$cap" ]; then
+    rest=$((n - cap))
+    lines[${#lines[@]}]="and $rest more, not named here"
+  fi
+  note ${lines[@]+"${lines[@]}"}
 }
 
 # Every link under $HOME that points into the built tree at a path the built
@@ -1473,7 +1735,7 @@ check_layers() {
 }
 
 cmd_build() {
-  local i dir n had_current qcur qold files was them copies
+  local i dir n had_current qcur qold
 
   parse_config || exit 1
 
@@ -1639,6 +1901,8 @@ cmd_build() {
   if [ "$n" -eq 0 ] && [ "$OLDER_COUNT" -eq 0 ]; then
     rm -rf "$OLD" || warn "could not remove $OLD"
   else
+    # The older direction keeps current.old and says nothing; only this one is
+    # reported here.  See older_than_layer.
     i=0
     while [ "$i" -lt "$n" ]; do
       warn "$CUR/${DIVERGED_PATHS[$i]} was newer than ${DIVERGED_LAYERS[$i]}" \
@@ -1646,24 +1910,6 @@ cmd_build() {
         "your version is kept at $OLD/${DIVERGED_PATHS[$i]}"
       i=$((i + 1))
     done
-    if [ "$OLDER_COUNT" -gt 0 ]; then
-      files='files'
-      was='were'
-      them='them'
-      copies='the layer copies that replaced them'
-      if [ "$OLDER_COUNT" -eq 1 ]; then
-        files='file'
-        was='was'
-        them='it'
-        copies='the layer copy that replaced it'
-      fi
-      # One group however many files, and it states both readings rather than
-      # naming one: nothing shale can read tells a file moved into the built
-      # tree from a built tree the layers have moved past.
-      warn "$OLDER_COUNT $files in $CUR $was older than $copies" \
-        "either something moved $them into the built tree, which is what stow --adopt does, or a layer changed and this is the first build since" \
-        "what was in $CUR before this build is kept at $OLD"
-    fi
   fi
 
   if [ -n "$DEFERRED" ]; then
@@ -1941,6 +2187,9 @@ cmd_doctor() {
       note ${lines[@]+"${lines[@]}"}
     fi
   done
+
+  # The two walks, in size order: the built tree, then the whole of $HOME.
+  audit_built_tree
 
   # Last, because it is the only check that walks the whole of $HOME and the only
   # one that means anything only once everything above it is sound.

--- a/tests/run
+++ b/tests/run
@@ -2161,9 +2161,14 @@ test_build_warns_when_the_built_tree_was_edited() {
 # The half of that path an mtime comparison cannot name.  stow --adopt moves the
 # user's own file into the built tree keeping its mtime, so a five-year-old
 # .zshrc lands there *older* than the layer copy about to overwrite it and the
-# newer-direction check above never fires.  The message may not say the tree was
-# edited: an older copy is equally a build the layers have moved past.
-test_build_warns_when_the_built_tree_is_older_than_its_layer() {
+# newer-direction check above never fires.
+#
+# The build says nothing about it, and must not: an edited layer leaves every
+# path it provides in this same state, so a build that reported it reported the
+# everyday loop.  What the build still does is keep current.old, which is the
+# whole of the recovery, and doctor is where the file is named - so the silence
+# here is only as good as the two assertions that follow it.
+test_build_keeps_an_older_built_copy_silently_and_doctor_names_it() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
   run_shale build
@@ -2176,51 +2181,62 @@ test_build_warns_when_the_built_tree_is_older_than_its_layer() {
   # Dated into the past because that is what an adopted file arrives with.
   printf 'FIVE YEARS OF ZSH\n' >|"$sandbox_path" || fail 'could not adopt into the built tree'
   touch -t 200001010000 "$sandbox_path" || fail 'could not date the adopted file'
+  # Before the build, which is the only window in which anything can be done
+  # about it cheaply, and the reason the report went here rather than nowhere.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'doctor stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.dotfiles/current/.zshrc" 'doctor stdout'
   run_shale build
   assert_status 0 "$shale_status"
-  assert_contains "$shale_err" \
-    "shale: 1 file in $HOME/.dotfiles/current was older than the layer copy that replaced it" \
-    'stderr'
-  assert_contains "$shale_err" 'which is what stow --adopt does' 'stderr'
-  assert_contains "$shale_err" \
-    "shale:   what was in $HOME/.dotfiles/current before this build is kept at $HOME/.dotfiles/current.old" \
-    'stderr'
-  assert_not_contains "$shale_err" 'you edited' 'stderr'
+  assert_empty "$shale_err" 'the build stderr'
   assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
   assert_eq 'FIVE YEARS OF ZSH' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
+  # The honest limit of the split: after the build the built copy is the layer's
+  # again, so doctor can no longer see it and current.old is the only copy left.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the build'
+  # Both spellings of the count line, here and at every other assertion that the
+  # note is absent: the singular and the plural share no whole phrase, so a check
+  # written for one lets the other past - which is not hypothetical, a mutation
+  # of blocked_layers produced the plural and went unnoticed by the singular.
+  assert_not_contains "$shale_out" 'does not match the layer copy' \
+    'doctor stdout after the build'
+  assert_not_contains "$shale_out" 'do not match the layer copies' \
+    'doctor stdout after the build'
 }
 
-# One group however many files: a pull that changed fifty of them must not print
-# a hundred and fifty lines.  The count is a count of files, so .zshrc coming
-# from two layers still counts once, and the two untouched files count not at
-# all.  Retention is one build deep - the rebuild leaves every copy the age of
-# the layer file it came from, so the next build has nothing left to re-detect.
-test_build_summarises_older_files_in_one_group_and_forgets_them_next_build() {
-  local name groups
+# Retention covers every older file, not the first of them, and it is one build
+# deep: the rebuild leaves every copy the age of the layer file it came from, so
+# the next build has nothing left to re-detect and reaps current.old.
+test_build_keeps_every_older_file_and_forgets_them_next_build() {
+  local name
   conf 'base personal/base' 'local local'
   mklayer personal/base .zshrc
   mklayer local .zshrc
   mklayer personal/base .vimrc
   mklayer personal/base .inputrc
-  mklayer personal/base .netrc
-  mklayer personal/base .gitconfig
   run_shale build
   assert_status 0 "$shale_status"
   assert_empty "$shale_err" 'the first build stderr'
   for name in .zshrc .vimrc .inputrc; do
     sandbox_mkdir "$HOME/.dotfiles/current"
     sandbox_leaf "$sandbox_dir" "$name"
+    # '>|': the build above put these here.  Content as well as a date, so what
+    # current.old holds says which copy was kept rather than only that one was.
+    printf 'MOVED IN %s\n' "$name" >|"$sandbox_path" || fail "could not replace $name"
     touch -t 200001010000 "$sandbox_path" || fail "could not date $name"
   done
   run_shale build
   assert_status 0 "$shale_status"
-  groups=$(printf '%s\n' "$shale_err" | grep -c 'were older than')
-  assert_eq 1 "$groups" 'summary lines'
-  assert_contains "$shale_err" \
-    "shale: 3 files in $HOME/.dotfiles/current were older than the layer copies that replaced them" \
-    'stderr'
-  assert_not_contains "$shale_err" 'you edited' 'stderr'
-  assert_exists "$HOME/.dotfiles/current.old/.zshrc" 'the previous tree'
+  assert_empty "$shale_err" 'the build stderr'
+  for name in .zshrc .vimrc .inputrc; do
+    assert_eq "MOVED IN $name" "$(cat "$HOME/.dotfiles/current.old/$name")" \
+      "the kept copy of $name"
+  done
+  assert_eq 'local/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
   run_shale build
   assert_status 0 "$shale_status"
   assert_empty "$shale_err" 'the next build stderr'
@@ -4276,16 +4292,13 @@ test_apply_a_content_change_is_seen_through_the_existing_link() {
   mklayer personal/base .zshrc 'second'
   run_shale apply
   assert_status 0 "$shale_status"
-  # The price of the adopted-file guard, paid here: an edited layer leaves the
-  # tree it replaces older than itself, which is indistinguishable from a file
-  # moved into that tree, so the first build after an edit says so.  It is a
-  # line on stderr and a retained current.old, not a failure.
-  assert_contains "$shale_err" \
-    "shale: 1 file in $HOME/.dotfiles/current was older than the layer copy that replaced it" \
-    'the second apply stderr'
-  # Nothing else on stderr: the tree was not edited, and a diverged record
-  # firing alongside the summary would otherwise pass unnoticed here.
-  assert_not_contains "$shale_err" 'you edited' 'the second apply stderr'
+  # The everyday loop, and it says nothing at all: an edited layer leaves the
+  # tree it replaces older than itself, which is the same state a file moved
+  # into that tree leaves, and reporting it here would report every edit.
+  assert_empty "$shale_err" 'the second apply stderr'
+  # The retention is not silent as well as the message: an adopted file at this
+  # path would still be in current.old, which is what the silence costs nothing.
+  assert_eq 'first' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
   assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
   assert_eq 'second' "$(cat "$HOME/.zshrc")" 'the linked file'
 }
@@ -6318,6 +6331,567 @@ test_doctor_says_when_the_built_tree_is_not_a_directory() {
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
 }
 
+# The report #66 put in build, moved here.  This is the shape it exists for: a
+# five-year-old .zshrc moved into the built tree keeps its own mtime, so it lands
+# there older than the layer copy that will replace it, and the next build
+# overwrites it - with current.old the only copy left afterwards.  Doctor is
+# ahead of that build, which is the window in which anything can be done.
+#
+# The whole wording, once, so the two readings and the recovery are pinned
+# somewhere; the cases below assert the parts they are about.
+test_doctor_notes_a_file_moved_into_the_built_tree() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  # '>|': the build above put this file here.  Dated into the past because that
+  # is what a file stow --adopt moved out of $HOME arrives with.
+  printf 'FIVE YEARS OF ZSH\n' >|"$sandbox_path" || fail 'could not adopt into the built tree'
+  touch -t 200001010000 "$sandbox_path" || fail 'could not date the adopted file'
+  run_shale doctor
+  # A note, not a finding: a built tree the layers have moved past is the
+  # ordinary state between an edit and a rebuild, and exiting 1 on it would move
+  # the alarm fatigue rather than remove it.
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'stdout'
+  assert_contains "$shale_out" \
+    'shale:   either something moved it into the built tree, which is what stow --adopt does, or a layer changed and there has been no build since' \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   the next build replaces it with the layer copy, keeping what is there now at $HOME/.dotfiles/current.old" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   the build after that removes $HOME/.dotfiles/current.old, so a file moved into the built tree is recoverable for one build and no longer" \
+    'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.dotfiles/current/.zshrc" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# The other reading of the same line, and the commoner one by far: edit a layer
+# file and the built copy is older than it until the next build.  Nothing shale
+# can read separates this from the case above, which is why one note states both
+# and why it is here rather than in the build a user runs all day.
+test_doctor_notes_a_built_tree_its_layers_have_moved_past() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc 'first'
+  # Both dates are set rather than left to the clock: bash 3.2's -nt compares
+  # whole seconds, and the built copy carries whatever mtime the layer file had
+  # when the build copied it, so the edit has to be strictly newer than this.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  mklayer personal/base .zshrc 'second'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch -t 202601010000 "$sandbox_path" || fail 'could not date the layer file'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'stdout'
+  assert_contains "$shale_out" 'which is what stow --adopt does' 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.dotfiles/current/.zshrc" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  # The build that follows is the everyday loop and says nothing, and the note
+  # goes with the rebuild rather than repeating for ever.
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the build stderr'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the build'
+  assert_not_contains "$shale_out" 'does not match the layer copy' 'stdout after the build'
+  assert_not_contains "$shale_out" 'do not match the layer copies' 'stdout after the build'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout after the build'
+}
+
+# The other direction, which is not this note's.  A built copy newer than its
+# layer is something build reports itself, per file, with wording that names what
+# happened and a remedy - so saying it here as well would be an accurate message
+# duplicated in words that are wrong for it, this note offering two readings of
+# which neither is 'you edited the built tree'.  The silence is only worth
+# asserting next to the message that does cover it, which is why build runs here.
+test_doctor_says_nothing_about_a_built_tree_build_reports_as_edited() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  # '>|': the build above put this file here, and editing it is the point.
+  printf 'HAND EDITED\n' >|"$sandbox_path" || fail 'could not edit the built tree'
+  touch -t 202601010000 "$sandbox_path" || fail 'could not date the edited file'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/current/.zshrc was newer than $HOME/.dotfiles/personal/base/.zshrc" \
+    'the build stderr'
+  assert_contains "$shale_err" 'shale:   you edited the built tree; the layer wins' \
+    'the build stderr'
+  assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
+}
+
+# A tree that matches its layers is the state every build leaves, cp -RPp having
+# carried each layer file's mtime across, so the note must be absent from the
+# clean report rather than merely short.
+test_doctor_says_nothing_about_a_built_tree_that_matches_its_layers() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# Only the layer that would win the path is compared, because that is the copy
+# the next build lands: a shadowed layer whose file is newer is not something a
+# build will do anything about, and reporting it would fire for ever.  The dates
+# are what make the first half say that - base is newer than the built copy, so
+# comparing against base rather than against the winner does fire.
+test_doctor_compares_the_built_tree_against_the_winning_layer() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 202606010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  touch -t 202601010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_eq 'local/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built file'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  # And the winner moving ahead of the built copy is what does fire.
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch -t 202603010000 "$sandbox_path" || fail 'could not date the layer file'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'stdout'
+}
+
+# A path the built tree holds and no layer provides is a different thing - a tree
+# the layers dropped a file from - and there is no copy to compare it against.
+# current/.stow-local-ignore is the permanent case: shale writes it itself, so
+# every doctor run would name it if the note were not scoped to what a layer
+# provides.  Both are here whatever their timestamps, which is what this pins:
+# the comparison alone is not what keeps them out, since a '-nt' whose *left*
+# operand is not there is false anyway - and the left operand is the layer copy.
+# The other way round is true rather than false, which is what made this guard
+# load-bearing while the newer direction was still reported.  What is being held
+# is that the scope stays deliberate rather than becoming an accident of which
+# side of the comparison the missing path happens to be on.
+test_doctor_says_nothing_about_a_built_tree_path_no_layer_provides() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .vimrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_exists "$HOME/.dotfiles/current/.stow-local-ignore" 'the ignore list'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .vimrc
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .vimrc
+  touch -t 200001010000 "$sandbox_path" || fail 'could not date the built copy'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# The rule #73 set for build's own comparison, and the same reasoning: a build
+# copies a link rather than what it points at, so an age comparison on one is
+# about two files nothing touches - and for a link whose target a higher layer
+# shadows, the two sides resolve to different files and would differ for ever.
+# All three shapes, because the skip has to be on the entry and not on the path.
+test_doctor_compares_no_symlink_in_the_built_tree() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer personal/base kindchange
+  mklayer local .zshrc
+  mklayer local layerlink
+  sandbox_write "$HOME/outside" thing 'OUTSIDE'
+  sandbox_mkdir "$HOME/outside"
+  touch -t 202601010000 "$sandbox_dir/thing" || fail 'could not date the outside file'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 202601010000 "$sandbox_dir/.zshrc" "$sandbox_dir/kindchange" ||
+    fail 'could not date the layer files'
+  # A link whose target the layer above shadows: current/zlink resolves through
+  # current/.zshrc to local's copy and base/zlink to base's own.
+  sandbox_leaf "$sandbox_dir" zlink new
+  ln -s .zshrc "$sandbox_path" || fail 'could not create the layer link'
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  touch -t 202001010000 "$sandbox_dir/.zshrc" "$sandbox_dir/layerlink" ||
+    fail 'could not date the layer files'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the build stderr'
+  # Every date is set so that each of the three shapes would fire if its side
+  # were compared: base/zlink resolves to 2026 against a built link resolving to
+  # 2020, local/layerlink to 2026 against a built copy of 2020, and base's plain
+  # kindchange is 2026 against a built link resolving to 2020.
+  #
+  # The layer entry is a link and the built copy a plain file.  It points out of
+  # the tree so that replacing it moves nothing else: a target inside a layer
+  # would be a path of its own for this walk to compare.
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  sandbox_leaf "$sandbox_dir" layerlink
+  rm -f "$sandbox_path" || fail 'could not clear the layer file'
+  ln -s "$HOME/outside/thing" "$sandbox_path" ||
+    fail 'could not replace the layer file with a link'
+  # And the built copy is a link where the layer entry is a plain file.
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" kindchange
+  rm -f "$sandbox_path" || fail 'could not clear the built copy'
+  ln -s .zshrc "$sandbox_path" || fail 'could not replace the built copy with a link'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# The volume the bound is for: a git pull that changed a couple of hundred files
+# leaves every one of them in this state, and a line each is a report nobody
+# reads.  Twelve in two sibling directories, which is the smallest tree that
+# crosses the cap of ten and has an ancestor that is neither directory.
+test_doctor_bounds_the_built_tree_note_at_ten_paths() {
+  local named i line
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  i=0
+  while [ "$i" -lt 6 ]; do
+    mklayer personal/base ".config/nvim/pack/start/f$i"
+    mklayer personal/base ".config/nvim/pack/opt/f$i"
+    i=$((i + 1))
+  done
+  # Both sides are dated, before the build and after it: the built copy carries
+  # whatever the layer file had when it was copied, and only a layer file that is
+  # strictly newer than that in whole seconds - all bash 3.2's -nt compares - is
+  # the direction this note is about.
+  i=0
+  while [ "$i" -lt 6 ]; do
+    sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim/pack/start"
+    sandbox_leaf "$sandbox_dir" "f$i"
+    touch -t 200001010000 "$sandbox_path" || fail "could not date start/f$i"
+    sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim/pack/opt"
+    sandbox_leaf "$sandbox_dir" "f$i"
+    touch -t 200001010000 "$sandbox_path" || fail "could not date opt/f$i"
+    i=$((i + 1))
+  done
+  run_shale build
+  assert_status 0 "$shale_status"
+  i=0
+  while [ "$i" -lt 6 ]; do
+    sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim/pack/start"
+    sandbox_leaf "$sandbox_dir" "f$i"
+    touch -t 202601010000 "$sandbox_path" || fail "could not date start/f$i"
+    sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim/pack/opt"
+    sandbox_leaf "$sandbox_dir" "f$i"
+    touch -t 202601010000 "$sandbox_path" || fail "could not date opt/f$i"
+    i=$((i + 1))
+  done
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 12 files in $HOME/.dotfiles/current do not match the layer copies that provide them" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   all of them are under $HOME/.dotfiles/current/.config/nvim/pack" 'stdout'
+  assert_contains "$shale_out" 'shale:   and 2 more, not named here' 'stdout'
+  # Ten named, whichever ten they are.  A case pattern rather than grep: the
+  # sandbox path is a literal here and a regular expression to grep.
+  named=0
+  while IFS= read -r line; do
+    case "$line" in
+      "shale:   $HOME/.dotfiles/current/.config/nvim/pack/"*) named=$((named + 1)) ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq 10 "$named" 'the number of paths named'
+  # The bound changes what is printed and never the exit status, which this note
+  # does not touch at any count.
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The common ancestor is worth a line only when it says something the count line
+# has not: below the cap every path is printed anyway, and the built tree itself
+# is the directory that line already names.
+test_doctor_the_built_tree_note_names_no_ancestor_below_the_cap() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim"
+  touch -t 200001010000 "$sandbox_dir/init.lua" "$sandbox_dir/spell.add" ||
+    fail 'could not date the layer files'
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim"
+  touch -t 202601010000 "$sandbox_dir/init.lua" "$sandbox_dir/spell.add" ||
+    fail 'could not date the layer files'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 2 files in $HOME/.dotfiles/current do not match the layer copies that provide them" \
+    'stdout'
+  assert_not_contains "$shale_out" 'all of them are under' 'stdout'
+  assert_not_contains "$shale_out" 'not named here' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.dotfiles/current/.config/nvim/init.lua" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.dotfiles/current/.config/nvim/spell.add" 'stdout'
+}
+
+# The one ancestor above the cap that is not worth a line, because the line above
+# it has already named the built tree.  Eleven dotfiles at the top of it, which
+# is also the shape that says the walk sees them at all: '*' matches none of them
+# on either bash, and current/.stow-local-ignore sits among them unreported.
+test_doctor_many_built_tree_paths_at_the_top_do_not_name_it_twice() {
+  local i
+  conf 'base personal/base'
+  i=0
+  while [ "$i" -lt 11 ]; do
+    mklayer personal/base ".f$i"
+    i=$((i + 1))
+  done
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  i=0
+  while [ "$i" -lt 11 ]; do
+    sandbox_leaf "$sandbox_dir" ".f$i"
+    touch -t 200001010000 "$sandbox_path" || fail "could not date .f$i"
+    i=$((i + 1))
+  done
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  i=0
+  while [ "$i" -lt 11 ]; do
+    sandbox_leaf "$sandbox_dir" ".f$i"
+    touch -t 202601010000 "$sandbox_path" || fail "could not date .f$i"
+    i=$((i + 1))
+  done
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 11 files in $HOME/.dotfiles/current do not match the layer copies that provide them" \
+    'stdout'
+  assert_not_contains "$shale_out" 'all of them are under' 'stdout'
+  assert_contains "$shale_out" 'shale:   and 1 more, not named here' 'stdout'
+  # shale writes this one itself, so no layer provides it and it is not among the
+  # eleven however its timestamp falls.
+  assert_not_contains "$shale_out" '.stow-local-ignore' 'stdout'
+}
+
+# A build skips a .git at every depth, so nothing under one is ever composed and
+# no build will replace it or keep it in current.old.  Naming it would be a note
+# whose every line is false, and the last of them - a current.old the next build
+# would create - is false in the direction that loses a file.
+test_doctor_says_nothing_about_a_git_directory_in_the_built_tree() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  run_shale build
+  assert_status 0 "$shale_status"
+  # In the layer as well as the built tree: the layer copy is what a comparison
+  # would find, and it has to be there for the case to be about the skip.
+  mklayer personal/base .git/config 'GIT'
+  mklayer personal/base .config/nvim/.git/config 'NESTED GIT'
+  sandbox_mkdir "$HOME/.dotfiles/current/.git"
+  sandbox_write "$HOME/.dotfiles/current/.git" config 'STALE GIT'
+  touch -t 200001010000 "$sandbox_path" || fail 'could not date the built copy'
+  sandbox_mkdir "$HOME/.dotfiles/current/.config/nvim/.git"
+  sandbox_write "$HOME/.dotfiles/current/.config/nvim/.git" config 'STALE NESTED GIT'
+  touch -t 200001010000 "$sandbox_path" || fail 'could not date the built copy'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  # And the build the note would have promised: it composes neither, so the
+  # promise would have been false in both halves.
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the build stderr'
+  assert_missing "$HOME/.dotfiles/current/.git" 'the built tree'
+  assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
+}
+
+# Every line of the note says what the next build will do with what was found,
+# and against a symlink at current no build does anything: it refuses the tree
+# and exits 1.  That this walk would follow the link is the smaller half; the
+# promise about a build that will not run is the half that would be false.
+test_doctor_says_nothing_about_a_built_tree_reached_through_a_symlink() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  mv "$sandbox_dir/current" "$sandbox_dir/elsewhere" ||
+    fail 'could not move the built tree aside'
+  sandbox_leaf "$sandbox_dir" current new
+  ln -s elsewhere "$sandbox_path" || fail 'could not link the built tree'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch -t 202601010000 "$sandbox_path" || fail 'could not date the layer file'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'does not match the layer copy' 'stdout'
+  assert_not_contains "$shale_out" 'do not match the layer copies' 'stdout'
+  assert_not_contains "$shale_out" 'the next build' 'stdout'
+  # The build that note would have described, and what it actually does.
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" "shale: $HOME/.dotfiles/current is a symlink" 'the build stderr'
+}
+
+# A directory this walk cannot enter drops out of it exactly as an empty one
+# does, so without a word about it the report reads as a complete answer when it
+# is not - the same claim audit_broken_links makes when chkstow's walk was short.
+# Both bits, because the verb is the mode's: 0300 lists nothing and 0600 stats
+# nothing below it.
+test_doctor_says_when_it_could_not_read_all_of_the_built_tree() {
+  local doctor_out doctor_status
+  skip_if_root
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base noread/a
+  mklayer personal/base nosearch/b
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch -t 202601010000 "$sandbox_path" || fail 'could not date the layer file'
+  chmod 0300 "$HOME/.dotfiles/current/noread" || fail 'could not set mode 0300'
+  chmod 0600 "$HOME/.dotfiles/current/nosearch" || fail 'could not set mode 0600'
+  run_shale doctor
+  doctor_out=$shale_out
+  doctor_status=$shale_status
+  chmod 0755 "$HOME/.dotfiles/current/noread" || fail 'could not restore the mode'
+  chmod 0755 "$HOME/.dotfiles/current/nosearch" || fail 'could not restore the mode'
+  assert_status 0 "$doctor_status"
+  assert_contains "$doctor_out" \
+    "shale: shale could not read everything this check compares, so what it says about the built tree at $HOME/.dotfiles/current is not the whole answer:" \
+    'stdout'
+  assert_contains "$doctor_out" \
+    "shale:   cannot read $HOME/.dotfiles/current/noread" 'stdout'
+  assert_contains "$doctor_out" \
+    "shale:   cannot search $HOME/.dotfiles/current/nosearch" 'stdout'
+  assert_contains "$doctor_out" \
+    'shale:   check the permissions on those directories' 'stdout'
+  # Uncounted, like every other note here: an unreadable directory is not a
+  # finding, it is a limit on what this one can say.
+  assert_contains "$doctor_out" 'shale: no problems found' 'stdout'
+  # And it qualifies the note under it rather than replacing it: the file it
+  # could reach is still named.
+  assert_contains "$doctor_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'stdout'
+  assert_contains "$doctor_out" "shale:   $HOME/.dotfiles/current/.zshrc" 'stdout'
+}
+
+# The other side of the comparison, and the one that gets a wrong answer rather
+# than a short one: a layer directory that cannot be searched makes every test
+# for a file inside it answer 'no', which is what a layer that has not got the
+# path answers.  Taking that at face value would name a lower layer as the winner
+# and report the built tree against the wrong copy, so the path is not compared
+# at all - the refusal cmd_which makes on the same tree - and the directory is
+# named once however many files are under it.
+test_doctor_does_not_blame_a_lower_layer_for_one_it_cannot_search() {
+  local doctor_out doctor_status
+  skip_if_root
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  mklayer local .config/nvim/init.lua
+  mklayer local .config/nvim/spell.add
+  # base's copies are newer than local's, so a walk that fell back to base would
+  # report both files rather than saying it could not tell.
+  sandbox_mkdir "$HOME/.dotfiles/local/.config/nvim"
+  touch -t 202001010000 "$sandbox_dir/init.lua" "$sandbox_dir/spell.add" ||
+    fail 'could not date the layer files'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim"
+  touch -t 202601010000 "$sandbox_dir/init.lua" "$sandbox_dir/spell.add" ||
+    fail 'could not date the layer files'
+  run_shale build
+  assert_status 0 "$shale_status"
+  chmod 0600 "$HOME/.dotfiles/local/.config" || fail 'could not set mode 0600'
+  run_shale doctor
+  doctor_out=$shale_out
+  doctor_status=$shale_status
+  chmod 0755 "$HOME/.dotfiles/local/.config" || fail 'could not restore the mode'
+  assert_status 0 "$doctor_status"
+  assert_not_contains "$doctor_out" 'does not match the layer copy' 'stdout'
+  assert_not_contains "$doctor_out" 'do not match the layer copies' 'stdout'
+  assert_contains "$doctor_out" \
+    "shale: shale could not read everything this check compares, so what it says about the built tree at $HOME/.dotfiles/current is not the whole answer:" \
+    'stdout'
+  # Once, not once per file under it, and singular because it is one directory.
+  assert_contains "$doctor_out" \
+    "shale:   cannot search $HOME/.dotfiles/local/.config" 'stdout'
+  assert_contains "$doctor_out" \
+    'shale:   check the permissions on that directory' 'stdout'
+  assert_contains "$doctor_out" 'shale: no problems found' 'stdout'
+}
+
+# Alongside something that is a finding, which is the only way to see that this
+# note added nothing to the count.  It is also where the note sits in the report:
+# above the link audit, which is the walk of the whole of $HOME and stays last.
+test_doctor_the_built_tree_note_is_not_counted_as_a_problem() {
+  local line seen
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch -t 202601010000 "$sandbox_path" || fail 'could not date the layer file'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'stdout'
+  # One, not two: the orphaned link is the problem and the note is not one.
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  seen=
+  while IFS= read -r line; do
+    case "$line" in
+      'shale: 1 file in '*' does not match the layer copy that provides it')
+        seen="$seen mismatch"
+        ;;
+      *'which the built tree no longer provides') seen="$seen orphan" ;;
+      'shale: 1 problem found') seen="$seen summary" ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq ' mismatch orphan summary' "$seen" 'the order of the report'
+}
+
 # The remedy doctor leads with, carried out exactly as written, on the stow this
 # suite is running against: the paths are the ones doctor printed and the delete
 # is the whole of it.  It leads because it works on every version, which the
@@ -7434,6 +8008,8 @@ test_meta_noclobber_overrides_are_allow_listed() {
     'HAND EDITED'
     # The same, for the file an adopt would have put there in its place.
     'FIVE YEARS OF ZSH'
+    # And for the several of them one build has to keep at once.
+    'MOVED IN '
   )
   found=0
   report=()


### PR DESCRIPTION
Closes #75.

The everyday edit-then-build loop is silent again; doctor reports a built tree its layers have moved past, as a note rather than a problem, bounded at ten paths. build still retains current.old silently, so an adopted file stays recoverable for one build.

Three review rounds. The gates caught the note firing in the newer direction with two readings that were both false there, a quadratic introduced by the per-directory layer check, and a test assertion that matched only the singular wording so a two-file failure passed unseen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)