### PR TITLE
State both readings of a built copy newer than its layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ shale:   if no other shale is running, this lock is stale: remove it with: rmdir
 and building again — and it should never be edited or versioned. Edit the layer, not the result. A
 build that finds a regular file in `current` differing in age from the layer's copy keeps the tree it
 replaced at `~/.dotfiles/current.old`, so what was there is recoverable until the next build, which
-removes it. Newer means something edited the built tree, and the build says so per file. Older means
+removes it. Newer means either that something wrote or moved a file into the built tree — which is
+what `stow --adopt` does with a file newer than the layer's copy — or that a different layer now
+provides the path with an older copy; the build says so per file, stating both. Older means
 either that something moved a file into it, which is what `stow --adopt` does, or that a layer has
 moved on and there has been no build since; the build is silent on that direction, and `shale doctor`
 names the files instead, up to ten of them with a count above that. A symlink is never itself

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -265,12 +265,20 @@ layer it came from warns and keeps the tree it displaced:
 
 ```
 shale: /home/you/.dotfiles/current/.zshrc was newer than /home/you/.dotfiles/personal/base/.zshrc
-shale:   you edited the built tree; the layer wins
-shale:   your version is kept at /home/you/.dotfiles/current.old/.zshrc
+shale:   either something wrote or moved a file into the built tree, or a different layer now provides this path and its copy is older
+shale:   the layer copy wins; what was there is kept at /home/you/.dotfiles/current.old/.zshrc until the next build, to copy into a layer if it was your edit
 ```
 
-Copy your version back into the layer from `current.old`. The next build reaps `current.old`, so do
-it before then. Never version `current/`, and never point a layer symlink into it.
+Read the kept copy before you act on it, because the message covers two things and shale cannot tell
+them apart. If it is your own file — an edit through the `~/.zshrc` link, or something `stow --adopt`
+moved in — copy it into a layer, and do it before the next build, which reaps `current.old`. If it is
+the copy the layer that used to win this path was providing, there is nothing to do: remove an
+override, drop a layer from `shale.conf`, or reorder precedence, and the copy that wins the path in
+its place is often the older file, which is the same comparison with nobody having touched
+`current/`. Two clone roots pulled minutes apart is enough for that. Copying `current.old` back into
+a layer there would put back the override you just stopped using.
+
+Never version `current/`, and never point a layer symlink into it.
 
 A symlink is never itself compared, in either direction. What a build copies for one is the link, not
 the file at the end of it, so a timestamp comparison there would be about two files the build never

--- a/shale
+++ b/shale
@@ -706,11 +706,19 @@ wins_this_path() {
   return 0
 }
 
-# Something wrote to the built tree through its $HOME symlink instead of to the
-# layer, which is this design's one silent data-loss path: ~/.zshrc is a link
-# into current/ and an editor writes straight through it.  cp -p is what keeps
-# a legitimate layer update from tripping this.  Recorded, not printed: the
-# message names current.old, which an aborted build never creates.
+# A built copy newer than the layer copy that is about to replace it, which has
+# two readings and no way to tell them apart.  One is this design's one silent
+# data-loss path: ~/.zshrc is a link into current/, so an editor writes straight
+# through it and a stow --adopt of a file newer than the layer copy moves one in
+# with its own mtime, cp -p being what keeps a legitimate layer update from
+# arriving in this state.  The other is which layer wins the path having changed
+# - drop an override, drop a layer, reorder shale.conf - after which the copy
+# that lands can simply be the older file, with nothing having been edited or
+# moved anywhere.  So the message states both and picks neither, as doctor's
+# note does for the other direction.
+#
+# Recorded, not printed: the message names current.old, which an aborted build
+# never creates.
 #
 # Recorded only for the layer that wins the path, which is what makes the layer
 # named in the message the one whose copy actually lands.
@@ -1157,9 +1165,9 @@ winning_layer() {
 # at is a conflict, which build reports and this must not read a timestamp from.
 #
 # One direction only.  A built copy *newer* than its layer is build's to report,
-# per file and with a remedy, and it never went silent; saying it here as well
-# would duplicate an accurate message in words that are wrong for it, this note
-# stating two readings neither of which is 'you edited the built tree'.
+# per file and naming the current.old that build keeps, and it never went
+# silent; saying it here as well would duplicate that in words that are wrong
+# for it, the two readings of this direction not being the two of that one.
 scan_built_tree() {
   local rel=$1 cap=$2 inherited=$3 here e base srel winner blocked
   here=$CUR${rel:+/$rel}
@@ -1906,8 +1914,8 @@ cmd_build() {
     i=0
     while [ "$i" -lt "$n" ]; do
       warn "$CUR/${DIVERGED_PATHS[$i]} was newer than ${DIVERGED_LAYERS[$i]}" \
-        'you edited the built tree; the layer wins' \
-        "your version is kept at $OLD/${DIVERGED_PATHS[$i]}"
+        'either something wrote or moved a file into the built tree, or a different layer now provides this path and its copy is older' \
+        "the layer copy wins; what was there is kept at $OLD/${DIVERGED_PATHS[$i]} until the next build, to copy into a layer if it was your edit"
       i=$((i + 1))
     done
   fi

--- a/tests/run
+++ b/tests/run
@@ -1832,7 +1832,7 @@ test_build_is_idempotent_and_drops_a_file_deleted_from_a_layer() {
   assert_eq "$first" "$(cd "$HOME/.dotfiles/current" && find . -print | sort)" 'the tree'
   # The -p in cp -RPp: it leaves the built copy no newer than the layer file, so
   # a rebuild that changed nothing has nothing to say.  Without it every second
-  # build accuses you of editing the tree.
+  # build reports a divergence nothing caused.
   assert_empty "$shale_err" 'the second build stderr'
   sandbox_mkdir "$HOME/.dotfiles/personal/base"
   sandbox_leaf "$sandbox_dir" .vimrc
@@ -2148,14 +2148,101 @@ test_build_warns_when_the_built_tree_was_edited() {
   assert_contains "$shale_err" \
     "shale: $HOME/.dotfiles/current/.zshrc was newer than $HOME/.dotfiles/local/.zshrc" \
     'stderr'
-  assert_contains "$shale_err" 'shale:   you edited the built tree; the layer wins' 'stderr'
   assert_contains "$shale_err" \
-    "shale:   your version is kept at $HOME/.dotfiles/current.old/.zshrc" 'stderr'
+    'shale:   either something wrote or moved a file into the built tree, or a different layer now provides this path and its copy is older' \
+    'stderr'
+  assert_contains "$shale_err" \
+    "shale:   the layer copy wins; what was there is kept at $HOME/.dotfiles/current.old/.zshrc until the next build, to copy into a layer if it was your edit" \
+    'stderr'
   # One edited file is one warning, naming the layer whose copy replaced it.
   assert_not_contains "$shale_err" "$HOME/.dotfiles/personal/base/.zshrc" 'stderr'
   assert_eq 'local/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
   assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
   assert_missing "$HOME/.dotfiles/current.old/junk"
+}
+
+# The same state, reached with nothing edited anywhere.  Removing an override is
+# an everyday act, and the copy that wins the path in its place can be older than
+# the built copy it replaces - two clone roots pulled minutes apart is enough.
+# Removing a layer from shale.conf and reordering precedence arrive at it too.
+# Shale cannot tell any of them from the case above, so what the message must not
+# do is name one of them: a remedy that says to put the kept copy back into a
+# layer, unconditionally, undoes the removal the user just made.
+#
+# Every decisive mtime is set with touch -t rather than by write order, because
+# -nt compares whole seconds on the oldest bash this has to run under.
+test_build_does_not_blame_an_edit_when_the_winning_layer_changes() {
+  local older newer message
+  message='shale:   either something wrote or moved a file into the built tree, or a different layer now provides this path and its copy is older'
+  conf 'personal personal/base' 'work work/base'
+  mklayer personal/base .zshrc
+  mklayer work/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  older=$sandbox_path
+  touch -t 200001010000 "$older" || fail 'could not date the personal layer file'
+  sandbox_mkdir "$HOME/.dotfiles/work/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  newer=$sandbox_path
+  touch -t 202601010000 "$newer" || fail 'could not date the work layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the first build stderr'
+  assert_eq 'work/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built file'
+
+  # The override is deleted, so personal provides the path again and its copy is
+  # the older of the two.
+  rm -f "$newer" || fail 'could not remove the overriding layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/current/.zshrc was newer than $HOME/.dotfiles/personal/base/.zshrc" \
+    'the stderr after the override was removed'
+  assert_contains "$shale_err" "$message" 'the stderr after the override was removed'
+  assert_not_contains "$shale_err" 'you edited the built tree' \
+    'the stderr after the override was removed'
+  # current.old holds the override, not an edit, which is why the remedy is
+  # conditional: this file is the one the user has just decided not to have.
+  assert_eq 'work/base/.zshrc' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
+  assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
+
+  # Back to the override winning, and this build is the everyday one: the layer
+  # copy is newer than the built copy, which is the direction build never speaks
+  # about.  Without it the arms below would start from the wrong built copy.
+  mklayer work/base .zshrc
+  touch -t 202601010000 "$newer" || fail 'could not date the work layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the stderr after the override came back'
+
+  # The layer is dropped from the config rather than from the disk.
+  conf 'personal personal/base'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/current/.zshrc was newer than $HOME/.dotfiles/personal/base/.zshrc" \
+    'the stderr after the layer was dropped from the config'
+  assert_contains "$shale_err" "$message" \
+    'the stderr after the layer was dropped from the config'
+  assert_not_contains "$shale_err" 'you edited the built tree' \
+    'the stderr after the layer was dropped from the config'
+
+  conf 'personal personal/base' 'work work/base'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the stderr after the layer came back'
+
+  # Neither layer changed at all: only which of them is last.
+  conf 'work work/base' 'personal personal/base'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/current/.zshrc was newer than $HOME/.dotfiles/personal/base/.zshrc" \
+    'the stderr after precedence was reordered'
+  assert_contains "$shale_err" "$message" 'the stderr after precedence was reordered'
+  assert_not_contains "$shale_err" 'you edited the built tree' \
+    'the stderr after precedence was reordered'
+  assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
 }
 
 # The half of that path an mtime comparison cannot name.  stow --adopt moves the
@@ -6411,12 +6498,12 @@ test_doctor_notes_a_built_tree_its_layers_have_moved_past() {
 }
 
 # The other direction, which is not this note's.  A built copy newer than its
-# layer is something build reports itself, per file, with wording that names what
-# happened and a remedy - so saying it here as well would be an accurate message
-# duplicated in words that are wrong for it, this note offering two readings of
-# which neither is 'you edited the built tree'.  The silence is only worth
-# asserting next to the message that does cover it, which is why build runs here.
-test_doctor_says_nothing_about_a_built_tree_build_reports_as_edited() {
+# layer is something build reports itself, per file, naming the current.old it
+# keeps - so saying it here as well would duplicate that in words that are wrong
+# for it, this note's two readings not being that direction's two.  The silence
+# is only worth asserting next to the message that does cover it, which is why
+# build runs here.
+test_doctor_says_nothing_about_a_built_tree_newer_than_its_layer() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
   sandbox_mkdir "$HOME/.dotfiles/personal/base"
@@ -6436,7 +6523,8 @@ test_doctor_says_nothing_about_a_built_tree_build_reports_as_edited() {
   assert_contains "$shale_err" \
     "shale: $HOME/.dotfiles/current/.zshrc was newer than $HOME/.dotfiles/personal/base/.zshrc" \
     'the build stderr'
-  assert_contains "$shale_err" 'shale:   you edited the built tree; the layer wins' \
+  assert_contains "$shale_err" \
+    'shale:   either something wrote or moved a file into the built tree, or a different layer now provides this path and its copy is older' \
     'the build stderr'
   assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
 }


### PR DESCRIPTION
Closes #80.

build no longer asserts the built tree was edited when the layers changed so that an older copy wins the path. Reviewed by the code gate, which confirmed the code delta is two string literals, traced all three arms of the new case, and looped it 20x under bash 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)