### PR TITLE
Make doctor refuse a setup that cannot build

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ above. The four commands in it are the whole surface: there are no others, and n
 |---|---|
 | `shale build` | Clones any missing clone root that has a url, then composes the layers into `~/.dotfiles/current` |
 | `shale apply` | Builds, then stows `current` over `$HOME`, replacing the last apply's links |
-| `shale doctor` | Checks the prerequisites, the config, the layers, the built tree and `$HOME`, and reports what it finds |
+| `shale doctor` | Checks the prerequisites, the config, the layers, the built tree and `$HOME`; it will not exit 0 on a setup `build` is certain to refuse |
 | `shale which PATH` | Names every layer providing `PATH`, winner first, and when `build` would refuse the set |
 
 After editing a file a layer already has, `build` is the whole loop: `~/.zshrc` is a link into
@@ -237,11 +237,14 @@ build.
 ## Checking the setup
 
 `shale doctor` checks that every tool shale runs is installed, that the config parses, that every
-configured layer directory is there, that the build lock is neither held nor uncreatable, that
-nothing in `~/.dotfiles` is a stray, that no layer ships shale itself, and that no link in `$HOME`
-points into the built tree at a path it no longer provides. Where a `.stowrc` exists it names the
-stow options that file sets, because several of them change an apply and three of them make it do
-nothing at all. It changes nothing itself.
+configured layer directory is there and that nothing in one is a directory it cannot search or a file
+it cannot open, that no two layers disagree about whether a path
+is a file or a directory, that no layer ships `.stow-local-ignore` — which shale writes itself — or
+shale itself, that `~/.dotfiles/current` is a directory rather than a file or a link to one, that the
+build lock is neither held nor uncreatable, that nothing in `~/.dotfiles` is a stray, and that no
+link in `$HOME` points into the built tree at a path it no longer provides. Where a `.stowrc` exists
+it names the stow options that file sets, because several of them change an apply and three of them
+make it do nothing at all. It changes nothing itself.
 
 ```
 $ shale doctor
@@ -250,7 +253,13 @@ shale: no problems found
 
 Doctor reports two kinds of line. A *problem* is a defect in the setup: it counts towards the total
 and makes doctor exit 1. Everything else is a note about something worth knowing, and neither counts
-nor changes the exit code. Below, a `vim  vim` line was added to the config for a layer that is not
+nor changes the exit code. Every state doctor can see that stops a build outright is a problem, so
+`no problems found` is a strong signal that `shale build` will run rather than a guarantee that it
+must. What it does not see: an absolute symlink in a layer, which stow refuses at apply time and the
+two stow versions disagree about — so shale asserts nothing about it, and
+[docs/layers.md](docs/layers.md) covers it — nor whether `$HOME` is writable, which fails an apply
+rather than a build, nor whether a leftover `current.old` can be removed. Below, a `vim  vim` line
+was added to the config for a layer that is not
 there, and a stray `~/.dotfiles/old-tmux` directory was created — the first is the problem, the
 second the note:
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -83,7 +83,33 @@ lines *as well*, use the tool's own include mechanism below rather than a second
 
 A layer cannot replace a directory with a file, or a file with a directory. `build` calls that a
 conflict, names both layers and the two paths, and rebuilds nothing; `which` reports the same pair
-as a note. Rename one of them.
+as a note, and `shale doctor` reports it as a problem without your having to guess which path to ask
+about. Rename one of them.
+
+```
+shale: 'build' would fail at .config/profile.d — it is a directory in layer 'base' and a file in layer 'work'
+shale:   /home/you/.dotfiles/base/.config/profile.d
+shale:   /home/you/.dotfiles/work/.config/profile.d
+shale:   a layer cannot replace a directory with a file, or a file with a directory
+shale:   remove or rename one of them
+```
+
+More than two layers can disagree at one path, and how many conflicts `build` reports then depends on
+the order rather than on the count: three layers holding directory, directory, file give it one,
+where file, directory, directory give it two. `doctor` reports the lowest of them and names the two
+layers `build` names it against — the nearest provider below, not the first one — and adds a line
+saying how many layers provide the path when it is more than two, because removing one of the pair
+it named can leave another that disagrees.
+
+## A layer restored under another user
+
+A layer cloned or restored under `sudo` keeps its owner, and `build` stops at the first directory it
+cannot search or file it cannot open — `cp` reports the path and shale reports the copy that failed.
+`shale doctor` finds these ahead of the build and names up to ten of them, counting the rest.
+
+Only a regular file matters. A build copies a symlink as a symlink and recreates a FIFO without
+opening either, so neither a link whose target you cannot read nor an unreadable FIFO stops
+anything, and `doctor` says nothing about them.
 
 ## Fragment directories
 
@@ -215,6 +241,11 @@ WARNING! stowing current would cause conflicts:
 All operations aborted.
 ```
 
+`shale doctor` does not report this one, and deliberately: the two stow versions disagree about
+which absolute links they refuse and where, so any finding shale wrote would be right on one of them
+and wrong on the other. Nothing but the apply itself can tell you, which is the reason for the rule
+rather than an exception to it.
+
 ## A layer, or a guard inside a file
 
 Both are right in different cases, and the deciding question is whether the file should exist at all
@@ -306,6 +337,12 @@ Shale cannot tell an adopted file from a built tree its layers have moved past, 
 the note states both readings and it is a note, not a problem — `doctor` still exits 0 on it. Above
 ten files it leads with the count and the directory they are under and names ten of them, so a
 `git pull` that changed two hundred is a dozen lines rather than two hundred.
+
+Where `doctor` has already found something that stops a build — a conflict, a layer it cannot read,
+a `current` that is not a directory — the two lines about the next build are replaced by
+`no build will run until the problems above are fixed, so nothing here is replaced yet`. The files
+are still named; what changes is that nothing promises you a `current.old` that a refused build
+never creates.
 
 `doctor` sees this only in the window between the file arriving and the next build. Afterwards the
 built copy is the layer's again and there is nothing left to notice, so recovery is `current.old`

--- a/shale
+++ b/shale
@@ -829,6 +829,17 @@ finding() {
   report "$@"
 }
 
+# A finding that also stops the next build outright.  Every line doctor prints
+# that offers a build, or says what the next one will do, is gated on this being
+# zero: with a conflict in the layers, 'build one with: shale build' is a remedy
+# that cannot succeed and 'the next build replaces it' is a promise nothing
+# keeps.  A finding that leaves a build able to run - an orphaned link, a layer
+# shipping the script - is an ordinary one.
+blocking_finding() {
+  BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
+  finding "$@"
+}
+
 note() {
   report "$@"
 }
@@ -1056,6 +1067,215 @@ EOF
   [ "${#STOWRC_OPTIONS[@]}" -gt 0 ]
 }
 
+# A layer path the walk below cannot read, as a finding, up to LAYER_DENIED_CAP
+# of them; above the cap they are counted and not named.  $1 is the layer name,
+# $2 the path, $3 'directory' or 'file'.
+#
+# Capped because build reports one of these and stops, where this walk goes on
+# and finds every one: a layer restored under another uid can hold forty, and
+# forty findings of three lines each is not a report.  The cap changes what is
+# printed and never what is counted, which is audit_broken_links' rule too.
+LAYER_DENIED_CAP=10
+layer_denied() {
+  local name=$1 path=$2 what=$3
+  LAYER_DENIED=$((LAYER_DENIED + 1))
+  if [ "$LAYER_DENIED" -gt "$LAYER_DENIED_CAP" ]; then
+    # Counted as a finding without being printed as one, exactly as the links
+    # above audit_broken_links' cap are.
+    FINDINGS=$((FINDINGS + 1))
+    BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
+    return 0
+  fi
+  if [ "$what" = directory ]; then
+    denied_verb "$path"
+    blocking_finding "layer '$name': $DENIED_VERB $path: permission denied" \
+      'shale composes a layer by walking it, and build stops there' \
+      'check the permissions on that directory'
+    return 0
+  fi
+  blocking_finding "layer '$name': cannot read $path: permission denied" \
+    'shale composes a layer by copying its files, and build stops there' \
+    'check the permissions on that file'
+}
+
+# Every path two layers disagree about the kind of, and every layer path this
+# walk cannot read: the states build refuses that nothing else in doctor sees.
+# The walk is build's own minus the copying - one listing per layer directory
+# and a kind test per entry - because nothing cheaper answers whether the next
+# build will refuse, and doctor promising a build that then refuses is what this
+# exists to stop.
+#
+# $1 is the path relative to the composed tree, '' for the whole of it.  $2 is
+# the indices of the layers whose subtree lands in it, in config order and
+# separated by spaces.  Carrying that list is what makes this build's answer
+# rather than a plain union of the layers: build does not descend a layer that
+# collided at a directory, so nothing under it is composed and nothing under it
+# can collide either.
+#
+# The kind that stands at a path is the first provider's, and it stays that
+# whatever a later layer holds there - build composes into the tree it has, and
+# a collision leaves that tree as it was.  Every later layer of the other kind
+# is therefore a collision, and build reports each of them; doctor reports the
+# lowest, in the same two layers build names it against, because that is the
+# pair standing between the config and a build that runs.  How many build
+# reports depends on the arrangement rather than on the number of layers
+# disagreeing: three layers holding directory, directory, file give it one, and
+# file, directory, directory give it two.
+scan_layer_trees() {
+  local rel=$1 layers=$2 i k here e base srel path alone lines
+  local kind first first_kind last other other_kind other_prev providers children
+  # One layer cannot disagree with anything, so below such a directory the whole
+  # of the comparison is skipped and the walk is only looking for a directory it
+  # cannot enter.  Worth its own arm because it is the ordinary shape: most of a
+  # layer's subtree is a directory no other layer has.
+  alone=1
+  case "$layers" in
+    *' '*) alone=0 ;;
+  esac
+  # Unquoted on purpose: $layers is this function's own list of decimal indices,
+  # and splitting it into words is what is wanted.
+  # shellcheck disable=SC2086
+  for i in $layers; do
+    here=$DOTFILES/${LAYER_PATHS[$i]}${rel:+/$rel}
+    # Neither dotglob nor nullglob is set in doctor, so an unlistable directory
+    # is told from an empty one here rather than by the glob below.  build stops
+    # at this directory, so doctor saying nothing about it is doctor reporting
+    # 'no problems found' on a tree that cannot be composed.  The wording is the
+    # layer-root arm's, which is the same fault one level up.
+    if [ ! -r "$here" ] || [ ! -x "$here" ]; then
+      layer_denied "${LAYER_NAMES[$i]}" "$here" directory
+      continue
+    fi
+    # Both patterns spelled out, and '.' and '..' dropped by name, whatever the
+    # glob options say about them.
+    for e in "$here"/* "$here"/.*; do
+      base=${e##*/}
+      case "$base" in
+        . | ..) continue ;;
+        '*' | '.*')
+          { [ -e "$e" ] || [ -L "$e" ]; } || continue
+          ;;
+      esac
+      # At every depth, as in the composer: a build composes no .git, so nothing
+      # inside one is ever a collision.
+      [ "$base" = .git ] && continue
+      srel=${rel:+$rel/}$base
+      # A symlink is a leaf whatever it points at, because the composer treats
+      # one that way: calling a link to a directory a directory here would
+      # promise a merge build refuses to perform.
+      kind='file'
+      if [ -d "$e" ] && [ ! -L "$e" ]; then
+        kind='directory'
+      fi
+      # A regular file build cannot open, which is the same provenance as the
+      # directory above - a layer restored or cloned under another uid - and the
+      # commoner half of it.  Checked for every layer's copy rather than the
+      # winner's, because build copies each in turn and stops at the first cp
+      # that fails, shadowed or not.
+      #
+      # All three tests earn their place, measured against build rather than
+      # argued: -f alone would take a mode 000 fifo, which cp -RPp recreates
+      # without reading and a build composes fine; and -f is true of a symlink
+      # to an unreadable file, which -r then calls unreadable while cp copies
+      # the link and never opens the target.  Only a regular file that is not a
+      # link stops a build.
+      if [ -f "$e" ] && [ ! -L "$e" ] && [ ! -r "$e" ]; then
+        layer_denied "${LAYER_NAMES[$i]}" "$e" file
+      fi
+      if [ "$alone" -eq 1 ]; then
+        [ "$kind" = directory ] || continue
+        scan_layer_trees "$srel" "$i"
+        continue
+      fi
+      # One pass, in config order, doing four things at once because each of
+      # them costs a stat per layer and none of them is worth a second walk of
+      # the list: it finds the layer that decides this path, it finds the first
+      # layer after that one holding the other kind, it keeps the last provider
+      # before that one, and it collects the layers whose subtree goes on down.
+      # The entry itself is never tested - this loop reached it through $i's own
+      # listing.
+      #
+      # An entry a lower layer already provided leaves the loop at that layer,
+      # so it costs the tests down to it and nothing else: it was examined in
+      # full when that layer's own listing reached it.
+      #
+      # The cost of that is the arrangement to know about.  The scan starts at
+      # the head of the list every time, so a path provided only by layers high
+      # in the config costs the distance to the lowest of them once per provider
+      # above it - Theta(paths * providers * that distance), not linear in the
+      # layer count.  Two dozen layers all providing the same paths is where it
+      # shows, which is a config nobody writes; the ordinary shapes - a path in
+      # one layer, or in a low layer and overridden - leave the loop at the
+      # first or second test.
+      first=-1
+      first_kind=
+      last=-1
+      other=-1
+      other_kind=
+      other_prev=-1
+      providers=0
+      children=
+      # shellcheck disable=SC2086
+      for k in $layers; do
+        if [ "$first" -lt 0 ]; then
+          if [ "$k" -eq "$i" ]; then
+            first=$i
+            first_kind=$kind
+            last=$i
+            providers=1
+            [ "$kind" != directory ] || children=$i
+            continue
+          fi
+          path=$DOTFILES/${LAYER_PATHS[$k]}/$srel
+          { [ -e "$path" ] || [ -L "$path" ]; } || continue
+          first=$k
+          break
+        fi
+        path=$DOTFILES/${LAYER_PATHS[$k]}/$srel
+        { [ -e "$path" ] || [ -L "$path" ]; } || continue
+        providers=$((providers + 1))
+        kind='file'
+        if [ -d "$path" ] && [ ! -L "$path" ]; then
+          kind='directory'
+        fi
+        if [ "$kind" = "$first_kind" ]; then
+          # Two directories merge, and a file over a file is the ordinary
+          # shadowing this whole tool is for.
+          [ "$kind" != directory ] || children="$children $k"
+        elif [ "$other" -lt 0 ]; then
+          other=$k
+          other_kind=$kind
+          other_prev=$last
+        fi
+        last=$k
+      done
+      [ "$first" -eq "$i" ] || continue
+      if [ "$other" -ge 0 ]; then
+        # The pair is build's pair: build collides against the *nearest*
+        # provider below, so naming the first one instead sends someone to a
+        # layer build never mentions.  Every provider between them agrees with
+        # the kind that stands, this being the first disagreement, so the kind
+        # named for it is that one.  The two closing lines are build's own, word
+        # for word: a reader who meets both reports meets one answer.
+        lines=("'build' would fail at $srel — it is a $first_kind in layer '${LAYER_NAMES[$other_prev]}' and a $other_kind in layer '${LAYER_NAMES[$other]}'"
+          "$DOTFILES/${LAYER_PATHS[$other_prev]}/$srel"
+          "$DOTFILES/${LAYER_PATHS[$other]}/$srel"
+          'a layer cannot replace a directory with a file, or a file with a directory'
+          'remove or rename one of them')
+        # Only where a third layer is in it.  With two providers, removing
+        # either one of them is the whole of the fix; with more, which one goes
+        # decides whether what is left still disagrees, and shale cannot say
+        # which without being told.
+        [ "$providers" -le 2 ] ||
+          lines[${#lines[@]}]="$providers layers provide $srel, so removing one of the two named here may leave another pair that disagrees"
+        blocking_finding ${lines[@]+"${lines[@]}"}
+      fi
+      [ "$first_kind" = directory ] || continue
+      scan_layer_trees "$srel" "$children"
+    done
+  done
+}
+
 # Records the directory $1 that this check could not enter, once each and up to
 # $2 of them, setting UNREACHABLE_MORE when it stops keeping them.  Either half
 # of the comparison can be behind one, and either way the walk has seen less than
@@ -1195,6 +1415,14 @@ scan_built_tree() {
     # promising that the next build will replace this one would be false, and so
     # would the current.old it promises with it.
     [ "$base" = .git ] && continue
+    # The same reasoning for the one file shale writes into the built tree
+    # itself, at the top of it and nowhere else: no build ever lands a layer's
+    # copy here - it refuses the whole tree while a layer provides one - so the
+    # note would promise a replacement and a current.old that never come.  A
+    # layer providing it is a finding of its own, with the remedy that works.
+    if [ -z "$rel" ] && [ "$base" = .stow-local-ignore ]; then
+      continue
+    fi
     srel=${rel:+$rel/}$base
     # A symlink to a directory is a leaf here as it is in the composer, and
     # descending one would walk out of the built tree.
@@ -1299,9 +1527,17 @@ audit_built_tree() {
 
   lines=("$n $files in $CUR $matches"
     "either something $moved the built tree, which is what stow --adopt does, or a layer changed and there has been no build since"
-    ${where[@]+"${where[@]}"}
-    "the next build $replaces, keeping what is there now at $OLD"
-    "the build after that removes $OLD, so a file moved into the built tree is recoverable for one build and no longer")
+    ${where[@]+"${where[@]}"})
+  # What the next build does with these is worth saying only where there is a
+  # next build.  With a finding above that stops one outright, the two lines
+  # below name a replacement and a current.old that never arrive, and the file
+  # this note exists to save is the one they would be wrong about.
+  if [ "$BUILD_BLOCKED" -gt 0 ]; then
+    lines[${#lines[@]}]='no build will run until the problems above are fixed, so nothing here is replaced yet'
+  else
+    lines[${#lines[@]}]="the next build $replaces, keeping what is there now at $OLD"
+    lines[${#lines[@]}]="the build after that removes $OLD, so a file moved into the built tree is recoverable for one build and no longer"
+  fi
   i=0
   while [ "$i" -lt "${#MISMATCH_PATHS[@]}" ]; do
     lines[${#lines[@]}]=${MISMATCH_PATHS[$i]}
@@ -1333,15 +1569,40 @@ audit_broken_links() {
   local out err marker line link dest target cur dots home qdots qhome n lines
   local stream cap rest msg samples remedy where
 
-  # Uncounted, and before every other check here, which all need a built tree to
-  # mean anything.
-  if [ -d "$DOTFILES" ] && [ ! -d "$CUR" ]; then
-    if [ -e "$CUR" ] || [ -L "$CUR" ]; then
-      note "$CUR exists but is not a directory, so there is no built tree to check the links in ${HOME-} against" \
-        'shale builds into it: remove it, or move it aside'
-    else
-      note "there is no built tree at $CUR, so shale cannot tell a link into it from any other broken link" \
-        'build one with: shale build'
+  # Before every other check here, which all need a built tree to mean anything.
+  #
+  # The two states build refuses are findings, in build's own words: a link to a
+  # directory answers -d as readily as a directory does, so without the -L arm
+  # the one shape that says nothing at all is the one a build would write
+  # through.  Nothing at that path is not a defect - it is the state before the
+  # first build - and stays a note.
+  #
+  # Both findings carry the clause the note they replaced had, and carry it
+  # only where it is true: everything below this returns without a word when
+  # $CUR is not a directory, and silence from a walk that did not run reads as
+  # a clean answer.  A link to a directory is the one shape where the walk does
+  # run - -d follows it - so that is the one that must not say it.
+  if [ -d "$DOTFILES" ]; then
+    if [ -L "$CUR" ]; then
+      lines=("$CUR is a symlink"
+        'shale builds into it, and would write through the link'
+        'remove it, or move it aside')
+      [ -d "$CUR" ] ||
+        lines[${#lines[@]}]="until then there is no built tree to check the links in ${HOME-} against"
+      blocking_finding ${lines[@]+"${lines[@]}"}
+    elif [ -e "$CUR" ] && [ ! -d "$CUR" ]; then
+      blocking_finding "$CUR exists but is not a directory" \
+        'shale builds into it' \
+        'remove it, or move it aside' \
+        "until then there is no built tree to check the links in ${HOME-} against"
+    elif [ ! -d "$CUR" ]; then
+      lines=("there is no built tree at $CUR, so shale cannot tell a link into it from any other broken link")
+      # Offered only where it would work.  With a layer conflict or an
+      # unreadable layer above, 'shale build' is a command that exits 1, and
+      # sending a reader to it is the failure this whole check exists to stop.
+      [ "$BUILD_BLOCKED" -gt 0 ] ||
+        lines[${#lines[@]}]='build one with: shale build'
+      note ${lines[@]+"${lines[@]}"}
     fi
   fi
 
@@ -2011,18 +2272,28 @@ cmd_apply() {
 # Nothing here exits early or short-circuits: every check runs whatever the ones
 # before it found, and only the finding count decides the exit status.
 cmd_doctor() {
-  local tool i name path root dir entry leaf known remedy qlock lines
+  local tool i name path root dir entry leaf known remedy qlock lines layers
+  local pending
 
   FINDINGS=0
+  BUILD_BLOCKED=0
+  pending=0
 
   # Every tool shale runs, and the list a new one joins.  Elsewhere a tool is
   # checked at its point of use only where its absence would be silent or would
   # name something other than the missing tool; doctor is where that stops,
   # because checking is its point of use and it promises prerequisites.
   for tool in cp git mkdir mv rm rmdir stow; do
-    command -v "$tool" >/dev/null 2>&1 ||
-      finding "$tool is not installed" \
-        "install it with your system package manager: shale installs nothing"
+    command -v "$tool" >/dev/null 2>&1 && continue
+    # git is wanted only for a clone root that has a url and nothing at its
+    # path, and stow only by apply, so neither of those two stops a build on its
+    # own; the other five do, and no line below may then offer one.
+    case "$tool" in
+      git | stow) ;;
+      *) BUILD_BLOCKED=$((BUILD_BLOCKED + 1)) ;;
+    esac
+    finding "$tool is not installed" \
+      "install it with your system package manager: shale installs nothing"
   done
   command -v chkstow >/dev/null 2>&1 ||
     note "chkstow is not installed" \
@@ -2037,16 +2308,16 @@ cmd_doctor() {
       # One input reaches this arm and is told something false: a symlink whose
       # target sits under a directory that cannot be searched.  Naming that needs
       # readlink, checked for lazily, so the line prescribes nothing.
-      finding "$DOTFILES exists but is not a directory" \
+      blocking_finding "$DOTFILES exists but is not a directory" \
         "shale keeps your layers, your config and its build output there"
     elif first_unsearchable_ancestor "$DOTFILES"; then
       # No remedy line: parse_config's arm names this same directory and this
       # same cause a moment later, and one is enough for both.
-      finding "cannot search $UNSEARCHABLE: permission denied" \
+      blocking_finding "cannot search $UNSEARCHABLE: permission denied" \
         "shale cannot tell whether there is a dotfiles directory at $DOTFILES"
     else
       shell_quote "$DOTFILES"
-      finding "no dotfiles directory at $DOTFILES" \
+      blocking_finding "no dotfiles directory at $DOTFILES" \
         "create it with: mkdir -p $QUOTED"
     fi
   fi
@@ -2057,7 +2328,7 @@ cmd_doctor() {
   # all - but the finding states both readings rather than calling it stale:
   # nothing shale can read tells a live holder from a killed one.
   if [ -L "$LOCK" ]; then
-    finding "$LOCK is a symlink" \
+    blocking_finding "$LOCK is a symlink" \
       'build and apply take their lock by creating that directory, and will not follow a link to one' \
       'remove it, or move it aside, or neither will run'
   elif [ -d "$LOCK" ]; then
@@ -2065,18 +2336,18 @@ cmd_doctor() {
     qlock=$QUOTED
     remedy="rmdir $qlock"
     dir_is_empty "$LOCK" || remedy="rm -rf $qlock"
-    finding "a shale has the lock at $LOCK, or a killed one left it behind" \
+    blocking_finding "a shale has the lock at $LOCK, or a killed one left it behind" \
       "build and apply take it so that two of them cannot rebuild $CUR at once, and both refuse while it is there" \
       'nothing shale can read tells a live holder from a dead one, so this is a lock to remove only if no other shale is running' \
       "remove it with: $remedy"
   elif [ -e "$LOCK" ]; then
-    finding "$LOCK exists but is not a directory" \
+    blocking_finding "$LOCK exists but is not a directory" \
       'build and apply take their lock by creating that directory' \
       'remove it, or move it aside, or neither will run'
   elif [ -d "$DOTFILES" ] && [ -x "$DOTFILES" ] && [ ! -w "$DOTFILES" ]; then
     # acquire_lock's last refusal, and the only one with nothing at the lock
     # path to look at.  The last line is build's own remedy, word for word.
-    finding "no build or apply can create the lock at $LOCK" \
+    blocking_finding "no build or apply can create the lock at $LOCK" \
       'they take their lock by creating that directory, and stop where they cannot' \
       "check that $DOTFILES is writable"
   fi
@@ -2086,6 +2357,9 @@ cmd_doctor() {
   # its errors as a finding, so each must land in the report the count describes.
   parse_config 2>&1
   FINDINGS=$((FINDINGS + CONFIG_ERRORS))
+  # Every one of them stops a build: build calls this same parse as
+  # 'parse_config || exit 1'.
+  BUILD_BLOCKED=$((BUILD_BLOCKED + CONFIG_ERRORS))
 
   i=0
   while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
@@ -2095,30 +2369,79 @@ cmd_doctor() {
     dir=$DOTFILES/$path
     if [ -d "$dir" ] && { [ ! -r "$dir" ] || [ ! -x "$dir" ]; }; then
       denied_verb "$dir"
-      finding "layer '$name': $DENIED_VERB $dir: permission denied" \
+      blocking_finding "layer '$name': $DENIED_VERB $dir: permission denied" \
         'shale composes a layer by walking it, and build stops there' \
         'check the permissions on that directory'
     elif [ -d "$dir" ]; then
       :
     elif obscured_ancestor "$DOTFILES" "$path"; then
-      finding "layer '$name': cannot search $OBSCURED: permission denied" \
+      blocking_finding "layer '$name': cannot search $OBSCURED: permission denied" \
         "shale cannot tell whether there is a directory at $dir" \
         'check the permissions on that directory'
     elif [ -e "$dir" ] || [ -L "$dir" ]; then
-      finding "layer '$name': $dir exists but is not a directory"
+      blocking_finding "layer '$name': $dir exists but is not a directory"
     elif [ -d "$DOTFILES/$root" ]; then
-      finding "layer '$name' has no directory at $dir, but its clone at $DOTFILES/$root exists" \
+      blocking_finding "layer '$name' has no directory at $dir, but its clone at $DOTFILES/$root exists" \
         "check the path on line ${LAYER_LINES[$i]}"
     elif [ -e "$DOTFILES/$root" ] || [ -L "$DOTFILES/$root" ]; then
-      finding "layer '$name' has no directory at $dir" \
+      blocking_finding "layer '$name' has no directory at $dir" \
         "its clone root $DOTFILES/$root exists but is not a directory" \
         'remove it, or move it aside'
     elif clone_url "$root"; then
+      # Nothing is at the clone root, so build will fetch it: this is
+      # will_clone's answer, reached by the same arms in the same order.
+      pending=1
       note "layer '$name' has no directory at $dir yet" \
         "its clone root '$root' has a url: $CLONE_URL"
     else
-      finding "layer '$name' has no directory at $dir and no url for '$root'" \
+      blocking_finding "layer '$name' has no directory at $dir and no url for '$root'" \
         "add a url on that line, or create the directory"
+    fi
+    i=$((i + 1))
+  done
+
+  # Missing git is a finding above and stops no build on its own - a machine
+  # holding every layer builds with no git at all.  Together with a layer whose
+  # clone root has a url and nothing at its path it does stop one, in
+  # clone_missing_roots, and doctor has both halves in hand: counted here so
+  # that nothing below offers a build that dies fetching.  No second finding -
+  # the missing tool is already one.
+  if [ "$pending" -eq 1 ] && ! command -v git >/dev/null 2>&1; then
+    BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
+  fi
+
+  # The layers as build composes them, once the loop above has said which of
+  # them there is anything to walk.  A root that is missing, unreadable or not a
+  # directory is that loop's finding and is left out here rather than reported
+  # twice; every layer left is one build would walk.
+  layers=
+  i=0
+  while [ "$i" -lt "${#LAYER_PATHS[@]}" ]; do
+    dir=$DOTFILES/${LAYER_PATHS[$i]}
+    if [ -d "$dir" ] && [ -r "$dir" ] && [ -x "$dir" ]; then
+      layers="$layers $i"
+    fi
+    i=$((i + 1))
+  done
+  LAYER_DENIED=0
+  [ -z "$layers" ] || scan_layer_trees '' "${layers# }"
+  # Under the cap every one of them is printed above and this says nothing.
+  if [ "$LAYER_DENIED" -gt "$LAYER_DENIED_CAP" ]; then
+    i=$((LAYER_DENIED - LAYER_DENIED_CAP))
+    note "and $i more layer paths shale cannot read, not named here"
+  fi
+
+  # build's own refusal, in build's own words.  It is checked against the layers
+  # rather than against the composed tree because that is where the file has to
+  # be removed from, and because a layer providing one refuses every build from
+  # now on: shale writes that path itself, so no build can be made to accept it.
+  i=0
+  while [ "$i" -lt "${#LAYER_NAMES[@]}" ]; do
+    dir=$DOTFILES/${LAYER_PATHS[$i]}/.stow-local-ignore
+    if [ -e "$dir" ] || [ -L "$dir" ]; then
+      blocking_finding "layer '${LAYER_NAMES[$i]}' provides $dir" \
+        "shale writes $CUR/.stow-local-ignore itself" \
+        'remove it from that layer'
     fi
     i=$((i + 1))
   done

--- a/tests/run
+++ b/tests/run
@@ -6404,18 +6404,627 @@ test_doctor_says_when_there_is_no_built_tree_to_check_links_against() {
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
 }
 
-# The same silence, and a state 'shale build' refuses rather than repairs.
-test_doctor_says_when_the_built_tree_is_not_a_directory() {
+# The plausible layering mistake, and the one 'shale which' already answers on
+# the same tree while doctor reported the setup sound.  Every build from now on
+# exits 1, so it is a finding, and the pair it names is the pair to fix.
+test_doctor_two_layers_disagreeing_about_a_path_is_a_finding() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer personal/base both/inner
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 'build' would fail at both — it is a directory in layer 'base' and a file in layer 'work'" \
+    'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.dotfiles/personal/base/both" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.dotfiles/work/both" 'stdout'
+  # build's own two closing lines, word for word.
+  assert_contains "$shale_out" \
+    'shale:   a layer cannot replace a directory with a file, or a file with a directory' 'stdout'
+  assert_contains "$shale_out" 'shale:   remove or rename one of them' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # The build it predicts, which is what makes the finding true rather than
+  # merely alarming.
+  run_shale build
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" 'shale: conflict at both' 'the build stderr'
+  # And the remedy carried out: one of the two goes, and the build runs.
+  sandbox_mkdir "$HOME/.dotfiles/work"
+  rm -f "$sandbox_dir/both" || fail 'could not remove the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the remedy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# A conflict after a successful build is the same finding: the built tree is
+# stale from the moment the layers stopped composing, and nothing in it says so.
+test_doctor_a_conflict_introduced_after_a_build_is_still_a_finding() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer work .vimrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  mklayer personal/base both/inner
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 'build' would fail at both — it is a directory in layer 'base' and a file in layer 'work'" \
+    'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# build reports a collision against the nearest provider below, so three layers
+# disagreeing at one path give it two of them.  Doctor names the lowest pair,
+# once: that is the pair to fix, and the one above it follows from it - and a
+# finding per layer would turn one mistake into a report that grows with the
+# config.
+test_doctor_names_one_pair_when_three_layers_disagree() {
+  conf 'base personal/base' 'mid mid' 'work work'
+  mklayer personal/base both/inner
+  mklayer mid both
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 'build' would fail at both — it is a directory in layer 'base' and a file in layer 'mid'" \
+    'stdout'
+  assert_not_contains "$shale_out" "in layer 'work'" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # Said only where a third layer is in it: with two providers, removing either
+  # of the named pair is the whole of the fix and this line would be noise.
+  assert_contains "$shale_out" \
+    'shale:   3 layers provide both, so removing one of the two named here may leave another pair that disagrees' \
+    'stdout'
+  # build, on the same tree, reports both collisions: doctor's one finding is a
+  # deliberate narrowing rather than a disagreement about what is wrong.
+  run_shale build
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" "shale: 2 conflicts; $HOME/.dotfiles/current not rebuilt" \
+    'the build stderr'
+}
+
+# Two layers is the whole of the fix, so the line above must not appear.
+test_doctor_says_nothing_about_a_third_layer_when_there_is_none() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base both/inner
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" "shale: 'build' would fail at both" 'stdout'
+  assert_not_contains "$shale_out" 'layers provide' 'stdout'
+}
+
+# build collides a layer against the *nearest* provider below it, not the first
+# one, so with base and mid both holding a directory and work a file, the pair
+# to send someone to is mid and work.  Naming base instead names a layer build's
+# own report never mentions, and removing base leaves the build failing exactly
+# as before.  All six arrangements of three layers, because which pair is right
+# is a property of the ordering and not of the count.
+test_doctor_names_the_pair_build_names() {
+  local kinds a b c layer kind lower upper lowkind upkind
+  # Three names of one length, so build's own column padding adds no spaces to
+  # one label and not another and the assertions below can be substrings of it.
+  for kinds in 'dir dir file' 'dir file dir' 'file dir dir' \
+    'dir file file' 'file file dir' 'file dir file'; do
+    # Rebuilt from scratch per arrangement: one $HOME cannot hold six of them.
+    sandbox_mkdir "$HOME/.dotfiles"
+    rm -rf "$sandbox_dir/low" "$sandbox_dir/mid" "$sandbox_dir/top" \
+      "$sandbox_dir/current" || fail 'could not clear the layers'
+    conf 'low low' 'mid mid' 'top top'
+    read -r a b c <<EOF
+$kinds
+EOF
+    for layer in low mid top; do
+      case "$layer" in
+        low) kind=$a ;;
+        mid) kind=$b ;;
+        *) kind=$c ;;
+      esac
+      if [ "$kind" = dir ]; then
+        mklayer "$layer" "d/in-$layer"
+      else
+        mklayer "$layer" d
+      fi
+    done
+    # build's pair, derived the way build derives it: the lowest layer whose
+    # kind differs from the one the layer below it established, and the
+    # provider immediately below that layer.
+    if [ "$a" != "$b" ]; then
+      lower=low
+      upper=mid
+      lowkind=$a
+      upkind=$b
+    else
+      lower=mid
+      upper=top
+      lowkind=$b
+      upkind=$c
+    fi
+    [ "$lowkind" != dir ] || lowkind=directory
+    [ "$upkind" != dir ] || upkind=directory
+    run_shale doctor
+    assert_status 1 "$shale_status" "$kinds doctor"
+    assert_contains "$shale_out" \
+      "shale: 'build' would fail at d — it is a $lowkind in layer '$lower' and a $upkind in layer '$upper'" \
+      "$kinds doctor stdout"
+    assert_contains "$shale_out" "shale:   $HOME/.dotfiles/$lower/d" "$kinds doctor stdout"
+    assert_contains "$shale_out" "shale:   $HOME/.dotfiles/$upper/d" "$kinds doctor stdout"
+    # And build, which has to name the same two paths in its first conflict.
+    run_shale build
+    assert_status 1 "$shale_status" "$kinds build"
+    assert_contains "$shale_err" "shale:   layer '$upper' provides a $upkind" "$kinds build stderr"
+    assert_contains "$shale_err" "shale:   layer '$lower' provides a $lowkind" "$kinds build stderr"
+  done
+}
+
+# A symlink is a leaf to the composer whatever it points at, so a link to a
+# directory under a real directory in a higher layer is a collision - and
+# calling the link a directory here would make doctor promise a merge that
+# build refuses.
+test_doctor_a_layer_symlink_under_a_layer_directory_is_a_finding() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer work d/inner
+  sandbox_mkdir "$HOME/elsewhere"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" d new
+  ln -s "$HOME/elsewhere" "$sandbox_path" || fail 'could not plant the link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 'build' would fail at d — it is a file in layer 'base' and a directory in layer 'work'" \
+    'stdout'
+  run_shale build
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" 'shale: conflict at d' 'the build stderr'
+}
+
+# build does not descend a layer that collided at a directory, so nothing under
+# it is composed and nothing under it can be a defect either.  The unsearchable
+# directory below the collision is real and build never reaches it: reporting it
+# would send someone to fix a permission that is not what stops the build.
+test_doctor_looks_no_further_under_a_layer_that_disagrees() {
+  local doctor_out doctor_status
+  skip_if_root
+  conf 'base personal/base' 'work work'
+  mklayer personal/base d 'a file where work has a directory'
+  mklayer work d/deeper/f
+  chmod 0000 "$HOME/.dotfiles/work/d/deeper" || fail 'could not remove the mode bits'
+  run_shale doctor
+  doctor_out=$shale_out
+  doctor_status=$shale_status
+  chmod 0755 "$HOME/.dotfiles/work/d/deeper" || fail 'could not restore the mode'
+  assert_status 1 "$doctor_status"
+  assert_contains "$doctor_out" \
+    "shale: 'build' would fail at d — it is a file in layer 'base' and a directory in layer 'work'" \
+    'stdout'
+  assert_not_contains "$doctor_out" 'deeper' 'stdout'
+  assert_contains "$doctor_out" 'shale: 1 problem found' 'stdout'
+}
+
+# The same provenance as the unsearchable directory below, and the commoner
+# half of it: a layer restored under another uid holds unreadable files more
+# often than unreadable directories, and build stops at the first cp that
+# cannot open one.  Every layer's copy is checked, not the winner's, because
+# build copies each in turn - so a file in a layer something else shadows stops
+# the build just the same.
+test_doctor_a_layer_file_it_cannot_read_is_a_finding() {
+  local doctor_out doctor_status
+  skip_if_root
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer personal/base secret
+  # Shadowed by a higher layer, and still fatal: this is the half that says the
+  # check is not scoped to the copy that wins.
+  mklayer work secret
+  chmod 0000 "$HOME/.dotfiles/personal/base/secret" ||
+    fail 'could not remove the mode bits'
+  run_shale doctor
+  doctor_out=$shale_out
+  doctor_status=$shale_status
+  run_shale build
+  chmod 0644 "$HOME/.dotfiles/personal/base/secret" ||
+    fail 'could not restore the mode'
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" \
+    "shale: could not copy $HOME/.dotfiles/personal/base/secret to $HOME/.dotfiles/current.new/secret" \
+    'the build stderr'
+  assert_status 1 "$doctor_status" 'the doctor'
+  assert_contains "$doctor_out" \
+    "shale: layer 'base': cannot read $HOME/.dotfiles/personal/base/secret: permission denied" \
+    'the doctor stdout'
+  assert_contains "$doctor_out" \
+    'shale:   shale composes a layer by copying its files, and build stops there' \
+    'the doctor stdout'
+  assert_contains "$doctor_out" 'shale:   check the permissions on that file' 'the doctor stdout'
+  assert_contains "$doctor_out" 'shale: 1 problem found' 'the doctor stdout'
+  # The remedy, carried out.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the remedy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# The three shapes an unreadable-looking entry takes that a build composes
+# without ever opening one, so a finding about any of them is a false one.  All
+# three are measured against the build rather than argued: '-f' alone takes the
+# fifo, and '-f' without '! -L' takes the link, whose target '-r' answers for
+# while cp copies the link and never reads through it.
+test_doctor_says_nothing_about_a_layer_entry_no_build_reads() {
+  skip_if_root
+  command -v mkfifo >/dev/null 2>&1 || skip 'mkfifo is not available'
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  # A file outside every layer, unreadable, with a layer link pointing at it.
+  sandbox_write "$CASE_DIR/outside" target 'PRECIOUS'
+  chmod 0000 "$sandbox_path" || fail 'could not remove the mode bits'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" tolink new
+  ln -s "$CASE_DIR/outside/target" "$sandbox_path" || fail 'could not plant the link'
+  sandbox_leaf "$sandbox_dir" dangling new
+  ln -s nowhere "$sandbox_path" || fail 'could not plant the dangling link'
+  sandbox_leaf "$sandbox_dir" pipe new
+  mkfifo "$sandbox_path" || fail 'could not plant the fifo'
+  chmod 0000 "$sandbox_path" || fail 'could not remove the fifo mode bits'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_not_contains "$shale_out" 'cannot read' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  # And the build that says so: it composes all three and exits 0.
+  run_shale build
+  chmod 0644 "$CASE_DIR/outside/target" || fail 'could not restore the mode'
+  assert_status 0 "$shale_status" 'the build'
+  assert_empty "$shale_err" 'the build stderr'
+  assert_exists "$HOME/.dotfiles/current/tolink" 'the copied link'
+  assert_dangling_symlink "$HOME/.dotfiles/current/dangling" 'the copied dangling link'
+}
+
+# build reports one of these and stops; this walk finds every one, and a layer
+# restored under another uid can hold dozens.  Ten named and the rest counted is
+# the shape every other multi-item report in doctor uses.
+test_doctor_bounds_the_layer_permission_findings_at_ten() {
+  local doctor_out doctor_status i n
+  skip_if_root
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  # Two digits, so the glob order the walk sees is the counting order and the
+  # assertions below can name which two fall past the cap.
+  i=0
+  while [ "$i" -lt 12 ]; do
+    n=$(printf 'd%02d' "$i")
+    mklayer personal/base "$n/f"
+    i=$((i + 1))
+  done
+  i=0
+  while [ "$i" -lt 12 ]; do
+    n=$(printf 'd%02d' "$i")
+    chmod 0000 "$HOME/.dotfiles/personal/base/$n" || fail "could not set the mode on $n"
+    i=$((i + 1))
+  done
+  run_shale doctor
+  doctor_out=$shale_out
+  doctor_status=$shale_status
+  i=0
+  while [ "$i" -lt 12 ]; do
+    n=$(printf 'd%02d' "$i")
+    chmod 0755 "$HOME/.dotfiles/personal/base/$n" || fail "could not restore the mode on $n"
+    i=$((i + 1))
+  done
+  assert_status 1 "$doctor_status"
+  # The cap changes what is printed and never what is counted.
+  assert_contains "$doctor_out" 'shale: 12 problems found' 'stdout'
+  assert_contains "$doctor_out" \
+    'shale: and 2 more layer paths shale cannot read, not named here' 'stdout'
+  # Ten named, and the eleventh and twelfth in walk order not.
+  assert_contains "$doctor_out" \
+    "shale: layer 'base': cannot search $HOME/.dotfiles/personal/base/d00: permission denied" 'stdout'
+  assert_contains "$doctor_out" \
+    "shale: layer 'base': cannot search $HOME/.dotfiles/personal/base/d09: permission denied" 'stdout'
+  assert_not_contains "$doctor_out" \
+    "$HOME/.dotfiles/personal/base/d10: permission denied" 'stdout'
+  assert_not_contains "$doctor_out" \
+    "$HOME/.dotfiles/personal/base/d11: permission denied" 'stdout'
+}
+
+# doctor checked the layer root only, so the ordinary way this arrives - a layer
+# restored or cloned under another user - was silent while every build stopped
+# at it.  The wording is the layer-root arm's, because it is the same fault one
+# level down.
+test_doctor_a_layer_subdirectory_it_cannot_search_is_a_finding() {
+  local doctor_out doctor_status
+  skip_if_root
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  chmod 0000 "$HOME/.dotfiles/personal/base/.config" ||
+    fail 'could not remove the mode bits'
+  run_shale doctor
+  doctor_out=$shale_out
+  doctor_status=$shale_status
+  run_shale build
+  chmod 0755 "$HOME/.dotfiles/personal/base/.config" ||
+    fail 'could not restore the mode'
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" \
+    "shale: layer 'base': cannot search $HOME/.dotfiles/personal/base/.config: permission denied" \
+    'the build stderr'
+  assert_status 1 "$doctor_status" 'the doctor'
+  assert_contains "$doctor_out" \
+    "shale: layer 'base': cannot search $HOME/.dotfiles/personal/base/.config: permission denied" \
+    'the doctor stdout'
+  assert_contains "$doctor_out" \
+    'shale:   shale composes a layer by walking it, and build stops there' 'the doctor stdout'
+  assert_contains "$doctor_out" 'shale: 1 problem found' 'the doctor stdout'
+  # The remedy, carried out.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the remedy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# Not merely quiet but false: shale writes current/.stow-local-ignore itself, so
+# the built copy is always older than a layer's, the built-tree note fired on
+# every run, and it promised a current.old the refused build never creates.
+test_doctor_a_layer_providing_a_stow_local_ignore_is_a_finding() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  mklayer personal/base .stow-local-ignore '^/secret'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  # build's three lines, word for word.
+  assert_contains "$shale_out" \
+    "shale: layer 'base' provides $HOME/.dotfiles/personal/base/.stow-local-ignore" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   shale writes $HOME/.dotfiles/current/.stow-local-ignore itself" 'stdout'
+  assert_contains "$shale_out" 'shale:   remove it from that layer' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # The note that used to fire here, and the promise inside it.  No build lands
+  # a layer copy at that path, so neither the replacement nor the current.old
+  # ever comes.
+  assert_not_contains "$shale_out" 'does not match the layer copy' 'stdout'
+  assert_not_contains "$shale_out" 'current.old' 'stdout'
+  run_shale build
+  assert_status 1 "$shale_status" 'the build'
+  assert_missing "$HOME/.dotfiles/current.old" 'the tree the note promised'
+  # The remedy, carried out.
+  sandbox_leaf "$HOME/.dotfiles/personal/base" .stow-local-ignore
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the remedy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# 'build one with: shale build' is a remedy, and a remedy that exits 1 is worse
+# than none: it sends the reader past the finding that says why.  Both halves,
+# because the line is right in one of them and the case would pass vacuously on
+# a doctor that had simply stopped printing it.
+test_doctor_offers_no_build_it_has_already_said_will_fail() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer work .vimrc
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .zshrc new
+  ln -s "$HOME/.dotfiles/current/.zshrc" "$sandbox_path" || fail 'could not plant the link'
+  assert_missing "$HOME/.dotfiles/current" 'the built tree'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" 'shale:   build one with: shale build' 'the sound setup stdout'
+  # The same tree with a collision in it: the note stays, the remedy goes.
+  mklayer personal/base both/inner
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the setup that cannot build'
+  assert_contains "$shale_out" \
+    "shale: there is no built tree at $HOME/.dotfiles/current, so shale cannot tell a link into it from any other broken link" \
+    'the stdout that cannot build'
+  assert_not_contains "$shale_out" 'build one with' 'the stdout that cannot build'
+  run_shale build
+  assert_status 1 "$shale_status" 'the build the remedy would have named'
+}
+
+# The conjunction, which neither half is: a missing git stops no build on its
+# own - a machine holding every layer builds without it - and a clone root with
+# a url and nothing at its path is an ordinary first-run state.  Together they
+# are a build that dies in clone_missing_roots, and doctor is holding both.
+#
+# The url is one no clone could succeed from, so an implementation that cloned
+# eagerly fails this case rather than passing it slowly.
+# shellcheck disable=SC2123
+test_doctor_offers_no_build_that_would_die_fetching() {
+  local saved
+  conf 'base personal/base' "vim vim $CASE_DIR/repos/absent"
+  mklayer personal/base .zshrc
+  stub_path_without git
+  saved=$PATH
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: git is not installed' 'stdout'
+  assert_contains "$shale_out" \
+    "shale: layer 'vim' has no directory at $HOME/.dotfiles/vim yet" 'stdout'
+  assert_not_contains "$shale_out" 'build one with' 'stdout'
+  # The build that remedy would have named.
+  PATH=$stub_path
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" \
+    "shale: git is not installed, and $HOME/.dotfiles/vim must be cloned from $CASE_DIR/repos/absent" \
+    'the build stderr'
+}
+
+# And the half of it that is not build-blocking: no git, nothing to clone, so
+# the build runs and the offer stands.  Without this the case above passes on a
+# doctor that suppressed the offer whenever git was missing at all.
+# shellcheck disable=SC2123
+test_doctor_offers_a_build_a_missing_git_does_not_stop() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  stub_path_without git
+  saved=$PATH
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" 'shale: git is not installed' 'stdout'
+  assert_contains "$shale_out" 'shale:   build one with: shale build' 'stdout'
+  PATH=$stub_path
+  run_shale build
+  PATH=$saved
+  assert_status 0 "$shale_status" 'the build'
+}
+
+# The other promise about a build that will not run: the built-tree note names a
+# replacement and a current.old, and with a collision above it neither arrives.
+# The count is the guard on the everyday half - the note itself stays a note.
+test_doctor_promises_no_replacement_from_a_build_that_will_not_run() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer work .vimrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch -t 202601010000 "$sandbox_path" || fail 'could not date the layer file'
+  # Without the collision: the promise is true, and made.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" \
+    "shale:   the next build replaces it with the layer copy, keeping what is there now at $HOME/.dotfiles/current.old" \
+    'the sound setup stdout'
+  mklayer personal/base both/inner
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the setup that cannot build'
+  assert_contains "$shale_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'the stdout that cannot build'
+  assert_contains "$shale_out" \
+    'shale:   no build will run until the problems above are fixed, so nothing here is replaced yet' \
+    'the stdout that cannot build'
+  assert_not_contains "$shale_out" 'the next build' 'the stdout that cannot build'
+  assert_not_contains "$shale_out" 'current.old' 'the stdout that cannot build'
+  # And the build it describes: refused, and nothing kept.
+  run_shale build
+  assert_status 1 "$shale_status" 'the build'
+  assert_missing "$HOME/.dotfiles/current.old" 'the tree the note would have promised'
+}
+
+# The everyday loop #75 exists for: edit a layer, run doctor.  A built tree the
+# layers have moved past is the ordinary state between an edit and a build, and
+# making it exit 1 would move the warning fatigue rather than remove it.
+test_doctor_an_edited_layer_is_still_a_note_and_still_exit_zero() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer work .vimrc
+  # cp -p carries the layer file's mtime into the built tree, so the edit below
+  # has to move it forward from a date the build already copied.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch -t 202601010000 "$sandbox_path" || fail 'could not date the layer file'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 file in $HOME/.dotfiles/current does not match the layer copy that provides it" \
+    'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  # And the build that follows says nothing at all, which is the other half of
+  # the quiet loop.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_empty "$shale_err" 'the build stderr'
+}
+
+# Two layers holding the same directory merge, and a file over a file is the
+# shadowing this whole tool is for.  Neither is a collision, and a walk that
+# called either one would fire on every setup that has more than one layer.
+test_doctor_says_nothing_about_layers_that_merge_or_shadow() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer work .config/nvim/spell.add
+  mklayer personal/base .zshrc
+  mklayer work .zshrc
+  mklayer personal/base .config/git/ignore
+  mklayer work .config/git/ignore
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# A .git is skipped at every depth in the composer, so nothing inside one is
+# ever composed and nothing inside one can collide.  Without the skip a layer
+# that is a working repository and a layer that is not would collide on every
+# path git keeps at a different kind, and doctor would refuse a setup that
+# builds.
+test_doctor_says_nothing_about_a_git_directory_in_a_layer() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer personal/base .git/config 'GIT'
+  mklayer work .git 'not a directory here'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_missing "$HOME/.dotfiles/current/.git" 'the built tree'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# A state 'shale build' refuses rather than repairs, so it is counted and doctor
+# says it in build's own words.
+test_doctor_a_built_tree_that_is_not_a_directory_is_a_finding() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
   sandbox_write "$HOME/.dotfiles" current 'not a tree'
   run_shale doctor
-  assert_status 0 "$shale_status"
+  assert_status 1 "$shale_status"
   assert_contains "$shale_out" \
-    "shale: $HOME/.dotfiles/current exists but is not a directory, so there is no built tree to check the links in $HOME against" \
-    'stdout'
-  assert_contains "$shale_out" 'shale:   shale builds into it: remove it, or move it aside' 'stdout'
-  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+    "shale: $HOME/.dotfiles/current exists but is not a directory" 'stdout'
+  assert_contains "$shale_out" 'shale:   shale builds into it' 'stdout'
+  assert_contains "$shale_out" 'shale:   remove it, or move it aside' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # No build to offer, so none is offered: the tree cannot be built until this
+  # is fixed, and the note about there being no built tree is not printed at all
+  # because there is something at that path.
+  assert_not_contains "$shale_out" 'build one with' 'stdout'
+  # The clause the note this replaced carried.  Everything below it in doctor
+  # returns without a word against a $CUR that is not a directory, and silence
+  # from a walk that did not run reads as a clean answer.
+  assert_contains "$shale_out" \
+    "shale:   until then there is no built tree to check the links in $HOME against" 'stdout'
+  # build says the same thing about the same path, which is what makes the
+  # finding's remedy the one that works.
+  run_shale build
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/current exists but is not a directory" 'the build stderr'
+  # And the remedy carried out clears it.
+  sandbox_mkdir "$HOME/.dotfiles"
+  rm -f "$sandbox_dir/current" || fail 'could not remove the planted file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the remedy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
 }
 
 # The report #66 put in build, moved here.  This is the shape it exists for: a
@@ -6817,11 +7426,12 @@ test_doctor_says_nothing_about_a_git_directory_in_the_built_tree() {
   assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
 }
 
-# Every line of the note says what the next build will do with what was found,
-# and against a symlink at current no build does anything: it refuses the tree
-# and exits 1.  That this walk would follow the link is the smaller half; the
-# promise about a build that will not run is the half that would be false.
-test_doctor_says_nothing_about_a_built_tree_reached_through_a_symlink() {
+# A link to a directory answers -d as readily as a directory does, so this is
+# the shape doctor used to pass in silence while every build refused it - a
+# regular file and a dangling link at that path both said something.  Counted
+# now, in build's words; and the note about the built tree still says nothing,
+# because every line of it describes a build that will not run.
+test_doctor_a_built_tree_that_is_a_symlink_is_a_finding() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
   sandbox_mkdir "$HOME/.dotfiles/personal/base"
@@ -6837,7 +7447,15 @@ test_doctor_says_nothing_about_a_built_tree_reached_through_a_symlink() {
   sandbox_leaf "$sandbox_dir" .zshrc
   touch -t 202601010000 "$sandbox_path" || fail 'could not date the layer file'
   run_shale doctor
-  assert_status 0 "$shale_status"
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" "shale: $HOME/.dotfiles/current is a symlink" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   shale builds into it, and would write through the link' 'stdout'
+  assert_contains "$shale_out" 'shale:   remove it, or move it aside' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # The link audit walks straight through a link to a directory - -d follows one
+  # - so this is the one shape that must not claim there was nothing to check.
+  assert_not_contains "$shale_out" 'no built tree to check the links' 'stdout'
   assert_not_contains "$shale_out" 'does not match the layer copy' 'stdout'
   assert_not_contains "$shale_out" 'do not match the layer copies' 'stdout'
   assert_not_contains "$shale_out" 'the next build' 'stdout'
@@ -6845,6 +7463,17 @@ test_doctor_says_nothing_about_a_built_tree_reached_through_a_symlink() {
   run_shale build
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" "shale: $HOME/.dotfiles/current is a symlink" 'the build stderr'
+  # The remedy: the link goes, and the build that was refused runs.  Both halves
+  # run, because a remedy doctor prints has to work.  The directory it pointed
+  # at goes with it, or it is a stray package doctor then has a note about.
+  sandbox_mkdir "$HOME/.dotfiles"
+  rm -f "$sandbox_dir/current" || fail 'could not remove the link'
+  rm -rf "$sandbox_dir/elsewhere" || fail 'could not remove the moved tree'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the remedy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
 }
 
 # A directory this walk cannot enter drops out of it exactly as an empty one
@@ -6924,7 +7553,13 @@ test_doctor_does_not_blame_a_lower_layer_for_one_it_cannot_search() {
   doctor_out=$shale_out
   doctor_status=$shale_status
   chmod 0755 "$HOME/.dotfiles/local/.config" || fail 'could not restore the mode'
-  assert_status 0 "$doctor_status"
+  # The one finding is the layer walk's, which is what build stops at; the note
+  # below adds nothing to the count, which is what this case is about.
+  assert_status 1 "$doctor_status"
+  assert_contains "$doctor_out" \
+    "shale: layer 'local': cannot search $HOME/.dotfiles/local/.config: permission denied" \
+    'stdout'
+  assert_contains "$doctor_out" 'shale: 1 problem found' 'stdout'
   assert_not_contains "$doctor_out" 'does not match the layer copy' 'stdout'
   assert_not_contains "$doctor_out" 'do not match the layer copies' 'stdout'
   assert_contains "$doctor_out" \
@@ -6935,7 +7570,6 @@ test_doctor_does_not_blame_a_lower_layer_for_one_it_cannot_search() {
     "shale:   cannot search $HOME/.dotfiles/local/.config" 'stdout'
   assert_contains "$doctor_out" \
     'shale:   check the permissions on that directory' 'stdout'
-  assert_contains "$doctor_out" 'shale: no problems found' 'stdout'
 }
 
 # Alongside something that is a finding, which is the only way to see that this


### PR DESCRIPTION
Closes #81.

doctor no longer exits 0 on a setup build is certain to refuse. The four states from the issue are findings, plus unreadable layer files, which both gates falsified the original claim with.

The code gate fuzzed 700 random layer trees asserting doctor and build agree in both directions; the implementer then extended that to 2100 trees after finding its own first fuzzer passed a deliberately broken mutant. Zero discrepancies. The everyday loop is byte-identical to main. Cost is 2.10x on a 2000-file three-layer tree, inside the budget set on the issue.

Scaling is linear in files and directories, and stated honestly in the commit message as not linear in layers for arrangements nobody writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)