### PR TITLE
Say which end of the file each tool's include goes at

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ Copy the script to any directory on your `PATH`:
 ```sh
 mkdir -p ~/.local/bin
 cp shale ~/.local/bin/shale
+command -v shale
 ```
 
-Shale never needs to know where it lives, and there is nothing else to install.
+`~/.local/bin` is the usual choice, and it is often not on `PATH` on the machine you are
+bootstrapping, because putting it there is a thing your dotfiles do and they are not applied yet.
+That is what the third line is for: nothing printed means this shell cannot find shale, and
+`export PATH="$HOME/.local/bin:$PATH"` is enough to get through the bootstrap below. Applying your
+layers is what makes it permanent.
+
+Shale never needs to know where it lives, and there is nothing else to install. There is no version
+command: shale is one file, and the copy you have is whatever the repository held when you copied it.
 
 ## Bootstrap on a new machine
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -66,13 +66,13 @@ $ diff -u /home/you/.dotfiles/personal/base/.gitconfig /home/you/.dotfiles/local
 --- /home/you/.dotfiles/personal/base/.gitconfig
 +++ /home/you/.dotfiles/local/.gitconfig
 @@ -1,7 +1,2 @@
--[include]
--	path = ~/.config/git/conf.d/50-work.conf
 -[alias]
 -	st = status
 -	lg = log --oneline
 -[core]
 -	excludesfile = ~/.gitignore
+-[include]
+-	path = ~/.config/git/conf.d/50-work.conf
 +[user]
 +	email = me@example.com
 ```
@@ -200,25 +200,47 @@ prepend_path() {
 ## Tools that include natively
 
 Where a tool has its own include mechanism, use it instead of inventing a fragment directory for it.
-They do not all behave alike.
+They do not all behave alike, and what decides the recipe is which value a tool keeps when it reads
+one keyword twice. Where the **last** value wins, the include goes at the *bottom* of the base
+layer's file, below everything a higher layer might override; where the **first** wins, it goes at
+the *top*. At the wrong end a fragment can still add a key the base file never sets, so the recipe
+looks like it works and only the overrides are lost, silently. Establish which rule a tool follows
+by asking the tool for the value it settled on rather than by reading the files — that is
+`git config --get alias.lg` for git and `ssh -G example.com` for ssh. For tmux it is
+`tmux show-options -g`, which answers only against a server that is already running: with none it
+prints nothing and exits 1, which is not the fragment failing to load. A window option needs `-gw`,
+because a value set with `setw -g` is invisible to plain `-g`.
 
-Git's `include.path` takes one path and does not glob: `path = ~/.config/git/conf.d/*.conf` includes
-nothing at all, silently. The base layer therefore names each file it expects, and a higher layer
-supplies it; an include whose file does not exist is ignored without error, so naming a file no
-layer ships costs nothing.
+Git keeps the last value, so the `[include]` goes at the bottom. Its `include.path` takes one path
+and does not glob: `path = ~/.config/git/conf.d/*.conf` includes nothing at all, silently. The base
+layer therefore names each file it expects, and a higher layer supplies it; an include whose file
+does not exist is ignored without error, so naming a file no layer ships costs nothing.
 
 ```
+[alias]
+  lg = log --oneline
 [include]
   path = ~/.config/git/conf.d/50-work.conf
 ```
 
-SSH's `Include` does glob, and `Include ~/.ssh/config.d/*.conf` over a directory that does not exist
-is not an error. Put it at the *top* of `~/.ssh/config`, above any `Host` block: ssh keeps the first
-value it obtains for each keyword, so a `Host *` default written above the `Include` wins over
-everything the included files say.
+Put those two blocks the other way round and a `50-work.conf` setting `alias.lg` is read first and
+beaten by the base layer's line below it. Nothing reports that, and `shale which .gitconfig` cannot
+help, because the base layer genuinely does provide the file and that answer is correct:
 
-tmux's own is `source-file`, and the same shape applies: the base layer's `tmux.conf` names what it
-sources, and the layers supply those files.
+```
+$ git config --get alias.lg
+log --oneline
+```
+
+SSH is the other way about: it keeps the first value it obtains for each keyword, so `Include` goes
+at the *top* of `~/.ssh/config`, above any `Host` block — a `Host *` default written above the
+`Include` would otherwise win over everything the included files say. `Include` does glob, and
+`Include ~/.ssh/config.d/*.conf` over a directory that does not exist is not an error.
+
+tmux's `source-file` keeps the last value, as git's include does, so it goes at the bottom of
+`tmux.conf`, below the `set -g` lines a fragment might replace. It does glob, so one line covers a
+directory; the base layer's `tmux.conf` still names what it sources, and the layers supply those
+files.
 
 ## Symlinks in a layer
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -110,8 +110,9 @@ work queue. Take it in this order.
    they went.
 
 3. **Move what you are keeping into a layer, and build again.** Your line goes in the layer that
-   should own it — usually `local`, above the repository you are adopting — and the diff is how you
-   know when you are finished:
+   should own it — usually `local`, above the repository you are adopting. Where your version of a
+   path is a whole file in a layer, the diff is how you know when you are finished, and you are
+   finished when everything left in it is a difference you chose:
 
    ```
    $ diff -u ~/.zshrc ~/.dotfiles/current/.zshrc
@@ -126,9 +127,26 @@ work queue. Take it in this order.
    The alias survived because it was copied into `~/.dotfiles/local/.zshrc` by hand; `EDITOR` differs
    because that difference was the point of adopting the layer.
 
-   The build you run here says nothing. A `shale doctor` between the edit and the build would have
-   named the file, because the built tree no longer matches the layer that provides it — that is
-   the state every layer edit leaves, and it clears the moment you build. See *The everyday loop* in
+   A path reconciled through the tool's own include instead — the route *Tools that include natively*
+   in [layers.md](layers.md) gives for git, ssh and tmux — has no diff that can empty, because your
+   lines deliberately live in a second file that the built copy only points at. Ask the tool there,
+   once for each value you meant to keep: read them while your original file is still in `$HOME`, and
+   read them again after the apply in step 5, which is when the include resolves. You are finished
+   when the second reading is still yours.
+
+   ```
+   $ git config --get alias.lg
+   log --oneline --graph
+   ```
+
+   The layer's answer coming back instead — `log --oneline` — is not about which layer wins the file.
+   It means your value sits in a file the tool reads *before* the one that overrides it, and what
+   fixes it is moving the include to the end of the base layer's file, as `layers.md` has it.
+
+   The build you run here says nothing about the file you just edited, beyond the `composed layer`
+   line it prints for each layer. A `shale doctor` between the edit and the build would have named
+   the file, because the built tree no longer matches the layer that provides it — that is the state
+   every layer edit leaves, and it clears the moment you build. See *The everyday loop* in
    [layers.md](layers.md).
 
 4. **Move the originals out of `$HOME`.** They are what stow named, and they only have to stop being


### PR DESCRIPTION
Closes #83 (its stray-file item moved to #82).

The git include recipe put the include at the top, and git is last-value-wins, so a higher layer fragment could not override anything the base set below it. A trial followed it exactly and silently lost an alias.

The functional gate verified each tool independently rather than trusting the transcripts: git and tmux 3.4 last-wins, ssh first-wins, all three by execution. It also confirmed git config --global --get does not follow includes, and that tmux show-options -g needs a running server and misses window options - both now qualified in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)