### PR TITLE
Name the trees a build left behind

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ until stow prunes it. Apply when unsure: it builds first, so it is never less th
 Builds are quiet. A build that finds `current` holding a copy older than the layer file replacing it
 keeps the previous tree at `~/.dotfiles/current.old` and says nothing, because an edited layer leaves
 exactly that state and a message there would be a message on every edit. `shale doctor` is what
-reports it, as a note rather than a problem, and only before the build that overwrites it — see
+reports the mismatch, as a note rather than a problem, and only until the build that overwrites it.
+After that build it reports `current.old` instead, until the build after that removes it — see
 [docs/layers.md](docs/layers.md).
 
 Shale chooses between three exit codes, and no others:
@@ -249,7 +250,8 @@ configured layer directory is there and that nothing in one is a directory it ca
 it cannot open, that no two layers disagree about whether a path
 is a file or a directory, that no layer ships `.stow-local-ignore` — which shale writes itself — or
 shale itself, that `~/.dotfiles/current` is a directory rather than a file or a link to one, that the
-build lock is neither held nor uncreatable, that nothing in `~/.dotfiles` is a stray, and that no
+build lock is neither held nor uncreatable, that nothing in `~/.dotfiles` is a stray, that neither
+`current.new` nor `current.old` has been left beside `current`, and that no
 link in `$HOME` points into the built tree at a path it no longer provides. Where a `.stowrc` exists
 it names the stow options that file sets, because several of them change an apply and three of them
 make it do nothing at all. It changes nothing itself.
@@ -351,8 +353,9 @@ overwrites, and how to carry on from a block that stopped.
 - A shale that is killed outright — `kill -9`, or the machine losing power — leaves its lock
   directory behind, and a `~/.dotfiles/current.new` as well if it died mid-build. Shale never
   reclaims a lock, because nothing it can read tells a live holder from a dead one. `doctor` reports
-  the lock and names the command that clears it; it says nothing about `current.new`, which the next
-  build removes once the lock is gone.
+  the lock and names the command that clears it, and notes `current.new` and any `current.old` beside
+  it, saying what each is. It does not promise the next build will remove them while the lock is
+  still there, because that build will not run: clear the lock and doctor says so instead.
 - Git cannot store an empty directory, so a layer that needs one ships a `.gitkeep`, which will
   appear in `$HOME`.
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -302,7 +302,7 @@ creates rather than copies — and a layer providing one fails the build, naming
 Never shale itself: applying a layer that ships it would replace the script with a link into
 `current/`. `shale doctor` reports that, judged against the path the running shale was invoked by.
 Run the installed copy — `~/.local/bin/shale doctor` — and the finding names the layer. Run the
-layer's own copy directly and you get `no problems found`, because no layer shadows *that* path.
+layer's own copy directly and there is no such finding, because no layer shadows *that* path.
 
 Watch for `~/.stowrc` and `~/.dotfiles/.stowrc`. Their `--ignore` patterns are *appended* to the
 ones stow is already using rather than overriding them, so a stray `--ignore=zshrc` leaves
@@ -366,10 +366,10 @@ a `current` that is not a directory — the two lines about the next build are r
 are still named; what changes is that nothing promises you a `current.old` that a refused build
 never creates.
 
-`doctor` sees this only in the window between the file arriving and the next build. Afterwards the
-built copy is the layer's again and there is nothing left to notice, so recovery is `current.old`
-and one build deep. If you use `stow --adopt` against `current/`, run `shale doctor` before you
-build.
+`doctor` names the files only in the window between one arriving and the next build. Afterwards the
+built copy is the layer's again and the mismatch is gone; what `doctor` says then is that
+`current.old` is there and that the next build removes it, so recovery is `current.old` and one
+build deep. If you use `stow --adopt` against `current/`, run `shale doctor` before you build.
 
 ## The everyday loop: build, and when to apply
 
@@ -377,11 +377,13 @@ Edit a file a layer already has, and `shale build` is the whole loop. `~/.zshrc`
 `current/`, so rebuilding the tree it points at makes the edit live at that instant — there is
 nothing for stow to do, because the link is already right.
 
-That build says nothing. It keeps `current.old` — the built copy your edit replaced was older than
+That build says nothing about the file you edited, beyond the `composed layer` line it prints for
+each layer. It keeps `current.old` — the built copy your edit replaced was older than
 the layer copy, which is the state a file moved into the tree also leaves, and shale keeps the
 previous tree either way — but it prints no message about it, because a message there is a message
 on every edit. `shale doctor` is where a built tree its layers have moved past is reported, and
-after a build there is nothing left for it to report.
+after a build the mismatch is gone; what doctor names then is `current.old` itself — what it holds,
+and that the next build removes it.
 
 `shale apply` is what you need when a **path** appears or disappears, since making and unmaking links
 is stow's job and nothing else does it:

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -17,9 +17,10 @@ will refuse a pile of conflicts, `--adopt` is what a search turns up for clearin
 moves your file out of `$HOME` and into `~/.dotfiles/current`, which is generated output that the
 next `shale build` overwrites. That build says nothing about it — it keeps the whole previous tree
 at `current.old`, so an adopted file survives one build and no more, and the build after that
-removes `current.old`. The command that tells you is `shale doctor`, and only while the file is
-still there: run it before you build, or copy the file into a layer instead and there is nothing to
-recover. The refusals themselves are covered below, each with what to do about it.
+removes `current.old`. The command that tells you is `shale doctor`: run it before you build and it
+names the file, run it after and it names `current.old` as a tree the next build removes. Or copy
+the file into a layer instead, and there is nothing to recover. The refusals themselves are covered
+below, each with what to do about it.
 
 ## Coming from plain files
 
@@ -317,8 +318,9 @@ same note from a `doctor` run any time after pulling a layer and before building
 to act on there —
 which is why it is a note and `doctor` still exits 0. Either way the previous tree is at
 `current.old` and your file is in it, until the next clean build removes it. After that build
-`doctor` cannot see it any more, because the built copy matches the layer again. Copy the file into
-a layer instead and there is nothing to recover.
+`doctor` cannot see the mismatch any more, because the built copy matches the layer again — what it
+still says is that `current.old` is there, what it holds and that the next build removes it, which is
+the last warning you get. Copy the file into a layer instead and there is nothing to recover.
 
 ## Links left behind after layers change
 
@@ -326,12 +328,14 @@ When a file leaves a layer, the next `shale apply` prunes its link. When an enti
 every layer, the links inside it are left dangling and the apply still exits 0: stow's unstow phase
 only visits directories the package still has.
 
-`shale doctor` finds them:
+Nothing says so at the moment it happens — that apply prints its `composed layer` line per layer and
+nothing else, and exits 0 — so run `shale doctor` after a change that takes a whole directory out of
+every layer. It is what finds them:
 
 ```
 shale: /home/you/.config/foo/a.conf points at /home/you/.dotfiles/current/.config/foo/a.conf, which the built tree no longer provides
-shale: stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links
-shale:   remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying
+shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying
+shale:   stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links
 shale:   stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:
 shale:     stow -D -p --no-folding -d '/home/you/.dotfiles' -t '/home/you' current && shale apply
 shale:   earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory

--- a/shale
+++ b/shale
@@ -1746,14 +1746,19 @@ EOF
   qdots=$QUOTED
   shell_quote "$HOME"
   qhome=$QUOTED
-  remedy=('stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links')
+  # The remedy leads and the reason for it follows, indented under it.  Below
+  # the cap this note is printed under the findings, and report leaves its first
+  # line unindented: a sentence there about what stow prunes reads as one more
+  # finding, against a summary that has just counted them.  An imperative reads
+  # as the answer to them, which is what this block is.
   if [ "$n" -le "$cap" ]; then
-    remedy+=('remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying')
+    remedy=('remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying')
   else
     # The findings are below the remedy in this shape, and most of them are not
     # printed at all, so there is nothing 'named above' to point at.
-    remedy+=('remove them; the built tree is correct, and nothing needs rebuilding or reapplying')
+    remedy=('remove them; the built tree is correct, and nothing needs rebuilding or reapplying')
   fi
+  remedy+=('stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links')
   remedy+=('stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
     "  stow -D -p --no-folding -d $qdots -t $qhome current && shale apply" \
     'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory')
@@ -2277,7 +2282,7 @@ cmd_apply() {
 # before it found, and only the finding count decides the exit status.
 cmd_doctor() {
   local tool i name path root dir entry leaf known remedy qlock lines layers
-  local pending
+  local pending removed
 
   FINDINGS=0
   NOTES=0
@@ -2551,6 +2556,63 @@ cmd_doctor() {
   # Last, because it is the only check that walks the whole of $HOME and the only
   # one that means anything only once everything above it is sound.
   audit_broken_links
+
+  # Build's two working names, after both walks: 'the next build' is a line to
+  # print only once every check above has settled BUILD_BLOCKED, and where there
+  # is no tree at $CUR this is what qualifies the build the check above has just
+  # offered.  Two existence tests and no walk - what is inside either of them is
+  # not doctor's to say.  Notes rather than findings: neither stops a build, and
+  # the next build reaps both, which is also why they are otherwise invisible -
+  # the stray check above skips both names, shale owning them.
+  removed='the next build removes it'
+  if [ "$BUILD_BLOCKED" -gt 0 ]; then
+    removed='no build will run until the problems above are fixed, so it stays where it is'
+  fi
+  if [ -e "$NEW" ] || [ -L "$NEW" ]; then
+    if [ -d "$NEW" ] && [ ! -L "$NEW" ]; then
+      note "$NEW is left over from a build that did not finish" \
+        "shale composes a build there and renames it onto $CUR, and nothing reads it after that" \
+        "$removed"
+    else
+      # Not a tree shale composed, so nothing is claimed about what it holds.
+      note "$NEW is at the path shale composes every build into" \
+        'shale clears that path before it composes' \
+        "$removed"
+    fi
+  fi
+  if [ -e "$OLD" ] || [ -L "$OLD" ]; then
+    if [ ! -d "$OLD" ] || [ -L "$OLD" ]; then
+      note "$OLD is at the path a build moves $CUR aside to" \
+        'shale clears that path before it swaps' \
+        "$removed"
+    elif [ -d "$CUR" ] && [ ! -L "$CUR" ]; then
+      # What the path is for, never what is in it: nothing here has looked, and
+      # a build that kept it because one file differed leaves a whole tree, while
+      # an empty one told that it holds the last copy of something is a lie in
+      # the direction that costs a reader time.
+      note "$OLD is where a build leaves the tree it replaced" \
+        'a build keeps it where it replaced a file that did not match the layer copy providing it' \
+        "$removed" \
+        'copy anything in it you want to keep into a layer first'
+    else
+      # The shape a kill between the two renames leaves, and the one a hand that
+      # removed $CUR leaves too.  Only what is on disk is stated: the composed
+      # tree still standing at $NEW is what distinguishes the interrupted build
+      # from the removal, and without it no cause is named.  $CUR is spoken for
+      # only where there is nothing at it at all - every other shape it can be
+      # in is a finding above, in the words build refuses it with.
+      lines=("$OLD is where a build leaves the tree it replaced")
+      { [ -e "$CUR" ] || [ -L "$CUR" ]; } ||
+        lines[${#lines[@]}]="there is nothing at $CUR"
+      if [ -e "$NEW" ] || [ -L "$NEW" ]; then
+        lines[${#lines[@]}]="a build was interrupted between moving it there and moving the tree it had composed into place, which is still at $NEW"
+      fi
+      lines[${#lines[@]}]='it may hold the only copy of anything that was moved into the built tree rather than composed from a layer'
+      lines[${#lines[@]}]=$removed
+      lines[${#lines[@]}]='copy anything in it you want to keep into a layer first'
+      note ${lines[@]+"${lines[@]}"}
+    fi
+  fi
 
   # 'no problems found' is the verdict on the findings and stays exactly that,
   # here and in the docs that quote it - the notes are not problems and this is

--- a/tests/run
+++ b/tests/run
@@ -5272,12 +5272,20 @@ test_doctor_notes_nothing_it_accounts_for() {
   conf 'base personal/base' 'local local'
   mklayer personal/base .zshrc
   mklayer local .zshrc
-  for name in current current.new current.old; do
-    sandbox_mkdir "$HOME/.dotfiles/$name"
-  done
+  sandbox_mkdir "$HOME/.dotfiles/current"
   run_shale doctor
   assert_status 0 "$shale_status"
   assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  # The other two names are a leftover tree apiece, and the check that owns them
+  # says what each is.  What none of the three is, ever, is a stray beside the
+  # config: this scan skips all of them by name.
+  for name in current.new current.old; do
+    sandbox_mkdir "$HOME/.dotfiles/$name"
+  done
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the leftover trees'
+  assert_not_contains "$shale_out" 'is not a configured layer' 'the leftover trees'
+  assert_not_contains "$shale_out" 'no build reads it' 'the leftover trees'
 }
 
 # The summary is the line a reader scanning for the verdict stops at, and it
@@ -5942,8 +5950,14 @@ test_doctor_a_link_into_the_built_tree_it_no_longer_provides_is_a_finding() {
     'stdout'
   # The delete leads, because it is the half that works on every version of stow;
   # the sweep under it names the version it needs, and says what happens below it.
+  # It leads the note as well as the remedy, so it is the unindented line: every
+  # other line of this block is detail under it, and an unindented one among the
+  # findings reads as one more of them against a summary that has counted them.
   assert_contains "$shale_out" \
-    'shale:   remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
+    'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
+    'stdout'
+  assert_contains "$shale_out" \
+    'shale:   stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links' \
     'stdout'
   assert_contains "$shale_out" \
     'shale:   stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
@@ -6005,7 +6019,7 @@ test_doctor_reports_the_links_a_directory_that_left_every_layer_kept() {
           *) seen="$seen finding" ;;
         esac
         ;;
-      'shale:   remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying')
+      'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying')
         seen="$seen remedy"
         ;;
       'shale: 3 problems found') seen="$seen summary" ;;
@@ -6053,7 +6067,9 @@ report_shape() {
         report_seen="$report_seen count"
         ;;
       'shale:   all of them are under '*) report_seen="$report_seen where" ;;
-      'shale:   remove '*) report_seen="$report_seen remedy" ;;
+      # Unindented below the cap, where it leads its note, and indented above
+      # it, where the count does.
+      'shale: remove '* | 'shale:   remove '*) report_seen="$report_seen remedy" ;;
       'shale: and '*' more, not named here') report_seen="$report_seen rest" ;;
       'shale: '*' problems found') report_seen="$report_seen summary" ;;
     esac
@@ -6134,7 +6150,7 @@ test_doctor_broken_links_up_to_the_cap_are_all_named_with_the_remedy_under_them(
   run_shale doctor
   assert_status 1 "$shale_status"
   assert_contains "$shale_out" \
-    'shale:   remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' 'stdout'
+    'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' 'stdout'
   assert_not_contains "$shale_out" 'point into the built tree at paths it no longer provides' 'stdout'
   assert_not_contains "$shale_out" 'not named here' 'stdout'
   assert_contains "$shale_out" 'shale: 10 problems found' 'stdout'
@@ -6511,6 +6527,208 @@ test_doctor_says_when_there_is_no_built_tree_to_check_links_against() {
   assert_contains "$shale_out" 'shale:   build one with: shale build' 'stdout'
   # Uncounted: an unbuilt tree is a state 'shale build' makes, not a defect.
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# ------------------------------------------------- doctor's leftover-tree cases
+#
+# The two names a build works under, both of which only a build that did not
+# finish leaves behind - and current.old also every build that replaced a file
+# not matching its layer copy.  Notes, not findings: neither stops a build, and
+# the next build removes both, which is also why nothing else in the report
+# mentions them - the stray scan skips both names because shale owns them.
+
+test_doctor_notes_a_leftover_scratch_tree() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  # What a compose killed part-way through leaves: the name, holding some of
+  # the tree.
+  sandbox_write "$HOME/.dotfiles/current.new" .zshrc 'half of a composed tree'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.new is left over from a build that did not finish" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   shale composes a build there and renames it onto $HOME/.dotfiles/current, and nothing reads it after that" \
+    'stdout'
+  assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  assert_empty "$shale_err" 'stderr'
+  # And the build that reaps it says nothing about it, which is what makes this
+  # a note about a state rather than a report of a problem.
+  run_shale build
+  assert_status 0 "$shale_status" 'the reaping build'
+  assert_missing "$HOME/.dotfiles/current.new" 'after the build'
+  assert_not_contains "$shale_out" 'current.new' 'the reaping build stdout'
+  assert_empty "$shale_err" 'the reaping build stderr'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the build'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report after the build'
+}
+
+# The tree a build keeps deliberately, which until now sat in ~/.dotfiles with
+# nothing saying what it was: the build that kept it named the one file, and one
+# build later that message is scrollback and the copy is gone.
+test_doctor_notes_the_tree_the_last_build_kept() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the first build'
+  assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  # '>|': the build above put this file here, and editing it is the point.
+  printf 'HAND EDITED\n' >|"$sandbox_path" || fail 'could not edit the built tree'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that keeps the tree'
+  assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   a build keeps it where it replaced a file that did not match the layer copy providing it' \
+    'stdout'
+  assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   copy anything in it you want to keep into a layer first' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# The state a kill between the two renames leaves, which is the one where saying
+# nothing costs something: current.old is the tree $HOME is linked against and
+# may be the only copy of anything adopted into it, and the note above it has
+# just offered a build that deletes it.  The note has to sit under that offer.
+#
+# The composed tree still standing at current.new is what says a build was
+# interrupted rather than that a hand removed current, and it is the only thing
+# that does; the case below is the same shape without it.
+test_doctor_names_the_tree_left_at_current_old_when_current_is_gone() {
+  local line seen
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.dotfiles"
+  sandbox_leaf "$sandbox_dir" current.old new
+  mv "$HOME/.dotfiles/current" "$sandbox_path" || fail 'could not move the tree aside'
+  sandbox_write "$HOME/.dotfiles/current.new" .zshrc 'the tree that was not installed'
+  assert_missing "$HOME/.dotfiles/current" 'the built tree'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   there is nothing at $HOME/.dotfiles/current" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   a build was interrupted between moving it there and moving the tree it had composed into place, which is still at $HOME/.dotfiles/current.new" \
+    'stdout'
+  assert_contains "$shale_out" \
+    'shale:   it may hold the only copy of anything that was moved into the built tree rather than composed from a layer' \
+    'stdout'
+  assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   copy anything in it you want to keep into a layer first' 'stdout'
+  # The scratch tree is named as well, and the two are different states with
+  # different words: only one of them holds anything worth keeping.
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.new is left over from a build that did not finish" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the 3 notes above' 'stdout'
+  # Under the build it qualifies, not above it.
+  seen=
+  while IFS= read -r line; do
+    case "$line" in
+      'shale:   build one with: shale build') seen="$seen build" ;;
+      'shale: '*'/current.old is where a build leaves the tree it replaced')
+        seen="$seen kept"
+        ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq ' build kept' "$seen" 'the order of the report'
+  # And the danger the note names, carried out: the build the line above offers
+  # is the one that removes the only copy.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_missing "$HOME/.dotfiles/current.old" 'after the build'
+  assert_exists "$HOME/.dotfiles/current/.zshrc" 'the rebuilt tree'
+}
+
+# The same tree at current.old with nothing at current and no current.new, which
+# no interrupted build can produce: a kill between the two renames leaves the
+# tree it composed standing at current.new, so this shape is a hand that removed
+# current.  The remedy is the same one; the cause is not shale's to guess.
+test_doctor_names_no_interrupted_build_where_there_cannot_have_been_one() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_mkdir "$HOME/.dotfiles"
+  sandbox_leaf "$sandbox_dir" current.old new
+  mv "$HOME/.dotfiles/current" "$sandbox_path" || fail 'could not move the tree aside'
+  assert_missing "$HOME/.dotfiles/current" 'the built tree'
+  assert_missing "$HOME/.dotfiles/current.new" 'the scratch tree'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   there is nothing at $HOME/.dotfiles/current" 'stdout'
+  assert_not_contains "$shale_out" 'a build was interrupted' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   it may hold the only copy of anything that was moved into the built tree rather than composed from a layer' \
+    'stdout'
+  assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the 2 notes above' 'stdout'
+}
+
+# Nothing has looked inside either tree, so nothing may say what is in one.  An
+# empty current.old is the state a build that composed no file at all leaves,
+# and 'copy anything in it you want to keep' is the whole of what a report that
+# did not walk it can offer.
+test_doctor_claims_no_contents_for_a_tree_it_has_not_walked() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_mkdir "$HOME/.dotfiles/current.old"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_not_contains "$shale_out" 'holds what' 'stdout'
+  assert_not_contains "$shale_out" 'it is the only copy' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+}
+
+# Every line doctor prints that says what the next build does is gated on there
+# being one, and these two are printed after every other check has had its say
+# about whether there is.
+test_doctor_promises_no_reaping_from_a_build_that_will_not_run() {
+  conf 'base personal/base' 'work work'
+  mklayer personal/base .zshrc
+  mklayer work .vimrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_write "$HOME/.dotfiles/current.new" .zshrc 'half of a composed tree'
+  # The collision every build from now on exits 1 on.
+  mklayer personal/base both/inner
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.new is left over from a build that did not finish" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   no build will run until the problems above are fixed, so it stays where it is' 'stdout'
+  assert_not_contains "$shale_out" 'the next build removes it' 'stdout'
+  run_shale build
+  assert_status 1 "$shale_status" 'the build the line refuses to promise'
 }
 
 # The plausible layering mistake, and the one 'shale which' already answers on
@@ -7747,7 +7965,7 @@ test_doctor_removing_the_links_it_names_clears_the_findings() {
   assert_status 1 "$shale_status"
   assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
   assert_contains "$shale_out" \
-    'shale:   remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
+    'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
     'stdout'
   removed=0
   while IFS= read -r line; do


### PR DESCRIPTION
Closes #84, the last of the six v1 trial issues.

doctor now notes a leftover current.new and current.old. The state that mattered is a kill between the two renames, where doctor previously recommended a build that would delete current.old - possibly the only surviving copy of an adopted file.

The functional gate constructed that state, confirmed the warning is true by running the build, and checked every odd shape against what is actually on disk. It also caught two claims about contents doctor never walked, and a false claim in my own README text.

--version was decided against: the closed four-word surface is a documented promise. Apply-time orphan detection was decided against: doctor already finds them, and the everyday path stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)