### PR TITLE
Put the exit check before the block it protects

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,14 @@ stow -D -d ~/.dotfiles -t ~ current
 
 It leaves your layers, your config and the built tree alone; `shale apply` puts the links back. To
 leave shale altogether and keep your dotfiles as ordinary files, copy the built tree back over them
-first — as one chained block, so a step that fails stops the ones after it:
+first. Run this before you do, while the links are still there — it names every file in `$HOME` the
+copy would overwrite, and on a `$HOME` only shale writes to it prints nothing:
+
+```sh
+( cd ~/.dotfiles/current && find . ! -type d -exec sh -c 'for p; do p=${p#./}; [ -L "$HOME/$p" ] || [ ! -e "$HOME/$p" ] || printf "%s\n" "$HOME/$p"; done' sh {} + )
+```
+
+Then the copy, as one chained block so a step that fails stops the ones after it:
 
 ```sh
 stow -D -d ~/.dotfiles -t ~ current &&
@@ -328,13 +335,7 @@ The chain cannot help where nothing fails, and on stow 2.4.1 nothing does: it un
 2.3.1 refuses, and `cp -RL` then overwrites whatever `$HOME` holds at a path the built tree provides.
 That is only ever a file shale never managed — one you edited in place so that it replaced the link,
 or one stow was never allowed to link, which is what a repository-root layer's own `README.md` is.
-Run this first and it names every one of them:
-
-```sh
-( cd ~/.dotfiles/current && find . ! -type d -exec sh -c 'for p; do p=${p#./}; [ -L "$HOME/$p" ] || [ ! -e "$HOME/$p" ] || printf "%s\n" "$HOME/$p"; done' sh {} + )
-```
-
-On a `$HOME` only shale writes to it prints nothing.
+Both are on the list the check above prints, which is the only warning either gets.
 
 What the copy deposits is exactly what `ls -a ~/.dotfiles/current` lists. The order matters, and
 [docs/migrating.md](docs/migrating.md) says what `cp` here does and does not preserve, what it

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -242,6 +242,27 @@ tmux's `source-file` keeps the last value, as git's include does, so it goes at 
 directory; the base layer's `tmux.conf` still names what it sources, and the layers supply those
 files.
 
+Whichever tool it is, a higher layer must not replace the file that carries the include. Reconciling
+`~/.gitconfig` the ordinary way — a whole `.gitconfig` in `local`, per *Replacing a file, and adding
+one* above — takes the `[include]` line with the rest of the file, and every fragment it named stops
+being read. Nothing reports it, and `which` is the wrong question to ask: the fragment is still in
+the built tree, still linked into `$HOME`, and still the winner at its own path. Only the tool
+knows, and what it answers with is the overriding file's value rather than the fragment's:
+
+```
+$ git config --get user.email
+me@example.com
+
+$ shale which .config/git/conf.d/50-work.conf
+winner    local  /home/you/.dotfiles/local/.config/git/conf.d/50-work.conf
+```
+
+A value you put in a fragment coming back as something else — or as nothing, exit 1 — is how you
+notice. Then ask `which` about the *including* file rather than the fragment: a `shadowed` line
+under `.gitconfig` says a higher layer replaced it, and that layer's copy has to carry the
+`[include]` too. Where both layers have a claim on the file itself, that copy is the one to add it
+to.
+
 ## Symlinks in a layer
 
 A symlink is copied as a symlink, target text unchanged, and it is a leaf: shale never recurses into

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -384,7 +384,21 @@ apply again.
 
 ## Leaving shale, with your dotfiles
 
-Four commands, in this order, each one conditional on the one before it. Paste the block whole:
+Run this first, before the block below and while the links are still there. It names every file in
+`$HOME` that the copy is about to overwrite:
+
+```sh
+( cd ~/.dotfiles/current && find . ! -type d -exec sh -c 'for p; do p=${p#./}; [ -L "$HOME/$p" ] || [ ! -e "$HOME/$p" ] || printf "%s\n" "$HOME/$p"; done' sh {} + )
+```
+
+Every path it prints is one the copy will overwrite; move each aside, or fold it into a layer,
+first. On a `$HOME` that only shale writes to it prints nothing at all. It is a separate command
+rather than a flag on the copy because GNU `cp` has a `-n` that skips an existing destination
+instead of overwriting it, and GNU coreutils 9.4 answers every use of it with `warning: behavior of
+-n is non-portable and may change in future` — so the recipe stays as it is and the check does the
+work. What can be on that list, and why nothing in the block itself stops on it, is below the block.
+
+Then four commands, in this order, each one conditional on the one before it. Paste the block whole:
 
 ```sh
 stow -D -d ~/.dotfiles -t ~ current &&
@@ -413,20 +427,9 @@ instead of writing through it, is one. A path the built tree carries but stow wa
 is the other, which is what `.stow-local-ignore` does to the `README.md`, `LICENSE` and `COPYING` at
 the top of a repository-root layer: your own `~/README.md` has no link there for `cp` to collide
 with, so the repository's lands on top of it. Neither is a conflict to stow or a refusal to `cp`, so
-neither stops the block, and the fourth command then deletes the copy in `~/.dotfiles`.
-
-This names every one of them, and it has to be run before the block, while the links are still
-there:
-
-```sh
-( cd ~/.dotfiles/current && find . ! -type d -exec sh -c 'for p; do p=${p#./}; [ -L "$HOME/$p" ] || [ ! -e "$HOME/$p" ] || printf "%s\n" "$HOME/$p"; done' sh {} + )
-```
-
-Every path it prints is one the copy will overwrite; move each aside, or fold it into a layer, first.
-On a `$HOME` that only shale writes to it prints nothing at all. GNU `cp` has a `-n` that skips an
-existing destination rather than overwriting it, and GNU coreutils 9.4 answers every use of it with
-`warning: behavior of -n is non-portable and may change in future`, so the recipe stays as it is and
-the check does the work.
+neither stops the block, and the fourth command then deletes the copy in `~/.dotfiles`. The check at
+the top of this section names both, which is the whole of why it is run before the block rather than
+after it.
 
 `.` in `~/.dotfiles/current/.` is what makes the copy the *contents* of the tree rather than a
 `~/current` directory, and it takes the dotfiles with it. `-L` reads through a symlink a layer ships
@@ -503,8 +506,8 @@ The newer stow does not refuse at all. 2.4.1 — the likelier one to be on a Mac
 where a Mac gets stow — unstows straight past that file and exits 0, and the block then runs to the
 end: the copy replaces your edited file with the built tree's version of it, and the fourth command
 deletes the tree that version came from. The whole run exits 0 with nothing on either stream.
-Chaining cannot catch that one, because nothing failed. The check above is what catches it, and only
-if you run it before the block.
+Chaining cannot catch that one, because nothing failed. The check this section opens with is what
+catches it, and it can only catch it there — run after the block, it has nothing left to look at.
 
 That is the whole of shale's footprint: it writes nothing outside `~/.dotfiles`, and the script is
 the copy you made yourself, at `~/.local/bin/shale` or wherever you put it. Delete that too and


### PR DESCRIPTION
Closes #94.

The pre-flight check that names every file the copy would overwrite now opens the section in both README and docs/migrating.md, instead of appearing several paragraphs after the destructive block. It is the only defence against two silent losses those documents describe, and on stow 2.4.1 the chain never stops because nothing fails.

docs/layers.md now also says that a higher layer replacing the file which carries an include detaches every fragment below it - reproduced end to end with real git, including that which still reports the fragment as the winner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)