### PR TITLE
Write stow's whole default ignore list, not three patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,15 @@ about a file the build never touches. A
 build composes into `~/.dotfiles/current.new` and renames that into place, so a `current.new` left
 lying about is a run that died mid-build and is safe to delete.
 
-One file in there is shale's own rather than a copy: `current/.stow-local-ignore`, which keeps a
-`README`, `LICENSE` or `COPYING` at the top of the built tree out of `$HOME`. A layer that ships a
-`.stow-local-ignore` at its own top level fails the build, naming the layer; one further down is an
-ordinary file and is copied like any other.
+One file in there is shale's own rather than a copy: `current/.stow-local-ignore`, which is GNU Stow
+2.4.1's default ignore list. It keeps a `README`, `LICENSE` or `COPYING` at the top of the built tree
+out of `$HOME`, and at any depth a `.gitignore`, a `.gitmodules`, an editor backup like `.zshrc~`, an
+emacs autosave or lock file like `#notes#` or `.#lockfile`, and
+the furniture of RCS, CVS, Subversion, Darcs and Mercurial. Stow reads a package's own list *instead
+of* its built-in one rather than as well, so the file has to carry the whole of it; writing 2.4.1's
+is also what makes stow 2.3.1 apply the same tree. A layer that ships a `.stow-local-ignore` at its
+own top level fails the build, naming the layer; one further down is an ordinary file and is copied
+like any other.
 
 To update your layers, pull each clone root with git, then apply:
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,9 +1,11 @@
 # Authoring a layer
 
 A layer is a directory tree that mirrors your home directory. Everything in it is copied, path for
-path, into `~/.dotfiles/current`, and everything in `current` is linked into `$HOME`. A file at
-`personal/base/.config/nvim/init.lua` becomes `~/.config/nvim/init.lua`. There is nothing else to
-learn about the mapping.
+path, into `~/.dotfiles/current`, and almost everything in `current` is linked into `$HOME`. A file
+at `personal/base/.config/nvim/init.lua` becomes `~/.config/nvim/init.lua`. The exception is the
+handful of names stow never links — version-control furniture, editor backups and emacs autosaves —
+which *Where a layer lives* below sets out; apart from those there is nothing else to learn about
+the mapping.
 
 Shale copies files. It never merges them, never templates them and never reads what is inside one.
 Fragment directories, numeric prefixes and shared helper files are conventions for *your* layers,
@@ -18,12 +20,15 @@ Give a layer a subdirectory of its repository rather than the repository root:
 base    personal/base     git@github.com:you/dotfiles.git
 ```
 
-Shale skips `.git` at every depth, and the built tree carries a `.stow-local-ignore` that keeps a
-top-level `README*`, `LICENSE*` and `COPYING` out of `$HOME`. Nothing else is filtered — a
-`.gitignore` at the top of the layer becomes `~/.gitignore`, and a `README.md` further down becomes
-a real link too. Name the repository root as the layer and `~/.github/`, `~/Makefile` and
-`~/CONTRIBUTING.md` join them. The subdirectory is what keeps the repository's own furniture out of
-the image.
+Shale skips `.git` at every depth, and the built tree carries a `.stow-local-ignore` holding GNU
+Stow's own default ignore list, which keeps a top-level `README*`, `LICENSE*` and `COPYING` out of
+`$HOME`, and at any depth a `.gitignore`, a `.gitmodules`, an editor backup like `.zshrc~`, an emacs
+autosave like `#notes#` or lock file like `.#init.el`, and the furniture of RCS, CVS, Subversion,
+Darcs and Mercurial. Nothing else is filtered — `.gitconfig`,
+`.gitkeep` and `~/.config/git/ignore` are matched by none of it, and a `README.md` below the top of
+the layer becomes a real link. Name the repository root as the layer and `~/.github/`, `~/Makefile`
+and `~/CONTRIBUTING.md` join them. The subdirectory is what keeps the repository's own furniture out
+of the image.
 
 Several layers can come from one repository — `personal/base` and `personal/wsl` are two
 directories in one clone at `~/.dotfiles/personal`, so the url is given once, on the first of them.
@@ -70,7 +75,7 @@ $ diff -u /home/you/.dotfiles/personal/base/.gitconfig /home/you/.dotfiles/local
 -	st = status
 -	lg = log --oneline
 -[core]
--	excludesfile = ~/.gitignore
+-	excludesfile = ~/.config/git/ignore
 -[include]
 -	path = ~/.config/git/conf.d/50-work.conf
 +[user]

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -369,6 +369,50 @@ longer holds. It also says when `chkstow` could not walk all of `$HOME` — a `.
 marker makes it skip a directory — because a walk that stopped early has nothing to say about what it
 did not reach. Either way the walk is not quick.
 
+## Links left behind by the ignore list itself
+
+A shale old enough to have written a three-line `current/.stow-local-ignore` — `^/README.*`,
+`^/LICENSE.*`, `^/COPYING` and nothing else — linked everything else a layer held, including the
+files GNU Stow's own default list leaves out. Shale now writes that whole default list, so a fresh
+machine never links them. **An upgraded machine keeps the links it already made**, and nothing says
+so at any point.
+
+The apply that upgrades you cannot remove them. `stow -R` unstows before it restows, and its unstow
+phase reads the *new* list, in which those paths are invisible — so it walks straight past them.
+Both stow versions behave this way; the apply exits 0 and prints only its `composed layer` lines.
+`shale doctor` is silent too, and correctly: the links are live rather than dangling, and a layer
+really does provide the path they point at. Nothing here is broken. It is only that two machines
+running the same layers now differ, at exactly the paths the ignore list covers.
+
+This lists them, and nothing else — every symlink in `$HOME` that points into `current/` at a path
+the list now suppresses, including one below a suppressed directory such as `CVS/`:
+
+```sh
+find ~ -type l -exec sh -c '
+for l; do
+  case $(readlink "$l") in *.dotfiles/current/*) ;; *) continue ;; esac
+  r=${l#"$HOME"/}
+  while :; do
+    case ${r##*/} in
+      *~ | "#"*"#" | ".#"* | *,v | .gitignore | .gitmodules | .cvsignore | RCS | CVS | .svn | _darcs | .hg)
+        printf "%s\n" "$l"; break ;;
+    esac
+    case $r in */*) r=${r%/*} ;; *) break ;; esac
+  done
+done' sh {} +
+```
+
+On a machine that only ever ran the current shale it prints nothing. `~/.config/git/ignore`,
+`~/.gitconfig` and a `.gitkeep` are not matched by any of those patterns and never appear.
+
+Delete what it names. `current` is already correct and nothing needs rebuilding or reapplying
+afterwards, exactly as for the dangling links above. A directory that held nothing but such links —
+`~/CVS`, or a `~/.zsh` whose only file was a `.gitignore` — is left behind empty; `rmdir` it if you
+want it gone.
+
+`stow -D` on its own does not help and is not the answer here: its unstow phase reads the same new
+list, so it leaves every one of these in place while removing everything else.
+
 ## Backing out one apply
 
 ```sh
@@ -424,12 +468,14 @@ worked, the paths shale managed are empty, so the only things left for the copy 
 ones shale never managed — which is to say, the ones that are yours alone. Two of those arrive
 without anything failing anywhere. A file you edited in place, so that your editor replaced the link
 instead of writing through it, is one. A path the built tree carries but stow was told never to link
-is the other, which is what `.stow-local-ignore` does to the `README.md`, `LICENSE` and `COPYING` at
-the top of a repository-root layer: your own `~/README.md` has no link there for `cp` to collide
-with, so the repository's lands on top of it. Neither is a conflict to stow or a refusal to `cp`, so
-neither stops the block, and the fourth command then deletes the copy in `~/.dotfiles`. The check at
-the top of this section names both, which is the whole of why it is run before the block rather than
-after it.
+is the other, and `.stow-local-ignore` names a good many: a `README.md`, `LICENSE` or `COPYING` at
+the top of a repository-root layer, and at any depth a `.gitignore`, a `.gitmodules`, an editor
+backup like `.zshrc~`, an emacs autosave like `#notes#` or lock file like `.#init.el`, and the
+furniture of RCS, CVS, Subversion, Darcs and Mercurial. Your own `~/README.md` and `~/.gitignore`
+have no link there for `cp` to collide with, so the layer's land on top of them. Neither is a
+conflict to stow or a refusal to `cp`, so neither stops the block, and the fourth command then
+deletes the copy in `~/.dotfiles`. The check at the top of this section names both, which is the
+whole of why it is run before the block rather than after it.
 
 `.` in `~/.dotfiles/current/.` is what makes the copy the *contents* of the tree rather than a
 `~/current` directory, and it takes the dotfiles with it. `-L` reads through a symlink a layer ships
@@ -455,11 +501,11 @@ is wrong in that state; the only thing left is the fourth command.
 What lands is exactly what the built tree holds, and shale generates one file of its own in there:
 `~/.stow-local-ignore`, the third command. Run `ls -a ~/.dotfiles/current` before the copy and that
 listing is what you are about to get — worth doing, because this copy pays no attention to
-`.stow-local-ignore` and so brings out whatever it was suppressing. Give a layer a subdirectory of
-its repository, as `docs/layers.md` says to, and that is nothing at all. Name a repository root as a
-layer instead and its `README.md` and `LICENSE` have been in the built tree all along, kept out of
-`$HOME` only by that ignore file; the copy puts them in `$HOME`, on top of a `README.md` or
-`LICENSE` of your own if you keep one there.
+`.stow-local-ignore` and so brings out whatever it was suppressing. A layer's own `.gitignore` or
+`.gitmodules` is the usual one, and a `.zshrc~` or `#notes#` it committed by accident is the other.
+Name a repository root as a layer and its `README.md` and `LICENSE` join them, having been in the
+tree all along and kept out of `$HOME` only by that ignore file; the copy puts them in `$HOME`, on
+top of a `README.md` or `LICENSE` of your own if you keep one there.
 
 Modes come across for the bit that matters: an executable stays executable, and a `~/.netrc` at 600
 arrives at 600. Two smaller things `cp` does here without `-p`, which are why `-p` is deliberately

--- a/examples/minimal.conf
+++ b/examples/minimal.conf
@@ -8,10 +8,12 @@
 # component — the clone root — so this clones the repository to
 # ~/.dotfiles/personal and uses the base directory inside it as the layer.
 # Name the clone root itself as the layer instead and everything the repository
-# keeps for its own sake is linked into your home directory: .gitignore,
-# .github, docs, Makefile, CONTRIBUTING.md.  Shale leaves out .git, README,
-# LICENSE and COPYING and nothing else; the subdirectory is what keeps the rest
-# out.
+# keeps for its own sake is linked into your home directory: .github, docs,
+# Makefile, CONTRIBUTING.md.  Shale leaves out .git; stow's default ignore
+# list, which every build writes into the built tree, leaves out a top-level
+# README, LICENSE and COPYING, and at any depth .gitignore, .gitmodules,
+# editor backups like .zshrc~ and emacs autosaves like #notes# and .#init.el.
+# Nothing else; the subdirectory is what keeps the rest out.
 
 base    personal/base     https://github.com/you/dotfiles.git
 local   local

--- a/examples/wsl-work.conf
+++ b/examples/wsl-work.conf
@@ -18,7 +18,7 @@ local   local
 # work/base is a subdirectory of its own clone at ~/.dotfiles/work, for the
 # same reason personal/base is a subdirectory of ~/.dotfiles/personal: name
 # the clone root itself as the layer and everything the repository keeps for
-# its own sake — .gitignore, .github, Makefile — is linked into $HOME too.
+# its own sake — .github, Makefile, CONTRIBUTING.md — is linked into $HOME too.
 #
 # `github-work` is an ssh config Host alias pointing at github.com with a
 # different IdentityFile; that is how two accounts coexist.

--- a/shale
+++ b/shale
@@ -2114,10 +2114,53 @@ cmd_build() {
     die "$CUR not rebuilt"
   fi
 
-  # A package-local ignore list replaces stow's built-in one wholesale, so these
-  # three root-anchored patterns are all of it - and the built-in list is what
-  # would otherwise keep a layer's .gitignore out of $HOME with apply exiting 0.
-  printf '%s\n' '^/README.*' '^/LICENSE.*' '^/COPYING' \
+  # A package-local ignore list replaces stow's built-in one wholesale rather
+  # than adding to it, so whatever is missing here is linked into $HOME with
+  # apply exiting 0.  Everything below the nine-line header is GNU Stow 2.4.1's
+  # default-ignore-list verbatim, so that nothing plain stow skips stops being
+  # skipped; its last three entries are the ^/README.*, ^/LICENSE.* and
+  # ^/COPYING shale once wrote on their own.  Upstream's inline comments are
+  # kept because both 2.3.1 and 2.4.1 strip a '#' that has whitespace before
+  # it, leaving the pattern alone.  Upstream's own first line, which says
+  # comments and blank lines are allowed, is the one thing not reproduced: it
+  # invites editing a file every build overwrites, and the header says so
+  # instead.
+  #
+  # On 2.4.1 the file changes no outcome, and that is not a reason to delete
+  # it: 2.3.1's built-in list has no \.gitmodules, so writing 2.4.1's list is
+  # the whole of what makes an apply land the same tree on both.
+  printf '%s\n' \
+    "# Written by shale on every build, which overwrites whatever is here:" \
+    "# edit a layer, not this file." \
+    '#' \
+    "# Below this header is GNU Stow 2.4.1's default-ignore-list, verbatim." \
+    "# Stow reads a package's own ignore list instead of its built-in one" \
+    "# rather than as well, so the whole of it has to be here or an apply" \
+    "# links what plain stow skips.  Writing 2.4.1's list rather than the" \
+    "# installed stow's is also what makes stow 2.3.1 apply the same tree:" \
+    '# 2.3.1 built in the same list without \.gitmodules.' \
+    '' \
+    'RCS' \
+    '.+,v' \
+    '' \
+    'CVS' \
+    '\.\#.+       # CVS conflict files / emacs lock files' \
+    '\.cvsignore' \
+    '' \
+    '\.svn' \
+    '_darcs' \
+    '\.hg' \
+    '' \
+    '\.git' \
+    '\.gitignore' \
+    '\.gitmodules' \
+    '' \
+    '.+~          # emacs backup files' \
+    '\#.*\#       # emacs autosave files' \
+    '' \
+    '^/README.*' \
+    '^/LICENSE.*' \
+    '^/COPYING' \
     >"$NEW/.stow-local-ignore" ||
     die "could not write $NEW/.stow-local-ignore"
 

--- a/tests/run
+++ b/tests/run
@@ -2203,8 +2203,8 @@ test_build_dot_entries_are_never_composed() {
 }
 
 # Skipped at every depth, because a layer is a working repo.  .gitignore is not
-# skipped: it is a file you want in your home directory, and the whole point of
-# the ignore list build writes.
+# skipped: the copy is unfiltered, and what does or does not reach $HOME from it
+# is stow's ignore list rather than anything build decides.
 test_build_git_directories_stay_out_of_current() {
   conf 'base personal/base'
   mklayer personal/base .git/config 'GIT'
@@ -3025,15 +3025,57 @@ test_build_refuses_a_layer_shipping_a_stow_local_ignore() {
   assert_missing "$HOME/.dotfiles/current.new"
 }
 
-# Exactly these three, because a package-local list replaces stow's built-in one
-# wholesale: without the file a layer's .gitignore silently never reaches $HOME,
-# and with the wrong contents a layer-root README does.
+# A nine-line shale header and then GNU Stow 2.4.1's default-ignore-list
+# verbatim, asserted whole because a package-local list replaces stow's built-in
+# one wholesale rather than adding to it: a line dropped from here is a file
+# plain stow skips that an apply then links, with everything exiting 0.  The
+# last three are the ones shale used to write on their own.  \.gitmodules is in
+# 2.4.1's built-in list and not in 2.3.1's, so this file is also what makes both
+# versions land the same tree.
+#
+# The header replaces upstream's own first line, which says comments and blank
+# lines are allowed and so invites editing a file every build overwrites.  Keep
+# it nine lines and 'diff <(tail -n +10 file) <(tail -n +2 default-ignore-list)'
+# stays clean against upstream, which is how the body below is checked.
+#
+# The inline comments further down are upstream's.  They are kept rather than
+# stripped because both versions of stow strip a '#' that has whitespace before
+# it themselves; test_apply_skips_what_stows_built_in_list_skips is what pins
+# that, by asserting the two patterns carrying a comment still match.
 test_build_writes_the_stow_local_ignore_list() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
   run_shale build
   assert_status 0 "$shale_status"
-  assert_eq '^/README.*
+  assert_eq '# Written by shale on every build, which overwrites whatever is here:
+# edit a layer, not this file.
+#
+# Below this header is GNU Stow 2.4.1'"'"'s default-ignore-list, verbatim.
+# Stow reads a package'"'"'s own ignore list instead of its built-in one
+# rather than as well, so the whole of it has to be here or an apply
+# links what plain stow skips.  Writing 2.4.1'"'"'s list rather than the
+# installed stow'"'"'s is also what makes stow 2.3.1 apply the same tree:
+# 2.3.1 built in the same list without \.gitmodules.
+
+RCS
+.+,v
+
+CVS
+\.\#.+       # CVS conflict files / emacs lock files
+\.cvsignore
+
+\.svn
+_darcs
+\.hg
+
+\.git
+\.gitignore
+\.gitmodules
+
+.+~          # emacs backup files
+\#.*\#       # emacs autosave files
+
+^/README.*
 ^/LICENSE.*
 ^/COPYING' "$(cat "$HOME/.dotfiles/current/.stow-local-ignore")" 'the ignore list'
 }
@@ -4428,20 +4470,57 @@ test_apply_makes_real_directories_with_per_file_links() {
   assert_missing "$HOME/.dotfiles/current/.config/nvim/shada" 'the built tree'
 }
 
-# stow's built-in ignore list matches .gitignore by basename at any depth, so
-# this link exists only because build replaced that list wholesale with one of
-# its own.  Without it an ordinary global gitignore never reaches $HOME and
-# every command still reports success.
-test_apply_links_a_layers_gitignore_into_home() {
+# The generated list is stow's own built-in one, so an apply leaves out exactly
+# what plain stow leaves out.  Each name below is a different entry of that
+# list, and the two carrying an inline comment upstream - '.+~' and '\#.*\#' -
+# are here because a comment stow did not strip would be part of the pattern and
+# neither file would be skipped.  \.gitmodules is 2.4.1's entry and not 2.3.1's:
+# it is skipped here on both, which is the divergence this file removes.
+#
+# The files still reach the built tree.  Only the linking is filtered, and the
+# filter is stow's rather than shale's - shale copies whatever a layer holds.
+test_apply_skips_what_stows_built_in_list_skips() {
   conf 'base personal/base'
+  mklayer personal/base .zshrc
   mklayer personal/base .gitignore
-  mklayer personal/base .config/git/config
+  mklayer personal/base .zsh/.gitignore
+  mklayer personal/base .gitmodules
+  mklayer personal/base '.zshrc~'
+  mklayer personal/base '#notes#'
   run_shale apply
   assert_status 0 "$shale_status"
-  assert_symlink_to "$HOME/.gitignore" "$HOME/.dotfiles/current/.gitignore"
-  assert_eq 'personal/base/.gitignore' "$(cat "$HOME/.gitignore")" 'the linked file'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  assert_exists "$HOME/.dotfiles/current/.gitignore" 'the built tree'
+  assert_exists "$HOME/.dotfiles/current/.zsh/.gitignore" 'the built tree'
+  assert_missing "$HOME/.gitignore"
+  assert_missing "$HOME/.zsh/.gitignore"
+  assert_missing "$HOME/.gitmodules"
+  assert_missing "$HOME/.zshrc~"
+  assert_missing "$HOME/#notes#"
   # The list itself is stow's own file and is never one of the links.
   assert_missing "$HOME/.stow-local-ignore"
+}
+
+# The near misses of that same list, which matches a whole basename and not a
+# prefix of one: '\.git' is not '.gitconfig' or '.gitkeep', and '\.gitignore' is
+# not the 'ignore' that core.excludesFile defaults to at ~/.config/git/ignore -
+# the spelling an ordinary global gitignore actually has.  A list that started
+# matching any of these would take a real file out of $HOME with apply exiting 0.
+test_apply_links_the_near_misses_of_the_ignore_list() {
+  conf 'base personal/base'
+  mklayer personal/base .gitconfig
+  mklayer personal/base .config/git/ignore
+  mklayer personal/base .config/zsh/rc.d/.gitkeep
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_symlink_to "$HOME/.gitconfig" "$HOME/.dotfiles/current/.gitconfig"
+  assert_eq 'personal/base/.config/git/ignore' "$(cat "$HOME/.config/git/ignore")" 'the linked file'
+  assert_symlink_to "$HOME/.config/git/ignore" "$HOME/.dotfiles/current/.config/git/ignore"
+  assert_symlink_to "$HOME/.config/zsh/rc.d/.gitkeep" \
+    "$HOME/.dotfiles/current/.config/zsh/rc.d/.gitkeep"
+  assert_symlink_to "$HOME/.config/nvim/init.lua" \
+    "$HOME/.dotfiles/current/.config/nvim/init.lua"
 }
 
 # The other half of that list: the files a layer keeps for its readers stay in


### PR DESCRIPTION
Closes #95 part 1. Part 2 is #96.

A package-local ignore list replaces stow built-in one rather than extending it, so shale three patterns were the entire filter and an apply linked nested .gitignore files, editor backups and VCS furniture that plain stow skips.

The generated file is now GNU Stow 2.4.1 default-ignore-list verbatim under a shale header. shale three patterns were already the last three entries of it, so nothing of shale own is lost - and writing 2.4.1 list is what makes 2.3.1 apply the same tree, removing the .gitmodules divergence between the two versions.

Verified by dumping stow compiled regexps with -v5 -n on both versions: identical filter sets. Five stale doc and example claims found and fixed by sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)