### PR TITLE
Refuse a split layer path only where a directory says which was meant

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ name    path              url
 
 `path` is relative to `~/.dotfiles`. `url` says how to clone the *first component* of `path` — the
 clone root — because several layers commonly come from one repository. Give the url once per clone
-root and leave it off the other lines that share it. Blank lines and `#` comments are ignored.
+root and leave it off the other lines that share it. Blank lines and `#` comments are ignored. The
+three fields are separated by whitespace and there is no quoting, so none of them can contain a
+space; [docs/layers.md](docs/layers.md) says what shale can and cannot tell you when one does.
 
 ```
 base    personal/base     git@github.com:you/dotfiles.git

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -30,6 +30,14 @@ the layer becomes a real link. Name the repository root as the layer and `~/.git
 and `~/CONTRIBUTING.md` join them. The subdirectory is what keeps the repository's own furniture out
 of the image.
 
+The three fields are separated by whitespace and there is no quoting, so a name, a path and a url
+cannot contain a space or a tab. A directory called `my layer` cannot be a layer; rename it.
+`base    my layer` is not a syntax error, because it is the same three strings as a layer at `my`
+cloned from a repository called `layer` — so shale refuses it only where a directory called
+`my layer` is there to say which was meant. Where it is not, the line is taken at its word and
+`doctor` cannot see it, because no url is fetched until the build — and the build then fails on the
+clone, unless `layer` really is a repository.
+
 Several layers can come from one repository — `personal/base` and `personal/wsl` are two
 directories in one clone at `~/.dotfiles/personal`, so the url is given once, on the first of them.
 A layer needs no repository at all: `~/.dotfiles/local` with no url is this machine's own directory.

--- a/shale
+++ b/shale
@@ -329,6 +329,27 @@ EOF
     done
     [ "$dup" -eq 0 ] || continue
 
+    # A path containing a space arrives here as PATH and URL, and the two fields
+    # are the two a legitimate line has: 'layer' is as valid a relative url as it
+    # is a directory name, so no test of the strings alone can tell 'my layer'
+    # from a layer at 'my' cloned from 'layer', and one that guessed would refuse
+    # working configs.  A directory sitting under the two fields joined is the
+    # one thing that can: it is the layer the line names read as written, and no
+    # url a build clones from spells one.
+    if [ -n "$url" ] && [ ! -e "$DOTFILES/$path" ] && [ ! -L "$DOTFILES/$path" ] &&
+      [ -d "$DOTFILES/$path $url" ]; then
+      # Quoted, because the single space this whole diagnosis turns on is
+      # invisible at the end of a long absolute path.  '-d' above followed a
+      # symlink to get here, as the layer checks do at a layer path, so the
+      # message says something rather than a directory.
+      shell_quote "$DOTFILES/$path $url"
+      config_error \
+        "$CONF:$lineno: nothing at $DOTFILES/$path, but there is something at $QUOTED" \
+        "fields are separated by whitespace, so this line reads as the path '$path' with the url '$url'" \
+        "a layer path cannot contain whitespace and shale has no quoting: rename it"
+      continue
+    fi
+
     if [ -n "$url" ]; then
       found=-1
       i=0

--- a/tests/run
+++ b/tests/run
@@ -1389,6 +1389,77 @@ test_config_invalid_paths_are_rejected() {
   done
 }
 
+# A path containing a space arrives as three fields, and 'base my layer' is the
+# same three strings as a layer at 'my' cloned from a repository directory
+# called 'layer'.  Nothing in the strings tells those apart.  A directory sitting
+# under the two fields joined does, since no url that clones names one, and it is
+# the only thing shale refuses on - the two cases below hold both halves of that.
+test_config_a_path_with_a_space_is_diagnosed_where_its_directory_exists() {
+  local expected
+  conf 'base my layer'
+  mklayer 'my layer' .zshrc
+  # Quoted in the message, and quoted in the assertion for the same reason: the
+  # space is the whole diagnosis and it is invisible at the end of a long path.
+  expected="shale: $HOME/.dotfiles/shale.conf:1: nothing at $HOME/.dotfiles/my, but there is something at '$HOME/.dotfiles/my layer'"
+  # doctor's config errors go to stdout with the rest of its report.
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" "$expected" 'doctor stdout'
+  assert_contains "$shale_out" "shale:   a layer path cannot contain whitespace" 'doctor stdout'
+  run_shale build
+  assert_status 1 "$shale_status" 'build exit status'
+  assert_contains "$shale_err" "$expected" 'build stderr'
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# A symlink to a directory is a layer directory everywhere else in shale - the
+# layer checks reach it through the same '-d' - so the line still names the
+# layer it was written to name, and the diagnosis still holds.  What the message
+# may not do is call it a directory.
+test_config_a_path_with_a_space_is_diagnosed_where_a_symlink_stands_there() {
+  conf 'base my layer'
+  mklayer elsewhere/real .zshrc
+  sandbox_mkdir "$HOME/.dotfiles"
+  ln -s "$HOME/.dotfiles/elsewhere/real" "$HOME/.dotfiles/my layer" ||
+    fail 'could not link the layer directory'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/shale.conf:1: nothing at $HOME/.dotfiles/my, but there is something at '$HOME/.dotfiles/my layer'" \
+    'stderr'
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# The other half: with nothing at either name the two readings are the same two
+# strings, so shale takes the line at its word rather than refuse a config that
+# clones.  Observed through doctor because doctor reads the url without fetching
+# it - every url here is a shape 'git clone' accepts, and a case that refused any
+# of them would be refusing a working config.
+test_config_a_url_is_taken_at_its_word_where_no_directory_joins_the_fields() {
+  local url
+  for url in \
+    'https://nowhere/dots.git' \
+    'git@nowhere:you/dots.git' \
+    'ssh://git@nowhere/you/dots.git' \
+    'file:///srv/git/dots.git' \
+    "$CASE_DIR/repos/dots" \
+    'repos/dots' \
+    'dots.git' \
+    'layer'; do
+    conf "base personal/base $url"
+    run_shale doctor
+    assert_status 0 "$shale_status" "url '$url' exit status"
+    assert_not_contains "$shale_out$shale_err" 'but there is a directory at' \
+      "url '$url' output"
+  done
+  # The reported config itself, with neither directory made: still a clone.
+  conf 'base my layer'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'unmade directory exit status'
+  assert_not_contains "$shale_out$shale_err" 'but there is a directory at' \
+    'unmade directory output'
+}
+
 test_config_invalid_names_are_rejected() {
   local name
   # 'ba#se' is a name with a '#' in it, not a comment: '#' opens one only where


### PR DESCRIPTION
Closes #93.

base    my layer parsed as path my with url layer, silently, and doctor exited 0 on it while build failed trying to clone a repository called layer.

The config is refused only when all three of these hold: the line has a url, nothing exists at the parsed path, and a directory exists at the two fields joined. That state is exactly the reported config and no working config can be in it, so there is no heuristic and no false refusal.

Quoting was investigated and rejected: valid_component restricts path components to A-Za-z0-9._- so a quoted my layer would parse and then be rejected as an invalid path anyway. Refusing on the shape of the url field was rejected empirically - a bare relative path is a valid git url and is what the test fixtures use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)