### PR TITLE
Make doctor's exit status answer for the apply as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ is the machine's business, not the repos'.
 
 `bash`, `git` and GNU `stow`, installed with your system package manager, and the coreutils any
 system already has — `cp`, `mv`, `rm`, `mkdir`, `rmdir` and `readlink`. Shale installs nothing,
-including itself. `git` is used only to clone a layer repository the machine does not have yet.
+including itself. `git` is used only to clone a layer repository the machine does not have yet, so
+`doctor` reports it missing as a note where no configured layer needs cloning and as a problem where
+one does.
 `chkstow` ships with GNU stow and is what `doctor` audits `$HOME` with; without it `doctor` says so
 and skips that one check. `shale doctor` names every one of these it cannot find, so it is the
 fastest answer to a machine where something will not run.
@@ -121,7 +123,7 @@ above. The four commands in it are the whole surface: there are no others, and n
 |---|---|
 | `shale build` | Clones any missing clone root that has a url, then composes the layers into `~/.dotfiles/current` |
 | `shale apply` | Builds, then stows `current` over `$HOME`, replacing the last apply's links |
-| `shale doctor` | Checks the prerequisites, the config, the layers, the built tree and `$HOME`; it will not exit 0 on a setup `build` is certain to refuse |
+| `shale doctor` | Checks the prerequisites, the config, the layers, the built tree and `$HOME`; it will not exit 0 on a setup `build` or `apply` is certain to refuse |
 | `shale which PATH` | Names every layer providing `PATH`, winner first, and when `build` would refuse the set |
 
 After editing a file a layer already has, `build` is the whole loop: `~/.zshrc` is a link into
@@ -254,9 +256,11 @@ build.
 
 `shale doctor` checks that every tool shale runs is installed, that the config parses, that every
 configured layer directory is there and that nothing in one is a directory it cannot search or a file
-it cannot open, that no two layers disagree about whether a path
-is a file or a directory, that no layer ships `.stow-local-ignore` — which shale writes itself — or
-shale itself, that `~/.dotfiles/current` is a directory rather than a file or a link to one, that the
+it cannot open, that no two layers disagree about whether a path is a file or a directory, that
+nothing in `$HOME` at a path the layers provide is something no apply put there — a file, a
+directory, or a link of your own, none of which stow will write over — that no layer ships
+`.stow-local-ignore`, which shale writes itself, or shale itself, that `~/.dotfiles/current` is a
+directory rather than a file or a link to one, that the
 build lock is neither held nor uncreatable, that nothing in `~/.dotfiles` is a stray, that neither
 `current.new` nor `current.old` has been left beside `current`, and that no
 link in `$HOME` points into the built tree at a path it no longer provides. Where a `.stowrc` exists
@@ -270,12 +274,14 @@ shale: no problems found
 
 Doctor reports two kinds of line. A *problem* is a defect in the setup: it counts towards the total
 and makes doctor exit 1. Everything else is a note about something worth knowing, and neither counts
-nor changes the exit code. Every state doctor can see that stops a build outright is a problem, so
-`no problems found` is a strong signal that `shale build` will run rather than a guarantee that it
-must. What it does not see: an absolute symlink in a layer, which stow refuses at apply time and the
-two stow versions disagree about — so shale asserts nothing about it, and
+nor changes the exit code. Every state doctor can see that stops a build or an apply outright is a
+problem, so `no problems found` is a strong signal that both will run rather than a guarantee that
+they must. What it does not see: an absolute symlink in a layer, which stow refuses at apply time
+and the two stow versions disagree about — so shale asserts nothing about it, and
 [docs/layers.md](docs/layers.md) covers it — nor whether `$HOME` is writable, which fails an apply
-rather than a build, nor whether a leftover `current.old` can be removed. Below, a `vim  vim` line
+rather than a build, nor whether a leftover `current.old` can be removed, nor an *absolute* link in
+`$HOME` pointing at the built tree's own copy of that same path, which stow refuses and which only
+a hand ever makes. Below, a `vim  vim` line
 was added to the config for a layer that is not
 there, and a stray `~/.dotfiles/old-tmux` directory was created — the first is the problem, the
 second the note:

--- a/shale
+++ b/shale
@@ -1136,6 +1136,181 @@ layer_denied() {
     'check the permissions on that file'
 }
 
+# The paths in $HOME that stow will refuse to write over, collected by the layer
+# walk below.  Capped like every other list doctor keeps: the cap changes what is
+# printed and never what is counted.
+APPLY_CONFLICT_CAP=10
+APPLY_CONFLICTS=0
+APPLY_CONFLICT_PATHS=()
+# The subtree below a path already answered for, empty when there is none.
+HOME_CONFLICT_SKIP=
+
+# Records $HOME/$1 when what stands there is not the built tree's own copy of
+# the path and a build would provide that path as a $2 - 'file' or 'directory'.
+# stow refuses every one of them, verified against 2.3.1 and 2.4.1, which word
+# the refusal differently, report it from different phases, and agree on which
+# shapes are refused.
+#
+# The layers rather than the built tree, because apply builds before it stows:
+# a path the built tree still holds and no layer provides any more is gone by
+# the time stow looks, and naming it would be a finding about a tree that apply
+# replaces on its way past.
+#
+# Two directories are the one pair that is not a refusal - stow puts its links
+# inside a directory that is already there - and the only reason the kind is
+# passed in at all.
+#
+# A symlink is the shape that costs the thought.  What stow accepts is the link
+# an apply wrote and nothing else: relative, and resolving to the built tree's
+# copy of that same path.  A link to another path in the tree is 'stowed to a
+# different package', one to anywhere else is 'not owned by stow', and both are
+# refusals on both versions.  -ef is what answers that in two stats and no fork,
+# because an apply's link resolves to the very file it is compared against -
+# where readlink would be a process per path in $HOME, on the walk that has to
+# stay cheap.  It is read only where it cannot mislead: -ef is true of an
+# absolute link to the right file as well, and stow refuses that one, so this
+# check is silent about a link nobody but a hand makes.  A dangling link is the
+# one shape -ef cannot speak for at all, and the only one readlink is spent on:
+# there is at most a handful in any $HOME, and every one of them costs a fork.
+home_conflict() {
+  local srel=$1 kind=$2 path
+  # Everything below a path this has already answered for.  Two shapes need it:
+  # a directory in $HOME that is a symlink, under which every path here could
+  # name resolves outside $HOME and would send the reader to delete the wrong
+  # file; and a directory the ignore list names by segment, under which stow
+  # never goes.
+  if [ -n "$HOME_CONFLICT_SKIP" ]; then
+    case "$srel" in
+      "$HOME_CONFLICT_SKIP"/*) return 0 ;;
+    esac
+  fi
+  # The ignore list cmd_build writes, read as stow reads it, and it has to stay
+  # that list: a name missing here is a finding on a working setup for ever - a
+  # ~/.gitignore of the reader's own beside a layer that has one - and a name
+  # here that is not in the list is a refusal doctor goes quiet about.  Inline
+  # rather than a predicate of its own because this runs once per composed path
+  # and a bash function call is not free at that count.
+  #
+  # Stow compiles the list into two regexps, checked against both 2.3.1 and
+  # 2.4.1.  A pattern holding a '/' is matched against the whole path anchored
+  # at its ends, so the four below match at the top of the tree only and cover
+  # everything under a directory one of them names; stow adds
+  # '^/\.stow-local-ignore$' to whatever the file holds, which is the fourth.  A
+  # pattern without one is matched against a single path segment at any depth,
+  # and stow skips the directory as it descends, as the skip above does here.
+  case "${srel%%/*}" in
+    .stow-local-ignore | COPYING | README* | LICENSE*)
+      [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
+      return 0
+      ;;
+  esac
+  case "${srel##*/}" in
+    RCS | CVS | .cvsignore | .svn | _darcs | .hg | .git | .gitignore | .gitmodules | \
+      ?*,v | '.#'?* | ?*~ | '#'*'#')
+      # '.+,v', '\.\#.+', '.+~' and '\#.*\#' in glob: '.+' is one character or
+      # more, and '.*' is none or more.
+      [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
+      return 0
+      ;;
+  esac
+  # An empty HOME would make every path below the root directory's.
+  [ -n "${HOME-}" ] || return 0
+  path=$HOME_PREFIX/$srel
+  if [ -L "$path" ]; then
+    # The applied state, and the whole of it: one lstat and one pair of stats.
+    [ ! "$path" -ef "$CUR/$srel" ] || return 0
+    [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
+    if [ ! -e "$path" ]; then
+      # Dangling, and -ef cannot answer for one at all: what it points at is
+      # what decides, and the next apply builds before it stows.
+      ! link_points_into_the_tree "$path" || return 0
+    fi
+  else
+    [ -e "$path" ] || return 0
+    if [ "$kind" = directory ] && [ -d "$path" ]; then
+      return 0
+    fi
+  fi
+  APPLY_CONFLICTS=$((APPLY_CONFLICTS + 1))
+  [ "$APPLY_CONFLICTS" -gt "$APPLY_CONFLICT_CAP" ] ||
+    APPLY_CONFLICT_PATHS+=("$path")
+  return 0
+}
+
+# Non-zero unless the symlink $1 points into the built tree the way an apply
+# writes one, which for a link with nothing at the end of it is the whole of what
+# stow needs: it removes its own links before it re-links, so a dangling relative
+# one pointing anywhere inside the tree is made good by the build and the stow an
+# apply runs in that order.  Whether it points at the tree's copy of its own path
+# or at another of them makes no difference while it dangles, and the package
+# holding a file or a directory there makes none either - all four run, on 2.3.1
+# and 2.4.1, exit 0.  A link that resolves is a different question and -ef has
+# already answered it: the same cross-tree link, once its target exists, is
+# 'stowed to a different package' on both.
+#
+# Called only for a dangling link, which is the one shape -ef cannot answer, and
+# it forks readlink - so the caller's guard is what keeps that off the walk.
+#
+# 'Cannot say' answers the same as 'it is the tree's', which is the answer that
+# reports nothing: a missing readlink is a note doctor has already printed, and a
+# finding raised on a guess is the failure this whole check exists to avoid.
+link_points_into_the_tree() {
+  local path=$1 dest
+  command -v readlink >/dev/null 2>&1 || return 0
+  dest=$(readlink "$path") || return 0
+  [ -n "$dest" ] || return 0
+  case "$dest" in
+    # An absolute link is refused wherever it points, on both versions.
+    /*) return 1 ;;
+    *) dest=${path%/*}/$dest ;;
+  esac
+  normalise_path "$dest"
+  dest=$NORMALISED
+  normalise_path "$CUR"
+  case "$dest" in
+    "$NORMALISED" | "$NORMALISED"/*) return 0 ;;
+  esac
+  return 1
+}
+
+# One finding however many paths, and a finding rather than a note: stow plans
+# the whole operation and abandons all of it, so this is one apply that will not
+# run - and doctor reporting green on the state where apply fails is the reading
+# of 'is this machine set up' that costs a reader the most.
+#
+# It stops no build, so BUILD_BLOCKED is left alone: the layers compose fine and
+# every line elsewhere that offers a build keeps its offer.
+report_home_conflicts() {
+  local n=$APPLY_CONFLICTS i lines paths hold each rest
+  [ "$n" -gt 0 ] || return 0
+  paths='paths'
+  hold='hold something no apply put there, and a layer provides each of them'
+  each='each of these is'
+  if [ "$n" -eq 1 ]; then
+    paths='path'
+    hold='holds something no apply put there, and a layer provides it'
+    each='it is'
+  fi
+  # Both halves of 'it does not go through', because the two kinds fail
+  # differently: stow refuses the whole operation at a file, and dies part-way
+  # with 'unstow_contents() called with non-directory path' at a directory the
+  # layers provide a file at - which is cmd_apply's 'stow failed part-way', so a
+  # doctor promising nothing was relinked would contradict shale's own apply.
+  lines=("$n $paths in $HOME $hold"
+    'apply gives the composed tree to stow, and stow will not write over what it did not create: it refuses the whole operation, or stops part-way through one'
+    "no apply finishes until $each moved aside, or copied into a layer and removed from $HOME")
+  i=0
+  while [ "$i" -lt "${#APPLY_CONFLICT_PATHS[@]}" ]; do
+    lines[${#lines[@]}]=${APPLY_CONFLICT_PATHS[$i]}
+    i=$((i + 1))
+  done
+  if [ "$n" -gt "$APPLY_CONFLICT_CAP" ]; then
+    rest=$((n - APPLY_CONFLICT_CAP))
+    lines[${#lines[@]}]="and $rest more, not named here"
+  fi
+  finding ${lines[@]+"${lines[@]}"}
+}
+
 # Every path two layers disagree about the kind of, and every layer path this
 # walk cannot read: the states build refuses that nothing else in doctor sees.
 # The walk is build's own minus the copying - one listing per layer directory
@@ -1221,6 +1396,9 @@ scan_layer_trees() {
         layer_denied "${LAYER_NAMES[$i]}" "$e" file
       fi
       if [ "$alone" -eq 1 ]; then
+        # One layer holds this subtree, so this listing is the only one that
+        # reaches this path and the kind here is the kind that lands.
+        home_conflict "$srel" "$kind"
         [ "$kind" = directory ] || continue
         scan_layer_trees "$srel" "$i"
         continue
@@ -1288,6 +1466,11 @@ scan_layer_trees() {
         last=$k
       done
       [ "$first" -eq "$i" ] || continue
+      # Below this line the walk is at the layer that decides this path, which is
+      # once per composed path however many layers provide it.  first_kind, not
+      # kind: the loop above reused kind for the layers it compared, and the kind
+      # that lands in the composed tree is the first provider's.
+      home_conflict "$srel" "$first_kind"
       if [ "$other" -ge 0 ]; then
         # The pair is build's pair: build collides against the *nearest*
         # provider below, so naming the first one instead sends someone to a
@@ -1588,6 +1771,39 @@ audit_built_tree() {
   note ${lines[@]+"${lines[@]}"}
 }
 
+# Non-zero unless the next apply removes the orphaned link $1 by itself, so that
+# the remedy printed for it is the one that works: $1 is the link's path
+# normalised, $2 is $HOME normalised, and $3 is 'relative' or 'absolute' for the
+# way the link's own target is spelled.
+#
+# Both halves were run, against 2.3.1 and 2.4.1, which agree on every one of
+# them.  A link spelled as an absolute path is never pruned - 2.3.1 says 'BUG in
+# find_stowed_path?' on its stderr and carries on, 2.4.1 says nothing - and a
+# relative one is pruned exactly where the built tree still holds the directory
+# it sits in, that being the directory stow's unstow phase walks.  Apply's own
+# links are relative, so the ordinary case of a file leaving its only layer is
+# one 'shale apply' and no rm at all; a directory that left every layer is the
+# case rm is for.
+apply_prunes_link() {
+  local nlink=$1 nhome=$2 spelling=$3 prefix rel dir
+  [ "$spelling" = relative ] || return 1
+  # A home of '/' is the one whose join would come out doubled, and the one
+  # whose prefix is empty.
+  prefix=${nhome%/}
+  case "$nlink" in
+    "$prefix"/*) rel=${nlink#"$prefix"/} ;;
+    *) return 1 ;;
+  esac
+  case "$rel" in
+    */*) dir=$CUR/${rel%/*} ;;
+    # A link directly in $HOME, whose directory is the built tree itself.
+    *) dir=$CUR ;;
+  esac
+  # A symlink to a directory is a leaf to stow as it is to the composer, so it
+  # is not a directory the unstow phase walks into.
+  [ -d "$dir" ] && [ ! -L "$dir" ]
+}
+
 # Every link under $HOME that points into the built tree at a path the built
 # tree no longer holds: one finding each, and the remedy once.  Up to $cap of
 # them the remedy follows the findings; past it the count, the directory they
@@ -1605,7 +1821,7 @@ audit_built_tree() {
 # own dangling symlink judged against itself would be reported for ever.
 audit_broken_links() {
   local out err marker line link dest target cur dots home qdots qhome n lines
-  local stream cap rest msg samples remedy where
+  local stream cap rest msg samples remedy where nlink nhome spelling prunable
 
   # Before every other check here, which all need a built tree to mean anything.
   #
@@ -1657,6 +1873,11 @@ audit_broken_links() {
   cur=$NORMALISED
   normalise_path "$DOTFILES"
   dots=$NORMALISED
+  # For the same comparison against a link's own path that $dots is for: both
+  # sides normalised, so the two spellings compare rather than the strings as
+  # they arrived.
+  normalise_path "$HOME"
+  nhome=$NORMALISED
 
   # Exactly one trailing slash.  File::Find will not descend a top directory
   # that is itself a symlink unless the path ends in '/', so a $HOME reached
@@ -1678,6 +1899,7 @@ audit_broken_links() {
   out=$( { err=$(chkstow -b -t "$home" 2>&1 1>&3 3>&-); printf '%s\n%s' "$marker" "$err"; } 3>&1 )
 
   n=0
+  prunable=0
   lines=()
   samples=()
   stream=out
@@ -1734,12 +1956,18 @@ audit_broken_links() {
     case "$NORMALISED" in
       "$dots" | "$dots"/*) continue ;;
     esac
+    # Kept, because the next normalise_path overwrites it and the remedy below
+    # needs the link's own path as well as its target's.
+    nlink=$NORMALISED
     dest=$(readlink "$link") || continue
     [ -n "$dest" ] || continue
     # A relative target is what stow writes, and it is relative to the directory
-    # holding the link rather than to anywhere shale is.
+    # holding the link rather than to anywhere shale is.  Which of the two it is
+    # decides whether an apply removes this link, so it is recorded before the
+    # join takes the difference away.
+    spelling=relative
     case "$dest" in
-      /*) ;;
+      /*) spelling=absolute ;;
       *) dest=${link%/*}/$dest ;;
     esac
     normalise_path "$dest"
@@ -1757,6 +1985,9 @@ audit_broken_links() {
     # this quadratic - and the ancestor is folded in one link at a time.
     n=$((n + 1))
     [ "$n" -gt "$cap" ] || samples+=("$link points at $target, which the built tree no longer provides")
+    # Counted for every link and not only for the ones named: the cap decides
+    # what is printed, and the remedy is about all of them.
+    ! apply_prunes_link "$nlink" "$nhome" "$spelling" || prunable=$((prunable + 1))
     common_ancestor "$link"
   done <<EOF
 $out
@@ -1785,17 +2016,46 @@ EOF
   # line unindented: a sentence there about what stow prunes reads as one more
   # finding, against a summary that has just counted them.  An imperative reads
   # as the answer to them, which is what this block is.
-  if [ "$n" -le "$cap" ]; then
-    remedy=('remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying')
+  #
+  # Three shapes, because the links have two causes and one remedy fits only
+  # one of them.  A file that left its only layer leaves a link the next apply
+  # removes on its own, and telling the reader to rm it - and that reapplying
+  # will not help - is both more work than the state needs and false about it.
+  # A directory that left every layer is the case that needs the rm, and the
+  # sweep under it is the alternative to doing that by hand.  Where the two are
+  # mixed, the rm is what covers all of them and the apply is named for what it
+  # takes off the list.
+  if [ "$prunable" -eq "$n" ] && [ "$n" -eq 1 ]; then
+    remedy=('clear it with: shale apply'
+      'stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and this is one of them')
+  elif [ "$prunable" -eq "$n" ]; then
+    remedy=('clear them with: shale apply'
+      'stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and every one of these is one of them')
   else
-    # The findings are below the remedy in this shape, and most of them are not
-    # printed at all, so there is nothing 'named above' to point at.
-    remedy=('remove them; the built tree is correct, and nothing needs rebuilding or reapplying')
+    if [ "$n" -le "$cap" ]; then
+      if [ "$prunable" -eq 0 ]; then
+        remedy=('remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying')
+      else
+        remedy=('remove the links named above; the built tree is correct and needs no rebuilding')
+      fi
+    else
+      # The findings are below the remedy in this shape, and most of them are not
+      # printed at all, so there is nothing 'named above' to point at.
+      if [ "$prunable" -eq 0 ]; then
+        remedy=('remove them; the built tree is correct, and nothing needs rebuilding or reapplying')
+      else
+        remedy=('remove them; the built tree is correct and needs no rebuilding')
+      fi
+    fi
+    if [ "$prunable" -gt 0 ]; then
+      remedy+=("an apply clears $prunable of them and leaves the rest: stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds")
+    else
+      remedy+=('stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links')
+    fi
+    remedy+=('stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
+      "  stow -D -p --no-folding -d $qdots -t $qhome current && shale apply" \
+      'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory')
   fi
-  remedy+=('stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links')
-  remedy+=('stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
-    "  stow -D -p --no-folding -d $qdots -t $qhome current && shale apply" \
-    'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory')
 
   if [ "$n" -le "$cap" ]; then
     for msg in ${samples[@]+"${samples[@]}"}; do
@@ -2150,6 +2410,9 @@ cmd_build() {
   # On 2.4.1 the file changes no outcome, and that is not a reason to delete
   # it: 2.3.1's built-in list has no \.gitmodules, so writing 2.4.1's list is
   # the whole of what makes an apply land the same tree on both.
+  #
+  # doctor reads this same list as stow_ignores, to know which paths in $HOME an
+  # apply never touches.  A pattern added here is added there.
   printf '%s\n' \
     "# Written by shale on every build, which overwrites whatever is here:" \
     "# edit a layer, not this file." \
@@ -2370,15 +2633,15 @@ cmd_doctor() {
   # checked at its point of use only where its absence would be silent or would
   # name something other than the missing tool; doctor is where that stops,
   # because checking is its point of use and it promises prerequisites.
-  for tool in cp git mkdir mv rm rmdir stow; do
+  #
+  # git is not here: it is wanted for one thing only, and whether that thing is
+  # wanted is not known until the layers have been looked at.  Its check is below
+  # them.
+  for tool in cp mkdir mv rm rmdir stow; do
     command -v "$tool" >/dev/null 2>&1 && continue
-    # git is wanted only for a clone root that has a url and nothing at its
-    # path, and stow only by apply, so neither of those two stops a build on its
-    # own; the other five do, and no line below may then offer one.
-    case "$tool" in
-      git | stow) ;;
-      *) BUILD_BLOCKED=$((BUILD_BLOCKED + 1)) ;;
-    esac
+    # stow is wanted only by apply, so it stops no build on its own; the other
+    # five do, and no line below may then offer one.
+    [ "$tool" = stow ] || BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
     finding "$tool is not installed" \
       "install it with your system package manager: shale installs nothing"
   done
@@ -2487,14 +2750,25 @@ cmd_doctor() {
     i=$((i + 1))
   done
 
-  # Missing git is a finding above and stops no build on its own - a machine
-  # holding every layer builds with no git at all.  Together with a layer whose
-  # clone root has a url and nothing at its path it does stop one, in
-  # clone_missing_roots, and doctor has both halves in hand: counted here so
-  # that nothing below offers a build that dies fetching.  No second finding -
-  # the missing tool is already one.
-  if [ "$pending" -eq 1 ] && ! command -v git >/dev/null 2>&1; then
-    BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
+  # git, here rather than in the tool list, because a machine holding every layer
+  # runs build and apply with no git at all: reported against the clone the
+  # config asks for, so that a setup which needs none is not told it has a
+  # problem.  A finding that offers no build is a false one, and the failure mode
+  # worse than the defect it guards against.
+  #
+  # The pending clone is the layer loop's own answer, which is will_clone's, so
+  # this and clone_missing_roots cannot drift over what a build is going to
+  # fetch.  Counted as blocking as well, so that nothing below offers a build
+  # that dies fetching.
+  if ! command -v git >/dev/null 2>&1; then
+    if [ "$pending" -eq 1 ]; then
+      BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
+      finding 'git is not installed, and a layer above has still to be cloned' \
+        'install it with your system package manager: shale installs nothing'
+    else
+      note 'git is not installed' \
+        'shale runs it only to clone a layer this machine has not got, and every configured layer is already here'
+    fi
   fi
 
   # The layers as build composes them, once the loop above has said which of
@@ -2511,12 +2785,18 @@ cmd_doctor() {
     i=$((i + 1))
   done
   LAYER_DENIED=0
+  APPLY_CONFLICTS=0
+  APPLY_CONFLICT_PATHS=()
+  HOME_CONFLICT_SKIP=
   [ -z "$layers" ] || scan_layer_trees '' "${layers# }"
   # Under the cap every one of them is printed above and this says nothing.
   if [ "$LAYER_DENIED" -gt "$LAYER_DENIED_CAP" ]; then
     i=$((LAYER_DENIED - LAYER_DENIED_CAP))
     note "and $i more layer paths shale cannot read, not named here"
   fi
+  # The other half of that walk: what the layers hold, against what is in $HOME
+  # at the same paths.
+  report_home_conflicts
 
   # build's own refusal, in build's own words.  It is checked against the layers
   # rather than against the composed tree because that is where the file has to
@@ -2573,6 +2853,14 @@ cmd_doctor() {
       # dangling symlink, a fifo and a socket are all of that third shape, and
       # a symlink to a directory reads as the directory it is one of.
       if [ -d "$entry" ]; then
+        # Only where every line of the config parsed.  A directory is
+        # unaccounted for either because nothing configured it or because the
+        # line that did failed to parse, and shale cannot tell those apart: the
+        # second line below then invites the reader to delete the layer they are
+        # running doctor to fix, and with a config shale could not read at all -
+        # unreadable, or holding no records - every layer on the machine gets it.
+        # The parse error is above, and it is the one thing to act on.
+        [ "$CONFIG_ERRORS" -eq 0 ] || continue
         note "$entry is not a configured layer" \
           "it may be a leftover stow package, a stray clone, or a layer you removed from the config"
       elif [ -f "$entry" ] && [ ! -L "$entry" ]; then

--- a/tests/run
+++ b/tests/run
@@ -1766,9 +1766,10 @@ test_config_a_carriage_return_on_one_line_keeps_the_layers_above_it() {
   done <<EOF
 $shale_out
 EOF
-  # Only the refused record's own root, which is a stray for exactly the reason
-  # every other refused record's root is.
-  assert_eq 1 "$count" 'the number of stray-directory notes'
+  # Not even the refused record's own root: ~/.dotfiles/last is the layer line 5
+  # names, and the note's second line offers 'a layer you removed from the
+  # config' about the one directory the reader is running doctor to get back.
+  assert_eq 0 "$count" 'the number of stray-directory notes'
   assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
 }
 
@@ -5990,32 +5991,86 @@ test_doctor_a_stow_resource_file_is_not_globbed() {
 
 # The reason doctor calls parse_config bare where every other command exits on
 # it: a broken config is when you most need the rest of the report.
+# The later checks are the claim, and the stray scan is deliberately not one of
+# them: with no config at all shale cannot tell a layer from a leftover, so the
+# directory gets no note here and the stowrc note below it is what shows the run
+# carried on.
 test_doctor_a_broken_config_does_not_stop_the_later_checks() {
   sandbox_mkdir "$HOME/.dotfiles/common"
   sandbox_write "$HOME" .stowrc '--ignore=secret'
   run_shale doctor
   assert_status 1 "$shale_status"
   assert_contains "$shale_out" "shale: no config file at $HOME/.dotfiles/shale.conf" 'stdout'
-  assert_contains "$shale_out" \
-    "shale: $HOME/.dotfiles/common is not a configured layer" 'stdout'
+  assert_not_contains "$shale_out" 'is not a configured layer' 'stdout'
   assert_contains "$shale_out" "shale: a stow resource file exists at $HOME/.stowrc" 'stdout'
   assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
   assert_empty "$shale_err" 'stderr'
 }
 
+# Same again where the config is there and shale could not read a line of it.
+# Every layer on the machine is unaccounted for in that state, and telling the
+# reader that each of them 'may be a layer you removed from the config' is advice
+# to delete the lot.
 test_doctor_an_unreadable_config_still_reports_the_rest() {
   skip_if_root
   conf 'base personal/base'
   sandbox_mkdir "$HOME/.dotfiles/common"
+  sandbox_write "$HOME" .stowrc '--ignore=secret'
   chmod 0000 "$HOME/.dotfiles/shale.conf" || fail 'could not remove the read bit'
   run_shale doctor
   assert_status 1 "$shale_status"
   assert_contains "$shale_out" \
     "shale: cannot read $HOME/.dotfiles/shale.conf: permission denied" 'stdout'
-  assert_contains "$shale_out" \
-    "shale: $HOME/.dotfiles/common is not a configured layer" 'stdout'
+  assert_not_contains "$shale_out" 'is not a configured layer' 'stdout'
+  assert_contains "$shale_out" "shale: a stow resource file exists at $HOME/.stowrc" 'stdout'
   assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
   assert_empty "$shale_err" 'stderr'
+}
+
+# The report the issue this came from opened with: a duplicate name two lines up
+# leaves ~/.dotfiles/local unregistered, and the note then offers the reader 'a
+# layer you removed from the config' about the one layer that exists nowhere
+# else.  The parse error is above it, and it is the whole of what there is to do.
+test_doctor_a_parse_error_does_not_call_a_layer_it_names_a_stray() {
+  conf 'base base' 'base local'
+  mklayer base .zshrc
+  mklayer local .vimrc
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/shale.conf:2: duplicate layer name 'base', first used on line 1" 'stdout'
+  assert_not_contains "$shale_out" "$HOME/.dotfiles/local is not a configured layer" 'stdout'
+  assert_not_contains "$shale_out" 'a layer you removed from the config' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# The same for a config that parsed whole and named nothing: an empty file is one
+# every layer is missing from, so every layer would get the note.
+test_doctor_a_config_naming_no_layers_calls_no_directory_a_stray() {
+  conf '# nothing here' ''
+  mklayer base .zshrc
+  mklayer local .vimrc
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: no layers configured in $HOME/.dotfiles/shale.conf" 'stdout'
+  assert_not_contains "$shale_out" 'is not a configured layer' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# And the other side of it, which is what keeps the scan worth having: a config
+# every line of which parsed says exactly which directories are layers, so a
+# stray really is one.
+test_doctor_a_config_that_parses_still_names_a_stray() {
+  conf 'base base'
+  mklayer base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/leftover"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/leftover is not a configured layer" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   it may be a leftover stow package, a stray clone, or a layer you removed from the config' 'stdout'
 }
 
 # Problems cluster, and a doctor that stopped at the first is one you have to
@@ -6049,7 +6104,12 @@ test_doctor_reports_its_checks_in_order() {
   local saved line seen
   conf 'base personal/base' 'work work' 'lonely'
   mklayer personal/base .zshrc
-  sandbox_mkdir "$HOME/.dotfiles/common"
+  # A file rather than a directory, because the config above has an error in it
+  # and a directory gets no note in that state.  The scan is the same one.
+  sandbox_write "$HOME/.dotfiles" common 'not a layer'
+  # The path a layer provides that $HOME already holds, which is reported off the
+  # back of the layer walk and belongs with it.
+  sandbox_write "$HOME" .zshrc 'mine'
   # The lock is above the config in the report and has to stay there: it is the
   # one finding that says why a build refused, and every arm this loop does not
   # recognise is ignored, so nothing else here would notice it moving.
@@ -6068,14 +6128,16 @@ test_doctor_reports_its_checks_in_order() {
       'shale: a shale has the lock at '*) seen="$seen lock" ;;
       "shale: $HOME/.dotfiles/shale.conf:3:"*) seen="$seen config" ;;
       "shale: layer 'work'"*) seen="$seen layer" ;;
-      *' is not a configured layer') seen="$seen stray" ;;
+      *' holds something no apply put there, and a layer provides it') seen="$seen home" ;;
+      *' is not a layer, and no build reads it') seen="$seen stray" ;;
       'shale: a stow resource file'*) seen="$seen stowrc" ;;
-      'shale: 4 problems found') seen="$seen summary" ;;
+      'shale: 5 problems found') seen="$seen summary" ;;
     esac
   done <<EOF
 $shale_out
 EOF
-  assert_eq ' prerequisite lock config layer stray stowrc summary' "$seen" 'the order of the report'
+  assert_eq ' prerequisite lock config layer home stray stowrc summary' "$seen" \
+    'the order of the report'
 }
 
 # The stub PATH holds every other binary doctor and the harness need, so this
@@ -6105,12 +6167,15 @@ test_doctor_a_missing_prerequisite_is_named_and_nothing_is_installed() {
 # to report 'no problems found', exit 0, and send the reader to a build that then
 # failed.  One tool removed per run, so each is named on its own rather than one
 # of them carrying the assertion for all.
+#
+# git is not in the loop because it is the one tool whose absence is not a defect
+# on its own: the two cases that pin it are named for the clone.
 # shellcheck disable=SC2123
 test_doctor_names_every_tool_shale_runs() {
   local tool saved
   conf 'base personal/base'
   mklayer personal/base .zshrc
-  for tool in cp git mkdir mv rm rmdir stow; do
+  for tool in cp mkdir mv rm rmdir stow; do
     stub_path_without "$tool"
     saved=$PATH
     PATH=$stub_path
@@ -6128,11 +6193,13 @@ test_doctor_names_every_tool_shale_runs() {
 }
 
 # The whole list at once, which is the state the issue this came from described:
-# a machine with a shell and nothing else.
+# a machine with a shell and nothing else.  The second layer has a url and no
+# directory, which is what puts git among the seven: on a machine with nothing
+# there is a clone to do.
 # shellcheck disable=SC2123
 test_doctor_names_all_the_missing_tools_in_one_run() {
   local tool saved
-  conf 'base personal/base'
+  conf 'base personal/base' "vim vim $CASE_DIR/repos/absent"
   mklayer personal/base .zshrc
   stub_path_without cp git mkdir mv rm rmdir stow
   saved=$PATH
@@ -6161,6 +6228,359 @@ test_doctor_a_missing_chkstow_warns_without_failing() {
   assert_status 0 "$shale_status"
   assert_contains "$shale_out" 'shale: chkstow is not installed' 'stdout'
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# ------------------------------------------ doctor's apply-conflict cases
+#
+# The paths in $HOME that stow will not write over, which is the commonest thing
+# there is to be wrong with a machine: a dotfile that was there before shale, or
+# one an editor replaced a link with.  stow plans the whole operation and
+# abandons all of it, so one of these is an apply that does nothing at all, and
+# doctor reporting green on it is the report costing a reader the most.
+#
+# Every case that says a path is a conflict runs the apply and asserts it failed,
+# and every case that says a path is not runs it and asserts it succeeded: the
+# claim is stow's, made against the stow on the machine, rather than this suite's
+# reading of what stow does.  2.3.1 and 2.4.1 word the refusal differently and
+# report it from different phases, so nothing here pins the text of it.
+
+test_doctor_a_home_path_a_layer_provides_is_a_finding_and_apply_fails() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .zshrc 'my existing zshrc'
+  # Before the first build, which is where a new machine meets it: the check is
+  # against the layers, so there is nothing to have built yet.
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor before the first build'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   apply gives the composed tree to stow, and stow will not write over what it did not create: it refuses the whole operation, or stops part-way through one' \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   no apply finishes until it is moved aside, or copied into a layer and removed from $HOME" \
+    'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.zshrc" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # And the apply it describes, on the same tree.
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+  assert_contains "$shale_err" "shale: stow failed; nothing in $HOME was relinked" 'the apply stderr'
+  assert_eq 'my existing zshrc' "$(cat "$HOME/.zshrc")" 'the file stow refused to replace'
+  # The build is not blocked by it, and the report must not say it is.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_exists "$HOME/.dotfiles/current/.zshrc" 'the built tree'
+}
+
+# Moved aside, and the same run says so: the finding is about $HOME rather than
+# about anything shale keeps, so nothing has to be rebuilt to clear it.
+test_doctor_the_finding_goes_when_the_path_does() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME" .zshrc 'my existing zshrc'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  rm -f "$sandbox_path" || fail 'could not move the file aside'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after'
+  assert_not_contains "$shale_out" 'no apply put there' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+}
+
+# The everyday loop: once an apply has run, every path a layer provides is a
+# link, so this check is silent for ever after.  A layer edited and rebuilt
+# leaves it silent too - that is the state #75 exists about.
+test_doctor_says_nothing_about_a_home_full_of_applied_links() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer local .config/nvim/extra.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the apply'
+  assert_not_contains "$shale_out" 'no apply put there' 'stdout'
+  mklayer personal/base .zshrc 'edited'
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the edit'
+  assert_not_contains "$shale_out" 'no apply put there' 'stdout'
+}
+
+# The whole of the ignore list build writes, one file of the reader's own at
+# every entry of it, and the apply that proves each of them is stow's doing and
+# not this suite's.  A name missing from doctor's copy of the list is a finding
+# on a working setup for ever - a ~/.gitignore beside a layer that has one - so
+# this is the case that fails when the two lists drift apart.
+#
+# The path-anchored patterns are the four that need a top-level and a nested
+# copy to tell apart: only the top-level one is ignored.  The segment patterns
+# match at any depth, and CVS is here as a directory because stow skips the
+# directory and never looks inside it.
+test_doctor_says_nothing_about_a_home_path_stow_never_links() {
+  local name
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  # Every entry of the list except '\.stow-local-ignore', which stow adds to
+  # whatever the file holds and which no layer may provide: a layer that does is
+  # a finding of its own, and build refuses the tree.
+  for name in README.md LICENSE COPYING \
+    RCS 'file,v' .cvsignore .svn _darcs .hg .gitignore .gitmodules \
+    '.#lock' 'notes~' '#notes#'; do
+    mklayer personal/base "$name"
+    sandbox_write "$HOME" "$name" 'mine'
+  done
+  mklayer personal/base CVS/keep
+  sandbox_write "$HOME/CVS" keep 'mine'
+  mklayer personal/base .zsh/.gitignore
+  sandbox_write "$HOME/.zsh" .gitignore 'mine'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'no apply put there' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_eq 'mine' "$(cat "$HOME/README.md")" 'the readme stow left alone'
+  assert_eq 'mine' "$(cat "$HOME/.gitignore")" 'the gitignore stow left alone'
+  assert_eq 'mine' "$(cat "$HOME/CVS/keep")" 'the file under CVS stow left alone'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc" 'the one link'
+  # And the anchored names one level down, which stow does link.
+  mklayer personal/base .config/README.md
+  sandbox_write "$HOME/.config" README.md 'mine'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor with the nested copy'
+  assert_contains "$shale_out" "shale:   $HOME/.config/README.md" 'stdout'
+  assert_not_contains "$shale_out" "shale:   $HOME/README.md" 'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply with the nested copy'
+}
+
+# A symlink of the reader's own at a path a layer provides is a refusal like any
+# other - 'existing target is not owned by stow' on both 2.3.1 and 2.4.1,
+# whether it points at a file or a directory and whether or not it resolves.
+# What stow accepts is the link an apply wrote and nothing else, so the check
+# compares what the link resolves to rather than trusting that it is one.
+test_doctor_names_a_home_symlink_that_is_not_the_built_trees() {
+  local kind
+  for kind in file directory dangling; do
+    conf 'base personal/base'
+    mklayer personal/base .zshrc
+    # A target per variant, because the three run in one sandbox.
+    sandbox_mkdir "$HOME/elsewhere"
+    case "$kind" in
+      file) sandbox_write "$HOME/elsewhere" "$kind" 'mine' ;;
+      directory) sandbox_mkdir "$HOME/elsewhere/$kind" ;;
+      dangling) ;;
+    esac
+    sandbox_mkdir "$HOME"
+    sandbox_leaf "$sandbox_dir" .zshrc new
+    ln -s "$HOME/elsewhere/$kind" "$sandbox_path" || fail 'could not plant the link'
+    run_shale doctor
+    assert_status 1 "$shale_status" "$kind exit status"
+    assert_contains "$shale_out" \
+      "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" \
+      "$kind stdout"
+    assert_contains "$shale_out" "shale:   $HOME/.zshrc" "$kind stdout"
+    run_shale apply
+    assert_status 1 "$shale_status" "$kind apply"
+    # The link itself, not what it points at, and by the one spelling that does
+    # not go through sandbox_leaf: it refuses a name a symlink is at.
+    sandbox_mkdir "$HOME"
+    rm "$sandbox_dir/.zshrc" || fail 'could not remove the planted link'
+  done
+}
+
+# A link an apply wrote, at a path nothing has built yet: the home this machine
+# had before ~/.dotfiles/current was deleted, which is what a re-clone leaves.
+# -ef cannot answer a dangling link at all, so this is the shape readlink is
+# spent on, and it is the shape that must not be a finding - the apply builds
+# before it stows, so the link is one it makes good rather than one it refuses.
+test_doctor_says_nothing_about_a_link_the_built_tree_answers_for() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  rm -rf "$sandbox_dir/current" || fail 'could not remove the built tree'
+  assert_dangling_symlink "$HOME/.zshrc" 'the link left without a tree'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'no apply put there' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc" 'the link it made good'
+  # The same while it points at another of the tree's paths, which is a refusal
+  # once its target exists and none at all while it does not: stow removes its
+  # own link before it re-links, so the apply's own build settles it.  The
+  # narrower reading - that only a link at its own path is the tree's - makes
+  # this a finding, and the apply after it exits 0.
+  #
+  # Only the absence of this check's finding is asserted, not doctor's status:
+  # a link pointing at a path the built tree has not got is audit_broken_links'
+  # to speak for, and it does, in its own words and with the remedy that works.
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s .dotfiles/current/.gone "$sandbox_path" || fail 'could not plant the link'
+  mklayer personal/base .vimrc
+  run_shale doctor
+  assert_not_contains "$shale_out" 'no apply put there' 'the crossed stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply with the crossed link'
+  assert_symlink_to "$HOME/.vimrc" "$HOME/.dotfiles/current/.vimrc" 'the link it made good'
+}
+
+# A link into the built tree at a different path is 'stowed to a different
+# package' on both versions, which is a refusal like any other.
+test_doctor_names_a_home_link_into_the_tree_at_another_path() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .vimrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s .dotfiles/current/.zshrc "$sandbox_path" || fail 'could not plant the link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" "shale:   $HOME/.vimrc" 'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+}
+
+# A directory in $HOME that is a symlink is named itself, and nothing under it
+# is: every path below it resolves outside $HOME, so naming one would be telling
+# the reader to remove a file that is not where the message says it is - and
+# stow's own complaint is about the directory.  #92's third item is the same
+# shape, and this is the one place a walk can wander into it.
+test_doctor_names_a_symlinked_directory_and_nothing_under_it() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_write "$HOME/elsewhere/nvim" init.lua 'mine'
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .config new
+  ln -s "$HOME/elsewhere" "$sandbox_path" || fail 'could not plant the link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.config" 'stdout'
+  assert_not_contains "$shale_out" "$HOME/.config/nvim" 'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+}
+
+# Two directories are the one pair stow merges rather than refusing, and the
+# whole reason the kind is compared at all: without it every ~/.config on earth
+# is a finding.  The two crossed pairs are the cases below.
+test_doctor_says_nothing_about_a_directory_home_and_a_layer_both_hold() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_mkdir "$HOME/.config"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'directory over directory'
+  assert_not_contains "$shale_out" 'no apply put there' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply over a directory'
+  assert_real_dir "$HOME/.config" 'the directory stow kept'
+}
+
+test_doctor_names_a_home_file_where_a_layer_has_a_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_write "$HOME" .config 'not a directory'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.config" 'stdout'
+  # Once: nothing below a path stow will not create is reachable to conflict.
+  assert_not_contains "$shale_out" "$HOME/.config/nvim" 'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+}
+
+# The crossed pair the other way, which stow reports from perl rather than as a
+# conflict - 'unstow_contents() called with non-directory path' on both 2.3.1 and
+# 2.4.1, and an exit status that is neither 0 nor 1.  That is the arm cmd_apply
+# calls a part-way failure, so doctor may not say the apply changes nothing: the
+# two commands are asserted against each other here, which is the whole reason
+# the finding's wording covers both ways of not finishing.
+test_doctor_names_a_home_directory_where_a_layer_has_a_file() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.zshrc"
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" "shale:   $HOME/.zshrc" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   apply gives the composed tree to stow, and stow will not write over what it did not create: it refuses the whole operation, or stops part-way through one' \
+    'stdout'
+  assert_not_contains "$shale_out" 'nothing in ' 'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+  # shale's own line rather than stow's, which the two versions word
+  # differently; both exit with the status this arm is for.
+  assert_contains "$shale_err" "shale: stow failed part-way: $HOME may be partly relinked" \
+    'the apply stderr'
+}
+
+# One finding however many paths, because it is one apply that will not run.  The
+# list is capped like every other list doctor keeps, and the cap changes what is
+# printed and not what is wrong.
+test_doctor_bounds_the_home_conflict_list_at_ten_paths() {
+  local i named line
+  conf 'base personal/base'
+  i=0
+  while [ "$i" -lt 12 ]; do
+    mklayer personal/base "f$i"
+    sandbox_write "$HOME" "f$i" 'mine'
+    i=$((i + 1))
+  done
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 12 paths in $HOME hold something no apply put there, and a layer provides each of them" 'stdout'
+  assert_contains "$shale_out" 'shale:   and 2 more, not named here' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  named=0
+  while IFS= read -r line; do
+    case "$line" in
+      "shale:   $HOME/f"*) named=$((named + 1)) ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq 10 "$named" 'the number of paths named'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+}
+
+# A path only the higher of two layers provides, and a path both provide: one
+# entry each in the report however many layers hold them, because the walk
+# reports at the layer that decides the path.
+test_doctor_names_a_home_conflict_once_however_many_layers_provide_it() {
+  local count line
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  sandbox_write "$HOME" .zshrc 'mine'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  count=0
+  while IFS= read -r line; do
+    case "$line" in
+      "shale:   $HOME/.zshrc") count=$((count + 1)) ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq 1 "$count" 'the number of times the path is named'
 }
 
 # ----------------------------------------------- doctor's broken-link cases
@@ -6203,6 +6623,10 @@ test_doctor_a_link_into_the_built_tree_it_no_longer_provides_is_a_finding() {
   # It leads the note as well as the remedy, so it is the unindented line: every
   # other line of this block is detail under it, and an unindented one among the
   # findings reads as one more of them against a summary that has counted them.
+  #
+  # The delete rather than the apply because the link planted here is spelled as
+  # an absolute path, which no stow prunes.  The case below is the pair to this
+  # one, and it is what says so.
   assert_contains "$shale_out" \
     'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
     'stdout'
@@ -6278,6 +6702,152 @@ test_doctor_reports_the_links_a_directory_that_left_every_layer_kept() {
 $shale_out
 EOF
   assert_eq ' finding remedy summary' "$seen" 'the order of the report'
+}
+
+# The other cause of the same finding, and the one the remedy above is wrong
+# about: a single file that left its only layer leaves a link stow prunes by
+# itself, because the built tree still holds the directory it sits in.  'remove
+# the links named above' is more work than the state needs, and 'nothing needs
+# rebuilding or reapplying' is false about it - one apply clears it.
+#
+# The apply is run, so the claim is stow's rather than this suite's.
+test_doctor_the_remedy_for_a_link_an_apply_clears_is_the_apply() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .tmux.conf
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .tmux.conf
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_dangling_symlink "$HOME/.tmux.conf" 'the leftover link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.tmux.conf points at $HOME/.dotfiles/current/.tmux.conf, which the built tree no longer provides" \
+    'stdout'
+  assert_contains "$shale_out" 'shale: clear it with: shale apply' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and this is one of them' \
+    'stdout'
+  assert_not_contains "$shale_out" 'remove the links named above' 'stdout'
+  assert_not_contains "$shale_out" 'nothing needs rebuilding or reapplying' 'stdout'
+  # No sweep either: it is the alternative to removing them by hand, and nothing
+  # here has to be removed by hand.
+  assert_not_contains "$shale_out" 'stow -D -p' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # And the command it names, which is the whole of the claim.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply the remedy names'
+  assert_missing "$HOME/.tmux.conf" 'the link the apply cleared'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the apply'
+  assert_contains "$shale_out" 'shale: no problems found' 'the stdout after the apply'
+}
+
+# The same remedy for more than one of them, which is the other half of its
+# wording and the shape a directory of files leaving one layer makes.
+test_doctor_the_apply_remedy_reads_for_more_than_one_link() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .config/nvim/init.lua
+  mklayer local .config/nvim/extra.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  # The directory stays in the built tree, because the higher layer is not the
+  # only one that has it - the lower one keeps .config/nvim alive.
+  mklayer personal/base .config/nvim/keep.lua
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_real_dir "$HOME/.dotfiles/current/.config/nvim" 'the directory the tree still holds'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: clear them with: shale apply' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and every one of these is one of them' \
+    'stdout'
+  assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply the remedy names'
+  assert_missing "$HOME/.config/nvim/init.lua" 'the first link'
+  assert_missing "$HOME/.config/nvim/extra.lua" 'the second link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the apply'
+}
+
+# The discriminator's other half, which no directory can stand for: a link
+# spelled as an absolute path is one no stow prunes, wherever it sits.  2.3.1
+# says 'BUG in find_stowed_path?' on its stderr and carries on; 2.4.1 says
+# nothing; both leave the link.  So the link here is in a directory the built
+# tree still holds, and the remedy is still the delete.
+test_doctor_an_absolute_link_is_not_one_an_apply_clears() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.config/nvim"
+  sandbox_leaf "$sandbox_dir" gone.lua new
+  ln -s "$HOME/.dotfiles/current/.config/nvim/gone.lua" "$sandbox_path" ||
+    fail 'could not plant the link'
+  assert_real_dir "$HOME/.dotfiles/current/.config/nvim" 'the directory the tree still holds'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
+    'stdout'
+  assert_not_contains "$shale_out" 'clear them with' 'stdout'
+  # The apply that would have cleared a link stow wrote itself leaves this one.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_dangling_symlink "$HOME/.config/nvim/gone.lua" 'the link the apply left'
+}
+
+# Both causes at once, which is the shape neither remedy alone is right for: the
+# rm covers all of them and is what leads, and the apply is named for the ones it
+# takes off the list rather than left out.
+test_doctor_the_remedy_names_both_where_an_apply_clears_only_some() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .tmux.conf
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .tmux.conf
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_dangling_symlink "$HOME/.tmux.conf" 'the link an apply clears'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the link it cannot'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    'shale: remove the links named above; the built tree is correct and needs no rebuilding' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   an apply clears 1 of them and leaves the rest: stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds' \
+    'stdout'
+  assert_not_contains "$shale_out" 'nothing needs rebuilding or reapplying' 'stdout'
+  # The sweep is still the alternative for the ones that are left.
+  assert_contains "$shale_out" \
+    "shale:     stow -D -p --no-folding -d '$HOME/.dotfiles' -t '$HOME' current && shale apply" 'stdout'
+  assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
+  # And the apply it describes: one gone, one left, and doctor down to the one.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_missing "$HOME/.tmux.conf" 'the link the apply cleared'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the link it left'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor after the apply'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'the stdout after the apply'
+  assert_contains "$shale_out" \
+    'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
+    'the stdout after the apply'
 }
 
 # plant_orphans DIR N - N links in $HOME/DIR into the built tree at paths it has
@@ -6767,7 +7337,9 @@ test_doctor_says_when_there_is_no_built_tree_to_check_links_against() {
   mklayer personal/base .zshrc
   sandbox_mkdir "$HOME"
   sandbox_leaf "$sandbox_dir" .zshrc new
-  ln -s "$HOME/.dotfiles/current/.zshrc" "$sandbox_path" || fail 'could not plant the link'
+  # Relative, which is how an apply writes one.  An absolute link at a path a
+  # layer provides is a refusal of stow's own, and a finding of its own with it.
+  ln -s .dotfiles/current/.zshrc "$sandbox_path" || fail 'could not plant the link'
   assert_missing "$HOME/.dotfiles/current" 'the built tree'
   run_shale doctor
   assert_status 0 "$shale_status"
@@ -7391,7 +7963,9 @@ test_doctor_offers_no_build_it_has_already_said_will_fail() {
   mklayer work .vimrc
   sandbox_mkdir "$HOME"
   sandbox_leaf "$sandbox_dir" .zshrc new
-  ln -s "$HOME/.dotfiles/current/.zshrc" "$sandbox_path" || fail 'could not plant the link'
+  # Relative, which is how an apply writes one, and what keeps this setup sound:
+  # an absolute link at a path a layer provides is a refusal of stow's own.
+  ln -s .dotfiles/current/.zshrc "$sandbox_path" || fail 'could not plant the link'
   assert_missing "$HOME/.dotfiles/current" 'the built tree'
   run_shale doctor
   assert_status 0 "$shale_status" 'the sound setup'
@@ -7427,7 +8001,10 @@ test_doctor_offers_no_build_that_would_die_fetching() {
   run_shale doctor
   PATH=$saved
   assert_status 1 "$shale_status"
-  assert_contains "$shale_out" 'shale: git is not installed' 'stdout'
+  # The finding names the clone rather than the tool list, because the clone is
+  # the whole of why a missing git is a problem at all.
+  assert_contains "$shale_out" \
+    'shale: git is not installed, and a layer above has still to be cloned' 'stdout'
   assert_contains "$shale_out" \
     "shale: layer 'vim' has no directory at $HOME/.dotfiles/vim yet" 'stdout'
   assert_not_contains "$shale_out" 'build one with' 'stdout'
@@ -7444,23 +8021,45 @@ test_doctor_offers_no_build_that_would_die_fetching() {
 # And the half of it that is not build-blocking: no git, nothing to clone, so
 # the build runs and the offer stands.  Without this the case above passes on a
 # doctor that suppressed the offer whenever git was missing at all.
+#
+# A note, and exit 0.  A setup that builds and applies must not be called a
+# problem: shale runs git to clone a layer the machine has not got, this machine
+# has every one of them, and a finding here is a false one - the failure mode
+# worse than the defect it guards against.  Both commands are run, so the claim
+# is the commands' and not this case's reading of them.
 # shellcheck disable=SC2123
 test_doctor_offers_a_build_a_missing_git_does_not_stop() {
   local saved
-  conf 'base personal/base'
+  conf 'base personal/base' 'local local'
   mklayer personal/base .zshrc
+  mklayer local .vimrc
   stub_path_without git
   saved=$PATH
   PATH=$stub_path
   run_shale doctor
   PATH=$saved
-  assert_status 1 "$shale_status" 'the doctor'
+  assert_status 0 "$shale_status" 'the doctor'
   assert_contains "$shale_out" 'shale: git is not installed' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   shale runs it only to clone a layer this machine has not got, and every configured layer is already here' 'stdout'
   assert_contains "$shale_out" 'shale:   build one with: shale build' 'stdout'
+  assert_not_contains "$shale_out" 'problem found' 'stdout'
   PATH=$stub_path
   run_shale build
   PATH=$saved
   assert_status 0 "$shale_status" 'the build'
+  PATH=$stub_path
+  run_shale apply
+  PATH=$saved
+  assert_status 0 "$shale_status" 'the apply'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc" 'the applied link'
+  # And the run afterwards, on the setup both commands completed: still no
+  # problem, and still a note.
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 0 "$shale_status" 'the second doctor'
+  assert_contains "$shale_out" 'shale: git is not installed' 'the second doctor stdout'
 }
 
 # The other promise about a build that will not run: the built-tree note names a
@@ -8336,7 +8935,13 @@ test_doctor_a_layer_providing_the_running_script_is_a_finding() {
       "shale: layer 'local' provides the running script itself at $HOME/.dotfiles/local/.local/bin/shale" \
       "$variant stdout"
     assert_not_contains "$shale_out" "layer 'base' provides" "$variant stdout"
-    assert_contains "$shale_out" 'shale: 1 problem found' "$variant stdout"
+    # The second finding is the running script itself: it is a regular file at a
+    # path a layer provides, so stow refuses the apply as it would over any
+    # other.  Two findings, and both of them true of this one file.
+    assert_contains "$shale_out" \
+      "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" "$variant stdout"
+    assert_contains "$shale_out" "shale:   $HOME/.local/bin/shale" "$variant stdout"
+    assert_contains "$shale_out" 'shale: 2 problems found' "$variant stdout"
     assert_empty "$shale_err" "$variant stderr"
   done
 }
@@ -8357,7 +8962,9 @@ test_doctor_finds_a_layer_shipping_a_script_that_lives_in_home() {
   assert_status 1 "$shale_status"
   assert_contains "$shale_out" \
     "shale: layer 'local' provides the running script itself at $HOME/.dotfiles/local/shale" 'stdout'
-  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # And the same file again as the path stow will not write over.
+  assert_contains "$shale_out" "shale:   $HOME/shale" 'stdout'
+  assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
   assert_empty "$shale_err" 'stderr'
 }
 


### PR DESCRIPTION
Closes #92.

doctor exited 0 on the state where apply fails - a real dotfile at a path the layers provide, which is the commonest breakage there is and which two trials found independently. It exited 1 on a setup that works, when git was absent with nothing to clone. It invited deleting a real layer after a config parse error, and its dangling-link remedy was wrong for the case apply clears in one command.

1000 fuzz trials assert doctor 0 implies build 0 and apply 0, and doctor 1 implies one of them fails: zero violations. The same fuzzer on main finds 14 violations, all doctor 0 but apply failed. Seven healthy scenarios are byte-identical to main. Cost is +13 to 19 percent on a 2000-file tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)