### PR TITLE
Refuse a non-ASCII layer name on both supported bashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ name    path              url
 clone root — because several layers commonly come from one repository. Give the url once per clone
 root and leave it off the other lines that share it. Blank lines and `#` comments are ignored. The
 three fields are separated by whitespace and there is no quoting, so none of them can contain a
-space; [docs/layers.md](docs/layers.md) says what shale can and cannot tell you when one does.
+space; [docs/layers.md](docs/layers.md) says what shale can and cannot tell you when one does. A
+`name`, and each component of a `path`, is ASCII: it starts with an ASCII letter, a digit or `_`,
+and may go on with those, `.` and `-`. A directory with an accent in its name cannot be a layer —
+rename it. A `url` is not restricted.
 
 ```
 base    personal/base     git@github.com:you/dotfiles.git

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -38,6 +38,12 @@ cloned from a repository called `layer` — so shale refuses it only where a dir
 `doctor` cannot see it, because no url is fetched until the build — and the build then fails on the
 clone, unless `layer` really is a repository.
 
+Names are ASCII. A layer name, and each component of a layer path, starts with an ASCII letter, a
+digit or `_`, and may go on with those, `.` and `-`; a url is not restricted. A directory called
+`léyer` therefore cannot be a layer any more than `my layer` can — rename it. Shale is the same tool
+on macOS and on Linux, and an allow-list is what stops one `shale.conf` from meaning two different
+things on them.
+
 Several layers can come from one repository — `personal/base` and `personal/wsl` are two
 directories in one clone at `~/.dotfiles/personal`, so the url is given once, on the first of them.
 A layer needs no repository at all: `~/.dotfiles/local` with no url is this machine's own directory.

--- a/shale
+++ b/shale
@@ -162,15 +162,39 @@ config_error() {
 # quoted expansion is a literal in a case pattern on every bash there is.
 CR=$'\r'
 
-# A layer name and every component of a layer path share one grammar.
+# A layer name and every component of a layer path share one grammar: the
+# characters below, and a first character that is not '.' or '-'.
+#
+# Written out rather than as the ranges '[A-Za-z0-9]', because what a range
+# holds is the locale's collation order and not ASCII - the same reason stated
+# at translate_segment, reached here from the other side.  bash 5.0's
+# globasciiranges, on by default, holds a range to ASCII only as far as U+00FF;
+# above that it collates, as 3.2 - the floor, and the bash macOS ships - does
+# throughout.  Measured on 3.2.57 and 5.2.21 under en_US.UTF-8, and both halves
+# matter: 'é' was inside '[A-Za-z]' on 3.2 and outside it on 5.2, so a layer
+# path 'léyer' parsed on the macOS floor and was refused on Linux; and 'ẞ'
+# (U+1E9E), 'ı' (U+0131), 'Ａ' (U+FF21) and '٣' (U+0663) were inside it on both,
+# so those were names the allow-list was letting through everywhere.
+#
+# A list of single characters is the same set in every locale, which is what
+# makes the answer the same everywhere without a byte locale to enter - and
+# these run inside valid_path's loop, where entering one per component would
+# nest with any caller that had already entered.
+COMPONENT_FIRST='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_'
+# '-' stays last because that is where an unquoted set needs it.  Quoted, as it
+# is used below, every character of the expansion is a literal and no range
+# forms at all: measured on 3.2.57 and 5.2.21, '["a-c"]' matches 'a', 'c' and
+# '-' and not 'b'.  The order is kept so that inlining these unquoted later
+# would still be correct.
+COMPONENT_CHARS=$COMPONENT_FIRST'.-'
 valid_component() {
   case "${1-}" in
     '') return 1 ;;
-    [A-Za-z0-9_]*) ;;
+    ["$COMPONENT_FIRST"]*) ;;
     *) return 1 ;;
   esac
   case "$1" in
-    *[!A-Za-z0-9._-]*) return 1 ;;
+    *[!"$COMPONENT_CHARS"]*) return 1 ;;
   esac
   return 0
 }
@@ -295,14 +319,17 @@ EOF
     fi
 
     ok=1
+    # 'ASCII' is worth the word: a name refused for holding an accented letter
+    # reads as a name made of letters, and nothing else here would say why.
     if ! valid_component "$name"; then
       config_error "$CONF:$lineno: invalid layer name '$name'" \
-        "a name starts with a letter, digit or '_' and may also contain '.' and '-'"
+        "a name starts with an ASCII letter, digit or '_' and may also contain '.' and '-'"
       ok=0
     fi
     if ! valid_path "$path"; then
       config_error "$CONF:$lineno: invalid layer path '$path'" \
-        "a path is one or more names joined by '/', relative to $DOTFILES"
+        "a path is one or more names joined by '/', relative to $DOTFILES" \
+        "a name starts with an ASCII letter, digit or '_' and may also contain '.' and '-'"
       ok=0
     fi
     [ "$ok" -eq 1 ] || continue
@@ -486,11 +513,14 @@ range_is_safe() {
 # case in which a '*' has a '/' it could cross.
 #
 # Runs under the byte locale its caller sets, and needs to: the set inside a
-# '[...]' is checked with a range, and bash 5.0 and later restrict a range to
-# ASCII by default where bash 3.2 - the floor - orders it by the locale's
-# collation.  Measured: 'é', 'ß' and '½' are inside '[A-Za-z0-9_...]' on 3.2.57
-# and outside it on 5.2, so without the locale a pattern refused on Linux is
-# accepted on the macOS floor and emits a two-byte perl class there.
+# '[...]' is checked with a range, and what a range holds is the locale's
+# collation order rather than ASCII.  bash 5.0's globasciiranges, on by default,
+# holds a range to ASCII only as far as U+00FF; above that it collates, as bash
+# 3.2 - the floor - does throughout.  Measured under en_US.UTF-8: 'é', 'ß' and
+# '½' are inside '[A-Za-z0-9_...]' on 3.2.57 and outside it on 5.2, and 'ẞ'
+# (U+1E9E), 'Ａ' (U+FF21) and '٣' (U+0663) are inside it on both.  So without the
+# locale a pattern refused on Linux is accepted on the macOS floor, or accepted
+# on both, and emits a multi-byte perl class where it is accepted.
 #
 # This is the whole of the safety argument, so it is stated here rather than
 # spread over the callers.  Stow joins every pattern in the file into one

--- a/tests/run
+++ b/tests/run
@@ -1487,6 +1487,54 @@ test_config_invalid_names_are_rejected() {
   done
 }
 
+# A name and a path component are checked against a set, and that set used to be
+# written as the ranges '[A-Za-z0-9_]', which hold what the locale's collation
+# puts between their ends rather than ASCII.  Two failures came of it, and the
+# characters below are chosen to catch both: one from each side of U+00FF, which
+# is as far as bash 5.0's globasciiranges holds a range to ASCII - above it bash
+# 5 collates, as 3.2 - the floor, and the bash macOS ships - does throughout.
+#
+# So 'é' was inside those ranges on 3.2 and outside them on 5.2, and a
+# shale.conf naming such a layer parsed on one supported platform and was
+# refused on the other; while 'ẞ', 'Ａ' and '٣' were inside them on both, and
+# such a name was accepted everywhere by an allow-list meant to hold ASCII.
+# Spelling the set out one character at a time is what settles both, and this
+# case is the only thing that holds it: restoring the ranges leaves every other
+# case green.
+#
+# The pair is what makes this red on both CI jobs rather than only the macOS
+# one, which is why it is a pair: the 'é' half passes on bash 5 whatever shale
+# does.  The locale is set explicitly rather than inherited, since under
+# LC_ALL=C every one of these is refused however the matching works.
+test_config_refuses_a_non_ascii_name_and_path_on_every_bash() {
+  local c
+  # Built from explicit bytes rather than typed, so the case controls what it
+  # asks for whatever an editor between here and the repository would do with
+  # it: e-acute (U+00E9), capital sharp s (U+1E9E), fullwidth A (U+FF21) and
+  # arabic-indic three (U+0663), each measured inside the old ranges under
+  # en_US.UTF-8 on 3.2.57, and the last three on 5.2.21 as well.  A machine
+  # without en_US.UTF-8 runs this under C, where the old ranges refused them
+  # too, so it tests less there rather than failing - as at
+  # test_build_refuses_a_non_ascii_set_on_every_bash, and for the same reason.
+  for c in $'\303\251' $'\341\272\236' $'\357\274\241' $'\331\243'; do
+    conf "l${c}yer personal/base"
+    LC_ALL=en_US.UTF-8 run_shale build
+    assert_status 1 "$shale_status" "name 'l${c}yer' exit status"
+    assert_contains "$shale_err" \
+      "shale: $HOME/.dotfiles/shale.conf:1: invalid layer name 'l${c}yer'" \
+      "name 'l${c}yer' stderr"
+    assert_missing "$HOME/.dotfiles/current" "name 'l${c}yer' build output"
+
+    conf "base personal/l${c}yer"
+    LC_ALL=en_US.UTF-8 run_shale build
+    assert_status 1 "$shale_status" "path 'personal/l${c}yer' exit status"
+    assert_contains "$shale_err" \
+      "shale: $HOME/.dotfiles/shale.conf:1: invalid layer path 'personal/l${c}yer'" \
+      "path 'personal/l${c}yer' stderr"
+    assert_missing "$HOME/.dotfiles/current" "path 'personal/l${c}yer' build output"
+  done
+}
+
 test_config_duplicate_names_and_paths_are_rejected() {
   conf 'base personal/base' 'base other' 'wsl personal/base'
   run_shale build


### PR DESCRIPTION
Closes #103.

The rule is now stated in `README.md` §Configuration and `docs/layers.md`, since a refused user looks there first.