### PR TITLE
Say when stow's own list is what blocked a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,10 @@ out of `$HOME`, and at any depth a `.gitignore`, a `.gitmodules`, an editor back
 emacs autosave or lock file like `#notes#` or `.#lockfile`, and
 the furniture of RCS, CVS, Subversion, Darcs and Mercurial. Stow reads a package's own list *instead
 of* its built-in one rather than as well, so the file has to carry the whole of it; writing 2.4.1's
-is also what makes stow 2.3.1 apply the same tree. The patterns from each clone root's
+is also what makes stow 2.3.1 apply the same tree. That list applies with nothing configured, so a
+file it covers reaches `current/` and stops there with every command exiting 0; `shale which` on the
+path says so, and says the list is stow's own rather than one of yours — there is no line to edit,
+and only a different name gets the path linked. The patterns from each clone root's
 `.shale-ignore` are appended below that list, translated into stow's syntax with the glob they came
 from beside each one. A layer that ships a `.stow-local-ignore` at its own top level fails the build,
 naming the layer; one further down is an ordinary file and is copied like any other.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -30,6 +30,11 @@ the layer becomes a real link. Name the repository root as the layer and `~/.git
 and `~/CONTRIBUTING.md` join them. The subdirectory is what keeps the repository's own furniture out
 of the image.
 
+That list needs no configuring and applies to every setup, so a file it covers reaches `current/`
+and stops there with every command exiting 0. When something you shipped does not turn up in
+`$HOME`, `shale which` on it names the list that is blocking it — see [When a pattern arrives
+late](#when-a-pattern-arrives-late).
+
 The three fields are separated by whitespace and there is no quoting, so a name, a path and a url
 cannot contain a space or a tab. A directory called `my layer` cannot be a layer; rename it.
 `base    my layer` is not a syntax error, because it is the same three strings as a layer at `my`
@@ -449,6 +454,21 @@ shale:   shale writes that pattern into /home/you/.dotfiles/current/.stow-local-
 `which` answers before the first build, because it matches the globs itself rather than reading the
 file a build writes.
 
+It reads stow's own default list the same way, and says which list it is, because the remedy is not
+the same — there is no line to edit, and every build rewrites the file:
+
+```
+$ shale which 'notes~'
+winner    base  /home/you/.dotfiles/personal/base/notes~
+shale: note: 'notes~' is on stow's own ignore list — no apply links it
+shale:   stow's default ignore list: .+~
+shale:   shale writes that list into /home/you/.dotfiles/current/.stow-local-ignore on every build
+shale:   that list has no line to edit: nothing but a different name gets this path past it
+```
+
+`doctor` says nothing about that list. A layer holding a `.gitignore` is not a problem, and the
+answer is only wanted about the one path you went looking for.
+
 **Adding a pattern does not unlink what is already linked.** Stow skips an ignored path rather than
 unstowing it, so the link an earlier apply made stays exactly where it was, and the apply that comes
 after the pattern exits 0 without mentioning it. `shale doctor` names every such link:
@@ -456,7 +476,7 @@ after the pattern exits 0 without mentioning it. `shale doctor` names every such
 ```
 shale: /home/you/.DS_Store is a link into the built tree at a path the ignore list covers
 shale: remove the link named above
-shale:   it was made by an apply that ran before the pattern covering it existed
+shale:   it was made by an apply that ran before that path was on the list stow reads
 shale:   stow skips an ignored path rather than unstowing it, so no build or apply removes it
 shale:   the built tree is correct and needs no rebuilding
 ```

--- a/shale
+++ b/shale
@@ -438,7 +438,9 @@ IGNORE_NAME=.shale-ignore
 # literal in a case pattern on every bash there is, as it is for CR above.
 TAB=$'\t'
 
-# One literal newline, for the trailing-newline arm in path_is_ignored.
+# One literal newline, for the trailing-newline arm in path_is_ignored and for
+# the trim and the two newline refusals that stand for it in
+# path_is_stow_ignored.
 NL=$'\n'
 
 # Every pattern read, in the order the files were read: the glob as it was
@@ -464,7 +466,8 @@ ignore_error() {
 }
 
 # The saved LC_ALL while a byte-wise stretch is running.  One value, so these
-# must not nest; the two callers - the reader and the matcher - do not.
+# must not nest; the three callers - the reader and the two matchers - do not,
+# and the callers that want both matchers run them one after the other.
 BYTE_LC_HAD=0
 BYTE_LC_SAVED=
 enter_byte_locale() {
@@ -947,6 +950,154 @@ path_is_ignored() {
   done
   leave_byte_locale
   [ "${#IGNORED_BY[@]}" -gt 0 ]
+}
+
+# ------------------------------------------------------ stow's own ignore list
+
+# GNU Stow's default-ignore-list is what cmd_build writes into
+# current/.stow-local-ignore, and stow reads a package's own list instead of its
+# built-in one rather than as well - so those entries decide what an apply links
+# exactly as an ignore file's patterns do, on a setup nobody has configured at
+# all.  They are perl regexps and this is a glob matcher, deliberately: no
+# regexp shale did not write reaches a matcher.  Hence a table.
+#
+# Two columns per row: upstream's regexp, then the glob that answers the same
+# question, with a leading '/' where the regexp is anchored at the top of the
+# tree - the spelling an ignore file's own patterns use for that.  '.+' is one
+# character or more and '.*' is none or more, which is the whole of why '?*'
+# stands where '*' does not.  Every glob is one path component, which is what
+# lets the anchored rows below be answered from the first component alone.
+#
+# This is a second copy of the list cmd_build writes, and drift between them is
+# a wrong answer of exactly the kind reporting this exists to remove: a row
+# missing here is a file stow declines to link with which saying nothing.
+# test_which_stows_default_list_table_covers_the_list_build_writes is what holds
+# the two together, in both directions.
+#
+# stow's own '^/\.stow-local-ignore$' is not a row.  It is not in the file -
+# stow adds it to whatever the file holds - and which answers for that path in
+# words of its own already, no layer being allowed to provide one.
+STOW_IGNORE_LIST=(
+  'RCS' 'RCS'
+  '.+,v' '?*,v'
+  'CVS' 'CVS'
+  '\.\#.+' '.#?*'
+  '\.cvsignore' '.cvsignore'
+  '\.svn' '.svn'
+  '_darcs' '_darcs'
+  '\.hg' '.hg'
+  '\.git' '.git'
+  '\.gitignore' '.gitignore'
+  '\.gitmodules' '.gitmodules'
+  '.+~' '?*~'
+  '\#.*\#' '#*#'
+  '^/README.*' '/README*'
+  '^/LICENSE.*' '/LICENSE*'
+  '^/COPYING' '/COPYING'
+)
+
+# The rows of that table matching a path, as indexes of its regexp column.
+STOW_IGNORED_BY=()
+
+# Fills STOW_IGNORED_BY for $1, and is non-zero unless it filled it.  Separate
+# from path_is_ignored rather than folded into it because the report tells the
+# two apart: an ignore file's pattern names a file and a line to edit, and one
+# of these has neither.
+#
+# Byte locale for path_is_ignored's reasons, and never nested inside it: the two
+# share one saved LC_ALL, and the one caller that wants both answers runs them
+# one after the other.
+#
+# Three things upstream's regexps do that the globs beside them do not, all
+# three measured against stow 2.3.1 and 2.4.1.  All three are a newline in a
+# name, which is legal on every filesystem shale runs on, and all three come
+# from the same place: upstream wrote these patterns with a plain '.', and
+# perl's '.' never matches a newline where the shell's '?' and '*' do.  A
+# translated ignore pattern has none of this - translate_segment emits '(?s:.)',
+# which does match one.
+#
+# Stow anchors every entry with '$', which perl matches immediately before a
+# final newline as well as at the end, so '.+~' covers 'notes~\n' - a name the
+# shell's '?*~' does not match.  One trailing newline comes off the component
+# before it is matched, and only one, because that is the whole of what '$'
+# allows.  This is path_is_ignored's trailing-newline arm, spelled as a trim
+# rather than as a second pattern.
+#
+# A newline inside a name is linked by stow and would be called ignored here:
+# 'a\nb~' is linked by both versions.  A row whose glob holds a wildcard is
+# therefore refused outright for a component that still holds a newline once
+# that trailing one is off.  The rows with no wildcard are literals, which
+# cannot diverge that way.
+#
+# A newline in an *ancestor* component takes every segment row with it, literals
+# included, and this is the one that is not about the pattern at all.  Stow does
+# not take the basename it tests as the last component: it is
+# '(my $basename = $target) =~ s!.+/!!', and '.+' cannot cross a newline - so
+# where a newline stands anywhere before the last '/', the substitution removes
+# some other run of characters and what is left still holds a newline in a
+# position no anchored pattern can match.  'a\nb/notes~' and 'a\nb/RCS' are both
+# linked by both versions.  So nothing below a component holding a newline can
+# match a segment row, whatever that component is, and the descent stops there.
+# The anchored rows are unaffected: they go through stow's path regexp against
+# the whole of '/$target', not through that basename.
+path_is_stow_ignored() {
+  local rel=$1 i glob anchored wild rest raw seg matched try
+  STOW_IGNORED_BY=()
+  enter_byte_locale
+  i=0
+  while [ "$i" -lt "${#STOW_IGNORE_LIST[@]}" ]; do
+    glob=${STOW_IGNORE_LIST[$((i + 1))]}
+    anchored=0
+    case "$glob" in
+      /*)
+        anchored=1
+        glob=${glob#/}
+        ;;
+    esac
+    wild=0
+    case "$glob" in
+      *'*'* | *'?'*) wild=1 ;;
+    esac
+    matched=0
+    rest=$rel
+    while :; do
+      raw=${rest%%/*}
+      seg=${raw%"$NL"}
+      try=1
+      if [ "$wild" -eq 1 ]; then
+        case "$seg" in
+          *"$NL"*) try=0 ;;
+        esac
+      fi
+      if [ "$try" -eq 1 ]; then
+        # Unquoted on purpose: the pattern is a glob, and this is the one place
+        # it is matched.
+        # shellcheck disable=SC2254
+        case "$seg" in
+          $glob) matched=1 ;;
+        esac
+      fi
+      [ "$matched" -eq 0 ] || break
+      # An anchored row names the top of the tree and covers everything under
+      # it, so the first component is the whole of what decides.  Checked on
+      # both versions: a directory called COPYING takes its subtree with it.
+      [ "$anchored" -eq 0 ] || break
+      # Untrimmed on purpose: a directory called 'a\n' breaks the basename stow
+      # tests below it exactly as one called 'a\nb' does, and the trim above is
+      # about the pattern's end rather than about this.
+      case "$raw" in
+        *"$NL"*) break ;;
+      esac
+      case "$rest" in
+        */*) rest=${rest#*/} ;;
+        *) break ;;
+      esac
+    done
+    [ "$matched" -eq 0 ] || STOW_IGNORED_BY+=("$i")
+    i=$((i + 2))
+  done
+  leave_byte_locale
+  [ "${#STOW_IGNORED_BY[@]}" -gt 0 ]
 }
 
 # ----------------------------------------------------------- the scratch trees
@@ -1750,7 +1901,10 @@ home_conflict() {
   # ~/.gitignore of the reader's own beside a layer that has one - and a name
   # here that is not in the list is a refusal doctor goes quiet about.  Inline
   # rather than a predicate of its own because this runs once per composed path
-  # and a bash function call is not free at that count.
+  # and a bash function call is not free at that count - so this is a third
+  # spelling of the same list, beside the file cmd_build writes and
+  # STOW_IGNORE_LIST.  test_doctor_says_nothing_about_stows_default_list is what
+  # holds this one to the other two, by planting every name it covers in $HOME.
   #
   # Stow compiles the list into two regexps, checked against both 2.3.1 and
   # 2.4.1.  A pattern holding a '/' is matched against the whole path anchored
@@ -2370,9 +2524,10 @@ audit_built_tree() {
 }
 
 # The built tree under $1, relative to $CUR and '' for the whole of it, walked
-# for paths the ignore list covers that $HOME still holds a link to.  $2 is 1
-# when a directory above this one is already covered, which is the answer for
-# everything below it and saves testing every path against every pattern.
+# for paths the ignore list covers that $HOME still holds a link to.  $2 says
+# whether a directory above this one is already covered, and by which of the two
+# lists - which is the answer for everything below it, and saves testing every
+# path against every pattern.
 #
 # Every component is what decides, not the leaf: a pattern naming a directory
 # takes the whole subtree, and the links an earlier apply made are at the files
@@ -2381,8 +2536,17 @@ audit_built_tree() {
 # in docs/migrating.md is written from, and this is the same walk with the
 # patterns in place of that sweep's fixed list.
 #
+# Both lists, because both are in the file stow reads and a link left at a path
+# either of them covers is the same dead file in $HOME.  The list stow ships is
+# reachable without anyone configuring anything: shale once wrote a three-line
+# .stow-local-ignore, and stow 2.3.1's built-in list has no '\.gitmodules', so a
+# ~/.gitmodules linked by an apply older than either is exactly this shape.
+#
+# One source per path and never both: a path an ignore file covers is reported
+# as that, because that is the one with a line to edit.
+#
 # Counted into IGNORED_LINK_COUNT and kept, up to $3 of them, in
-# IGNORED_LINK_PATHS.
+# IGNORED_LINK_PATHS with the source that covered each in IGNORED_LINK_SOURCES.
 scan_ignored_links() {
   local rel=$1 inherited=$2 cap=$3 here e base srel ignored link
   here=$CUR${rel:+/$rel}
@@ -2399,12 +2563,21 @@ scan_ignored_links() {
     esac
     srel=${rel:+$rel/}$base
     ignored=$inherited
-    [ "$ignored" -eq 1 ] || ! path_is_ignored "$srel" || ignored=1
+    if [ "$ignored" -eq 0 ]; then
+      # Guarded on the count rather than left to the loop inside, because the
+      # ordinary config has no ignore line at all and the call still pays for
+      # two locale switches.
+      if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$srel"; then
+        ignored=1
+      elif path_is_stow_ignored "$srel"; then
+        ignored=2
+      fi
+    fi
     if [ -d "$e" ] && [ ! -L "$e" ]; then
       scan_ignored_links "$srel" "$ignored" "$cap"
       continue
     fi
-    [ "$ignored" -eq 1 ] || continue
+    [ "$ignored" -ne 0 ] || continue
     # --no-folding gives every file its own link, so the link that has to go is
     # at the leaf however far above it the pattern matched.
     link=$HOME_PREFIX/$srel
@@ -2414,28 +2587,36 @@ scan_ignored_links() {
     # them to remove it would be telling them to remove their own file.
     [ "$link" -ef "$e" ] || continue
     IGNORED_LINK_COUNT=$((IGNORED_LINK_COUNT + 1))
-    [ "$IGNORED_LINK_COUNT" -gt "$cap" ] || IGNORED_LINK_PATHS+=("$link")
+    if [ "$IGNORED_LINK_COUNT" -le "$cap" ]; then
+      IGNORED_LINK_PATHS+=("$link")
+      IGNORED_LINK_SOURCES+=("$ignored")
+    fi
   done
 }
 
-# The links an apply made before the pattern that now covers them existed.  The
-# workflow this is for is the ordinary one: apply, notice ~/.DS_Store, add the
-# pattern, apply again - and the link is still there, because stow skips an
-# ignored path rather than unstowing it.  Both versions walk straight past it,
-# the apply exits 0, and until this check nothing said so.
+# The links an apply made before the list covering them said so.  The workflow
+# this is for is the ordinary one: apply, notice ~/.DS_Store, add the pattern,
+# apply again - and the link is still there, because stow skips an ignored path
+# rather than unstowing it.  Both versions walk straight past it, the apply
+# exits 0, and until this check nothing said so.
+#
+# The same holds without an ignore file anywhere, which is why there is no
+# guard on the pattern count here: the list stow ships is in that file too, and
+# it grew.  ~/.gitmodules linked by an apply that ran under 2.3.1 before shale
+# wrote 2.4.1's list is the case, and it read as a clean report until now.
 #
 # Findings rather than notes: each one is a file in $HOME the reader has asked
-# not to have, and the remedy is one rm.  They stop no build, so BUILD_BLOCKED
-# is left alone.
+# not to have - or that stow was never going to link - and the remedy is one rm.
+# They stop no build, so BUILD_BLOCKED is left alone.
 audit_ignored_links() {
   local cap n i rest msg lines links made removes
-  [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] || return 0
   [ -d "$CUR" ] || return 0
   [ ! -L "$CUR" ] || return 0
   [ -n "${HOME-}" ] || return 0
 
   IGNORED_LINK_COUNT=0
   IGNORED_LINK_PATHS=()
+  IGNORED_LINK_SOURCES=()
   # audit_broken_links' cap, for its reasons: enough to act on, few enough to
   # stay inside a short terminal.
   cap=10
@@ -2444,17 +2625,20 @@ audit_ignored_links() {
   [ "$n" -gt 0 ] || return 0
 
   links='links'
-  made='they were made by an apply that ran before the patterns covering them existed'
+  # Neither source is named here, because each finding above names its own and
+  # the two can be mixed in one report.  What is true of both: the file stow
+  # reads did not cover this path when the apply that made the link ran.
+  made='they were made by applies that ran before those paths were on the list stow reads'
   removes='so no build or apply removes one'
   if [ "$n" -eq 1 ]; then
     links='link'
-    made='it was made by an apply that ran before the pattern covering it existed'
+    made='it was made by an apply that ran before that path was on the list stow reads'
     removes='so no build or apply removes it'
   fi
   if [ "$n" -le "$cap" ]; then
     i=0
     while [ "$i" -lt "${#IGNORED_LINK_PATHS[@]}" ]; do
-      finding "${IGNORED_LINK_PATHS[$i]} is a link into the built tree at a path the ignore list covers"
+      ignored_link_finding "$i"
       i=$((i + 1))
     done
     note "remove the $links named above" \
@@ -2465,13 +2649,13 @@ audit_ignored_links() {
   fi
 
   lines=("$n links under $HOME are into the built tree at paths the ignore list covers"
-    'they were made by an apply that ran before the patterns covering them existed'
+    "$made"
     'stow skips an ignored path rather than unstowing it, so no build or apply removes one'
     'remove them; the built tree is correct and needs no rebuilding')
   note ${lines[@]+"${lines[@]}"}
   i=0
   while [ "$i" -lt "${#IGNORED_LINK_PATHS[@]}" ]; do
-    finding "${IGNORED_LINK_PATHS[$i]} is a link into the built tree at a path the ignore list covers"
+    ignored_link_finding "$i"
     i=$((i + 1))
   done
   rest=$((n - cap))
@@ -2479,6 +2663,19 @@ audit_ignored_links() {
   # Every one of them is a link that has to go, so every one of them is a
   # finding: the cap changes what is printed and never what is wrong.
   FINDINGS=$((FINDINGS + rest))
+}
+
+# One finding for the link kept at index $1, in the words of the list that
+# covers it: a reader sent to an ignore file that does not hold the pattern goes
+# looking for a line nobody wrote, and one told there is nothing to edit when
+# there is would leave the pattern in place.
+ignored_link_finding() {
+  local i=$1
+  if [ "${IGNORED_LINK_SOURCES[$i]}" -eq 2 ]; then
+    finding "${IGNORED_LINK_PATHS[$i]} is a link into the built tree at a path stow's own ignore list covers"
+  else
+    finding "${IGNORED_LINK_PATHS[$i]} is a link into the built tree at a path the ignore list covers"
+  fi
 }
 
 # Non-zero unless the next apply removes the orphaned link $1 by itself, so that
@@ -2961,8 +3158,8 @@ which_describe() {
 }
 
 # The ignore patterns matching $1, one per line and each named where it was
-# written, on stderr with which's other notes.  IGNORED_BY is path_is_ignored's
-# answer for that same path.
+# written, on stderr with which's other notes.  IGNORED_BY and STOW_IGNORED_BY
+# are path_is_ignored's and path_is_stow_ignored's answers for that same path.
 #
 # Which is where this has to be said: a pattern that matches more than it was
 # meant to leaves the file it matched in the built tree and out of $HOME, with
@@ -2977,16 +3174,41 @@ which_describe() {
 # closes; doctor names every one of them, and this names the one asked about.
 report_ignored() {
   local rel=$1 i idx lines that link
-  that='that pattern'
-  [ "${#IGNORED_BY[@]}" -eq 1 ] || that='those patterns'
-  lines=("note: '$rel' is on the ignore list — no apply links it")
-  i=0
-  while [ "$i" -lt "${#IGNORED_BY[@]}" ]; do
-    idx=${IGNORED_BY[$i]}
-    lines[${#lines[@]}]="${IGNORE_FILES[$idx]}:${IGNORE_LINES[$idx]}: ${IGNORE_PATTERNS[$idx]}"
-    i=$((i + 1))
-  done
-  lines[${#lines[@]}]="shale writes $that into $CUR/.stow-local-ignore, which is the list stow reads"
+  # Whose list it is, in the first line, because the remedy turns on it: a
+  # reader told their file is ignored goes looking for the ignore file they
+  # wrote, and for a path stow's own list covers there is no such file.  Where
+  # both cover it the general headline stands and the two blocks below say the
+  # rest.
+  if [ "${#IGNORED_BY[@]}" -gt 0 ]; then
+    lines=("note: '$rel' is on the ignore list — no apply links it")
+    that='that pattern'
+    [ "${#IGNORED_BY[@]}" -eq 1 ] || that='those patterns'
+    i=0
+    while [ "$i" -lt "${#IGNORED_BY[@]}" ]; do
+      idx=${IGNORED_BY[$i]}
+      lines[${#lines[@]}]="${IGNORE_FILES[$idx]}:${IGNORE_LINES[$idx]}: ${IGNORE_PATTERNS[$idx]}"
+      i=$((i + 1))
+    done
+    lines[${#lines[@]}]="shale writes $that into $CUR/.stow-local-ignore, which is the list stow reads"
+  else
+    lines=("note: '$rel' is on stow's own ignore list — no apply links it")
+  fi
+  # The entry as upstream spells it, so that a reader who opens the built list
+  # finds the line this names.  There is nothing to edit there - every build
+  # overwrites the file - so the remedy is the path's name and nothing else.
+  #
+  # 'no line to edit' is scoped to these rows and says so, because a block above
+  # may have just named a file and a line: read top to bottom without the scope
+  # it contradicts the line before it.
+  if [ "${#STOW_IGNORED_BY[@]}" -gt 0 ]; then
+    i=0
+    while [ "$i" -lt "${#STOW_IGNORED_BY[@]}" ]; do
+      lines[${#lines[@]}]="stow's default ignore list: ${STOW_IGNORE_LIST[${STOW_IGNORED_BY[$i]}]}"
+      i=$((i + 1))
+    done
+    lines[${#lines[@]}]="shale writes that list into $CUR/.stow-local-ignore on every build"
+    lines[${#lines[@]}]='that list has no line to edit: nothing but a different name gets this path past it'
+  fi
   if [ -n "${HOME-}" ]; then
     link=$HOME_PREFIX/$rel
     if [ -L "$link" ] && [ "$link" -ef "$CUR/$rel" ]; then
@@ -3164,8 +3386,10 @@ cmd_build() {
   # it: 2.3.1's built-in list has no \.gitmodules, so writing 2.4.1's list is
   # the whole of what makes an apply land the same tree on both.
   #
-  # doctor reads this same list as stow_ignores, to know which paths in $HOME an
-  # apply never touches.  A pattern added here is added there.
+  # Two readers hold a copy of this list and neither can be generated from it:
+  # home_conflict, to know which paths in $HOME an apply never touches, and
+  # STOW_IGNORE_LIST, which which reports from.  A pattern added here is added
+  # to both, and a case fails for each that is missed.
   printf '%s\n' \
     "# Written by shale on every build, which overwrites whatever is here:" \
     "# edit a layer, not this file." \
@@ -3879,8 +4103,12 @@ cmd_which() {
   # branch below prints it: an ignored path is ignored whether or not a layer
   # provides it, and the reader arrives asking about a file that is missing
   # rather than about which layer wins.
+  #
+  # Both lists, and both answers kept: stow reads them out of one file and a
+  # path can be on either or on both, while what to do about it differs.
   ignored=0
   ! path_is_ignored "$rel" || ignored=1
+  ! path_is_stow_ignored "$rel" || ignored=1
 
   # Highest precedence first, which is the order the answer prints in and the
   # reverse of the config's.
@@ -3983,6 +4211,19 @@ cmd_which() {
   # First among the notes: the table above says which layer's copy lands in the
   # built tree, which is true and is not the answer to why the file is not in
   # $HOME.
+  #
+  # Before that one, and unconditionally: the composer drops a '.git' at every
+  # depth, so a path with one in it never reaches the built tree at all.  Every
+  # such path is on stow's list too and the note below says so, but a reader
+  # sent to look at the list would open the built tree and find nothing there to
+  # look at.  Not conditional on the ignore answer either - an ancestor holding
+  # a newline takes the list's rows off this path and leaves the composer's
+  # skip exactly where it was.
+  case "/$rel/" in
+    */.git/*)
+      emit "note: no build composes a .git — shale skips one at every depth, so this path never reaches $CUR"
+      ;;
+  esac
   [ "$ignored" -eq 0 ] || report_ignored "$rel"
 
   if [ "$upper" -ge 0 ]; then

--- a/tests/run
+++ b/tests/run
@@ -6385,6 +6385,78 @@ test_doctor_an_ignored_path_is_not_an_apply_conflict() {
   assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
 }
 
+# The same for the entries stow ships, and doctor's side of #104: nothing is
+# wrong with a layer holding a .gitignore, so doctor says nothing about one.
+# The reader needs to hear about it only when they go looking for a file that
+# did not arrive, which is the question 'which' answers.
+#
+# Silence with a control, so a doctor gone quiet altogether fails as loudly as
+# one gone noisy: the .zshrc below is planted the same way and is the one
+# finding.  And silence that is checked rather than assumed - every planted file
+# is still its own content after the apply, so stow really did leave all of them
+# where they were.
+#
+# '.git' is not among them.  The composer drops one at every depth, so it never
+# reaches the built tree and this walk never sees it.
+test_doctor_says_nothing_about_stows_default_list() {
+  local names i rel
+  names=('RCS/x' 'file,v' 'CVS/x' '.#lock' '.cvsignore' '.svn/x' '_darcs/x' '.hg/x'
+    '.gitignore' '.gitmodules' 'notes~' '#notes#' 'README.md' 'LICENSE' 'COPYING')
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    mklayer common/base "${names[$i]}"
+    i=$((i + 1))
+  done
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_write "$HOME" .zshrc 'mine, and not a link'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    rel=${names[$i]}
+    case "$rel" in
+      */*) sandbox_write "$HOME/${rel%/*}" "${rel##*/}" 'mine, and not a link' ;;
+      *) sandbox_write "$HOME" "$rel" 'mine, and not a link' ;;
+    esac
+    i=$((i + 1))
+  done
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor with the control conflict'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.zshrc" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    assert_not_contains "$shale_out" "$HOME/${names[$i]}" "the finding for '${names[$i]}'"
+    i=$((i + 1))
+  done
+  # The control out of the way, and nothing at all is left to report.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.zshrc" || fail 'could not remove the control'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor with the control gone'
+  assert_eq 'shale: no problems found' "$shale_out" 'the second stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    rel=${names[$i]}
+    assert_eq 'mine, and not a link' "$(cat "$HOME/$rel")" "the file stow left alone: '$rel'"
+    i=$((i + 1))
+  done
+  # And after the apply, which is the state the stale-link walk runs over on
+  # every doctor from now on: a layer holding these names, applied, with no link
+  # at any of them, is a clean report.  The walk reporting one of them here
+  # would be a finding on a setup with nothing wrong with it.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the apply'
+  assert_eq 'shale: no problems found' "$shale_out" 'the third stdout'
+}
+
 # #92's guarantee, against the one input that would break it: a pattern shale
 # refuses stops every build and every apply, so doctor must not report it green.
 # The refusal is a finding, it blocks the build, and no line offering a build
@@ -6450,6 +6522,140 @@ test_doctor_names_links_left_behind_by_a_new_pattern() {
   assert_status 0 "$shale_status" 'the doctor after the removal'
   assert_not_contains "$shale_out" 'the ignore list covers' 'the second stdout'
   assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+}
+
+# The same finding for the list stow ships, which needs no ignore file to reach
+# and which is why that walk now runs on every doctor.  Reachable without a
+# hand: shale once wrote a three-line .stow-local-ignore, and stow 2.3.1's
+# built-in list has no '\.gitmodules', so an apply under either linked this path
+# and no apply since has removed it.  Planted here, because no shale in the tree
+# makes one.
+#
+# Named as stow's list rather than as 'the ignore list': there is no file of the
+# reader's holding that pattern, and sending them to look for one sends them
+# after a line nobody wrote.
+test_doctor_names_a_link_left_by_stows_own_list() {
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mklayer common/base .gitmodules
+  mklayer common/base 'CVS/Entries'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_missing "$HOME/.gitmodules"
+  assert_missing "$HOME/CVS"
+  # No ignore file anywhere, so this is the walk running on a config nobody has
+  # configured.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor before the links are planted'
+  assert_eq 'shale: no problems found' "$shale_out" 'the first stdout'
+  sandbox_leaf "$HOME" .gitmodules new
+  ln -s "$HOME/.dotfiles/current/.gitmodules" "$sandbox_path" ||
+    fail 'could not plant the link'
+  # Stale through the directory above it, which is the half a check on the leaf
+  # name alone would miss: nothing is called 'Entries' on that list.
+  sandbox_mkdir "$HOME/CVS"
+  sandbox_leaf "$HOME/CVS" Entries new
+  ln -s "$HOME/.dotfiles/current/CVS/Entries" "$sandbox_path" ||
+    fail 'could not plant the nested link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor with the links'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.gitmodules is a link into the built tree at a path stow's own ignore list covers" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/CVS/Entries is a link into the built tree at a path stow's own ignore list covers" 'stdout'
+  assert_contains "$shale_out" 'shale: remove the links named above' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   they were made by applies that ran before those paths were on the list stow reads' 'stdout'
+  assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
+  # One rm each, and nothing rebuilt or reapplied.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.gitmodules" || fail 'could not remove the link'
+  sandbox_mkdir "$HOME/CVS"
+  rm -f "$sandbox_dir/Entries" || fail 'could not remove the nested link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the removal'
+  assert_not_contains "$shale_out" 'ignore list covers' 'the third stdout'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+}
+
+# One finding, not two, for a path both lists cover - and in the words of the
+# one with a line to edit, because that is the remedy that stops it coming back.
+test_doctor_a_link_both_lists_cover_is_reported_once() {
+  local hits
+  conf 'base common/base'
+  mkignore common '*modules'
+  mklayer common/base .zshrc
+  mklayer common/base .gitmodules
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_leaf "$HOME" .gitmodules new
+  ln -s "$HOME/.dotfiles/current/.gitmodules" "$sandbox_path" ||
+    fail 'could not plant the link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.gitmodules is a link into the built tree at a path the ignore list covers" 'stdout'
+  assert_not_contains "$shale_out" "stow's own ignore list covers" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  hits=$(printf '%s\n' "$shale_out" | grep -c 'is a link into the built tree')
+  assert_eq 1 "$hits" 'findings naming that link'
+}
+
+# A '.git' is never composed, so a link at one is dangling and belongs to the
+# broken-link audit rather than to this walk - which cannot see it, the built
+# tree having no such path.  Asserted because the two audits run over the same
+# $HOME and a path in both would be counted twice.
+test_doctor_a_link_at_a_dot_git_is_only_a_broken_link() {
+  local hits
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mklayer common/base .git/config
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_missing "$HOME/.dotfiles/current/.git" 'the built tree'
+  sandbox_leaf "$HOME" .git new
+  ln -s "$HOME/.dotfiles/current/.git" "$sandbox_path" || fail 'could not plant the link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.git points at $HOME/.dotfiles/current/.git, which the built tree no longer provides" 'stdout'
+  assert_not_contains "$shale_out" 'ignore list covers' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  hits=$(printf '%s\n' "$shale_out" | grep -c "$HOME/.git ")
+  assert_eq 1 "$hits" 'findings naming that link'
+}
+
+# The ancestor-newline rule, in the walk where getting it wrong tells someone to
+# delete a file that is theirs: stow links 'a\nb/notes~' - measured on 2.3.1 and
+# on 2.4.1 - so the link an apply made there is one it maintains, and calling it
+# stale would send the reader to remove a working link.
+#
+# The control is the same name under an ordinary directory, whose link is
+# planted the same way and is the finding.
+test_doctor_says_nothing_about_a_link_below_a_newline() {
+  local dir
+  dir=$(printf 'a\nb')
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mklayer common/base "$dir/notes~"
+  mklayer common/base 'plain/notes~'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_symlink_to "$HOME/$dir/notes~" "$HOME/.dotfiles/current/$dir/notes~"
+  assert_missing "$HOME/plain/notes~"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor with the link stow maintains'
+  assert_eq 'shale: no problems found' "$shale_out" 'stdout'
+  # The control, planted at the path stow really does decline.
+  sandbox_mkdir "$HOME/plain"
+  sandbox_leaf "$HOME/plain" 'notes~' new
+  ln -s "$HOME/.dotfiles/current/plain/notes~" "$sandbox_path" ||
+    fail 'could not plant the control link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor with the control'
+  assert_contains "$shale_out" \
+    "shale: $HOME/plain/notes~ is a link into the built tree at a path stow's own ignore list covers" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
 }
 
 # An ignore file nothing reads is silence otherwise: the patterns in it do
@@ -10534,6 +10740,309 @@ test_which_says_nothing_about_ignoring_an_ordinary_path() {
   run_shale which swap
   assert_status 0 "$shale_status" 'the one-character near miss'
   assert_empty "$shale_err" 'the one-character near miss stderr'
+}
+
+# The list stow ships with, which shale writes into the built tree itself, and
+# the whole of why which reads it: an editor backup in a layer hits it with
+# nobody having configured anything at all.  The file is composed, stow declines
+# to link it, and every command exits 0 - so without this the answer names the
+# winning layer and says nothing about the file not being there.
+#
+# 'stow's own ignore list' in the first line rather than 'the ignore list': the
+# reader's next move is to open the ignore file they wrote, and for this path
+# there is no such file and no line in one.  The remedy named is the only one
+# there is.
+test_which_a_path_on_stows_default_list_names_that_list() {
+  conf 'base common/base'
+  mklayer common/base 'notes~' 'an editor backup'
+  mklayer common/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  assert_missing "$HOME/notes~"
+  assert_exists "$HOME/.dotfiles/current/notes~" 'the composed copy'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  run_shale which 'notes~'
+  assert_status 0 "$shale_status"
+  assert_eq "winner    base  $HOME/.dotfiles/common/base/notes~" "$shale_out" 'stdout'
+  assert_eq "shale: note: 'notes~' is on stow's own ignore list — no apply links it
+shale:   stow's default ignore list: .+~
+shale:   shale writes that list into $HOME/.dotfiles/current/.stow-local-ignore on every build
+shale:   that list has no line to edit: nothing but a different name gets this path past it" \
+    "$shale_err" 'stderr'
+}
+
+# Every entry of that list, not a sample.  The table which matches with is a
+# second copy of the file cmd_build writes, and an entry missing from it is a
+# file stow declines to link with which saying nothing - which is this issue.
+# Each name below is chosen for the entry beside it, and each is confirmed
+# absent from $HOME through a real stow rather than asserted.
+#
+# '\.git' is the one entry no apply can witness: the composer drops a .git at
+# every depth, so it never reaches the built tree for stow to skip.  It is still
+# asked about, a layer holding one being exactly the case that brings someone
+# here, and its absence from the built tree is asserted instead.
+test_which_every_entry_of_stows_default_list_is_named() {
+  local patterns paths i rel
+  patterns=(RCS '.+,v' CVS '\.\#.+' '\.cvsignore' '\.svn' _darcs '\.hg' '\.git'
+    '\.gitignore' '\.gitmodules' '.+~' '\#.*\#' '^/README.*' '^/LICENSE.*' '^/COPYING')
+  paths=('RCS/x' 'file,v' 'CVS/x' '.#lock' '.cvsignore' '.svn/x' '_darcs/x' '.hg/x'
+    '.git/config' '.gitignore' '.gitmodules' 'notes~' '#notes#' 'README.md' 'LICENSE'
+    'COPYING')
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  i=0
+  while [ "$i" -lt "${#paths[@]}" ]; do
+    mklayer common/base "${paths[$i]}"
+    i=$((i + 1))
+  done
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  i=0
+  while [ "$i" -lt "${#paths[@]}" ]; do
+    rel=${paths[$i]}
+    assert_missing "$HOME/$rel" "linked despite '${patterns[$i]}'"
+    case "$rel" in
+      .git/*) assert_missing "$HOME/.dotfiles/current/$rel" 'the composed copy' ;;
+      *) assert_exists "$HOME/.dotfiles/current/$rel" "the composed copy of '$rel'" ;;
+    esac
+    run_shale which "$rel"
+    assert_status 0 "$shale_status" "which '$rel'"
+    assert_contains "$shale_err" "shale:   stow's default ignore list: ${patterns[$i]}" \
+      "which '$rel' stderr"
+    i=$((i + 1))
+  done
+}
+
+# The near misses of that list, and the silence around it.  Every entry is
+# anchored at both ends of a whole path component, so a prefix of one is not a
+# match and neither is a longer name: '\.git' is not '.gitconfig' or '.gitkeep',
+# and '\.gitignore' is not the 'ignore' that core.excludesFile defaults to.
+# '.+' is one character or more, so '~', ',v' and '.#' are names of their own
+# rather than the tails of patterns.  The three anchored entries name the top of
+# the tree, so a README below it is an ordinary file.
+#
+# A note on any of these would be a wrong answer in the other direction - a file
+# that is in $HOME with which saying nothing links it - so the apply is asserted
+# here as well as the silence.
+test_which_says_nothing_about_the_near_misses_of_stows_default_list() {
+  local names i rel spelling
+  names=('.gitconfig' '.gitkeep' '.config/git/ignore' 'notes' 'a~b' 'CVSX' '.hgrc'
+    'docs/README.md' 'sub/LICENSE' 'sub/COPYING' '~' ',v' '.#' '#' '##x' 'x.cvsignore'
+    '.svnx' '_darcsX' 'RCSX' '.gitx' '.cvsignorex' '.hgx')
+  conf 'base common/base'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    mklayer common/base "${names[$i]}"
+    i=$((i + 1))
+  done
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    rel=${names[$i]}
+    assert_symlink_to "$HOME/$rel" "$HOME/.dotfiles/current/$rel" "the link for '$rel'"
+    # A leading './' for the file called '~': bare, that spelling is $HOME
+    # itself and names no path under it.
+    spelling=$rel
+    [ "$rel" != '~' ] || spelling=./$rel
+    run_shale which "$spelling"
+    assert_status 0 "$shale_status" "which '$rel'"
+    assert_empty "$shale_err" "which '$rel' stderr"
+    i=$((i + 1))
+  done
+}
+
+# Both lists at once, because stow reads them out of the one file and a path can
+# be on either or on both.  The first line stays the general one where an ignore
+# file covers the path too - there is a line to edit, and it is named - and the
+# block below it says the rest.
+test_which_stows_default_list_and_an_ignore_file_are_both_named() {
+  conf 'base common/base'
+  mkignore common '*.md'
+  mklayer common/base README.md
+  mklayer common/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_missing "$HOME/README.md"
+  run_shale which README.md
+  assert_status 0 "$shale_status"
+  assert_eq "shale: note: 'README.md' is on the ignore list — no apply links it
+shale:   $HOME/.dotfiles/common/.shale-ignore:1: *.md
+shale:   shale writes that pattern into $HOME/.dotfiles/current/.stow-local-ignore, which is the list stow reads
+shale:   stow's default ignore list: ^/README.*
+shale:   shale writes that list into $HOME/.dotfiles/current/.stow-local-ignore on every build
+shale:   that list has no line to edit: nothing but a different name gets this path past it" \
+    "$shale_err" 'stderr'
+}
+
+# The other half of that answer, for stow's list as for an ignore file's
+# patterns: stow skips an ignored path rather than unstowing it, so a link at
+# one stays where it is.  Reachable without a hand: stow 2.3.1's built-in list
+# has no '\.gitmodules', so an apply run by a shale that did not write this file
+# left a link at exactly this path.  Planted here, no shale in the tree making
+# one.
+test_which_a_path_on_stows_default_list_with_a_live_link_says_both() {
+  conf 'base common/base'
+  mklayer common/base .gitmodules
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_leaf "$HOME" .gitmodules new
+  ln -s "$HOME/.dotfiles/current/.gitmodules" "$sandbox_path" ||
+    fail 'could not plant the link'
+  run_shale which .gitmodules
+  assert_status 0 "$shale_status"
+  assert_eq "shale: note: '.gitmodules' is on stow's own ignore list — no apply links it
+shale:   stow's default ignore list: \\.gitmodules
+shale:   shale writes that list into $HOME/.dotfiles/current/.stow-local-ignore on every build
+shale:   that list has no line to edit: nothing but a different name gets this path past it
+shale:   a link an earlier apply made is still at $HOME/.gitmodules, because stow skips an ignored path rather than unstowing it
+shale:   remove that link by hand: no build or apply removes it" "$shale_err" 'stderr'
+}
+
+# A newline in a name, which these entries answer differently from a translated
+# ignore pattern because upstream wrote them with a plain '.'.
+#
+# Inside a name, perl's '.' never matches one and the shell's '?' and '*' do, so
+# the glob standing in for '.+~' matches a name stow links: 'a\nb~' is linked by
+# 2.3.1 and by 2.4.1, measured.  Called ignored it would be a wrong answer in
+# the other direction - a file that is in $HOME with which saying it cannot be.
+#
+# At the end of a name it goes the other way: stow anchors the list with '$',
+# which perl matches immediately before a final newline, so 'notes~\n' is
+# covered by '.+~' and the shell's '?*~' does not match it.  Both are in one
+# case because one arm closes each and a fix for either alone breaks the other.
+test_which_stows_default_list_reads_a_newline_as_stow_reads_it() {
+  local inside trailing
+  inside=$(printf 'a\nb~')
+  # printf -v rather than a command substitution, which strips exactly the
+  # trailing newline this name is about.
+  printf -v trailing 'notes~\n'
+  conf 'base common/base'
+  mklayer common/base "$inside" 'a newline in the middle of the name'
+  mklayer common/base "$trailing" 'a newline at the end of the name'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  assert_symlink_to "$HOME/$inside" "$HOME/.dotfiles/current/$inside"
+  assert_missing "$HOME/$trailing"
+  run_shale which "$inside"
+  assert_status 0 "$shale_status" 'which on the name holding one'
+  assert_empty "$shale_err" 'the which stderr'
+  run_shale which "$trailing"
+  assert_status 0 "$shale_status" 'which on the name ending in one'
+  assert_contains "$shale_err" "stow's default ignore list: .+~" 'the trailing which stderr'
+}
+
+# The third way a newline diverges, and the one that is not about the patterns
+# at all: stow does not test the last component of the path. Stow.pm's 'ignore'
+# takes its basename with '(my $basename = $target) =~ s!.+/!!', and '.+' cannot
+# cross a newline - so where one stands anywhere before the last '/', the
+# substitution takes some other run of characters out and what is left still
+# holds a newline in a position no anchored pattern can match. Every segment
+# entry goes with it, the literals included: 'a\nb/notes~' and 'a\nb/RCS' are
+# both linked by 2.3.1 and by 2.4.1, measured against both.
+#
+# Called ignored they would be the wrong answer in the direction that costs -
+# a file that is in $HOME, with which saying no apply links it and, once a link
+# is there, telling the reader to remove it by hand.
+#
+# The control is the same four names under an ordinary directory, so a matcher
+# that stopped looking below the top level altogether fails here as well.
+test_which_stows_default_list_stops_at_a_newline_in_an_ancestor() {
+  local dir names i rel
+  dir=$(printf 'a\nb')
+  names=('notes~' 'RCS' '.gitignore' 'file,v')
+  conf 'base common/base'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    mklayer common/base "$dir/${names[$i]}"
+    mklayer common/base "plain/${names[$i]}"
+    i=$((i + 1))
+  done
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    rel=$dir/${names[$i]}
+    assert_symlink_to "$HOME/$rel" "$HOME/.dotfiles/current/$rel" \
+      "the link below the newline for '${names[$i]}'"
+    run_shale which "$rel"
+    assert_status 0 "$shale_status" "which below the newline on '${names[$i]}'"
+    assert_empty "$shale_err" "which below the newline on '${names[$i]}' stderr"
+    rel=plain/${names[$i]}
+    assert_missing "$HOME/$rel" "the control for '${names[$i]}'"
+    run_shale which "$rel"
+    assert_status 0 "$shale_status" "which on the control '${names[$i]}'"
+    assert_contains "$shale_err" "stow's default ignore list:" \
+      "the control stderr for '${names[$i]}'"
+    i=$((i + 1))
+  done
+}
+
+# Why a '.git' does not arrive, which is not the ignore list: the composer drops
+# one at every depth, so the path never reaches the built tree for stow to
+# decline it. Every such path is on stow's list too and that note follows, but a
+# reader sent only to the list would open the built tree and find nothing there
+# to look at.
+test_which_a_dot_git_says_no_build_composes_one() {
+  conf 'base common/base'
+  mklayer common/base .git/config
+  mklayer common/base .config/nvim/.git/HEAD
+  mklayer common/base .gitconfig
+  mklayer common/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_missing "$HOME/.dotfiles/current/.git" 'the built tree'
+  assert_missing "$HOME/.dotfiles/current/.config/nvim/.git" 'the built tree'
+  run_shale which .git/config
+  assert_status 0 "$shale_status"
+  assert_eq "shale: note: no build composes a .git — shale skips one at every depth, so this path never reaches $HOME/.dotfiles/current
+shale: note: '.git/config' is on stow's own ignore list — no apply links it
+shale:   stow's default ignore list: \\.git
+shale:   shale writes that list into $HOME/.dotfiles/current/.stow-local-ignore on every build
+shale:   that list has no line to edit: nothing but a different name gets this path past it" \
+    "$shale_err" 'stderr'
+  # At any depth, which is where the composer drops it.
+  run_shale which .config/nvim/.git/HEAD
+  assert_status 0 "$shale_status" 'the nested one'
+  assert_contains "$shale_err" \
+    'shale: note: no build composes a .git — shale skips one at every depth' 'the nested stderr'
+  # And never on a name that merely begins with it.
+  run_shale which .gitconfig
+  assert_status 0 "$shale_status" 'the near miss'
+  assert_empty "$shale_err" 'the near miss stderr'
+  assert_exists "$HOME/.dotfiles/current/.gitconfig" 'the composed copy'
+}
+
+# The table path_is_stow_ignored matches with is a second copy of the list
+# cmd_build writes, and drift between them is a silent wrong answer whichever
+# way it goes: an entry the table lost is a file stow declines to link with
+# which saying nothing, and an entry the written file lost is a file which calls
+# blocked that an apply then links.
+#
+# The regexp column is compared with the file as stow reads it - comment lines
+# out, and an inline comment off the end, which both versions strip from the
+# whitespace before its '#'.  The table is two single-quoted fields on one line
+# per row and no entry holds a single quote, which is what makes the column
+# extractable without a parser; the second assertion is what keeps that shape.
+test_which_stows_default_list_table_covers_the_list_build_writes() {
+  local written rows table misshapen
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  written=$(sed -e 's/[[:space:]][[:space:]]*#.*$//' -e '/^#/d' -e '/^$/d' \
+    "$HOME/.dotfiles/current/.stow-local-ignore")
+  rows=$(sed -n -e '/^STOW_IGNORE_LIST=($/,/^)$/p' "$SHALE" | sed -e '1d' -e '$d')
+  table=$(printf '%s\n' "$rows" | sed -e "s/^  '//" -e "s/'.*\$//")
+  assert_eq "$written" "$table" 'the table against the list build writes'
+  misshapen=$(printf '%s\n' "$rows" | grep -vc "^  '[^']*' '[^']*'\$")
+  assert_eq 0 "$misshapen" 'table rows that are not a regexp and a glob'
 }
 
 # A layer shipping the file shale reads: the table names the layer holding it


### PR DESCRIPTION
Closes #104.

`doctor`'s stale-link scan now covers stow's list too, which the functional review found asymmetric: a leftover link at a path the default list covers was reported for a `.shale-ignore` pattern and by nothing for the list shale writes itself.

Follow-ups recorded rather than done here: the cost of the per-path match in doctor's walk (measured, three alternatives compared), and `home_conflict`'s inline copy of the list, which lacks the newline rules.