### PR TITLE
Route doctor and which through one view of stow's default list

### DIFF
--- a/shale
+++ b/shale
@@ -974,9 +974,15 @@ path_is_ignored() {
 # test_which_stows_default_list_table_covers_the_list_build_writes is what holds
 # the two together, in both directions.
 #
-# stow's own '^/\.stow-local-ignore$' is not a row.  It is not in the file -
-# stow adds it to whatever the file holds - and which answers for that path in
-# words of its own already, no layer being allowed to provide one.
+# stow's own '^/\.stow-local-ignore$' is not a row, because a row here is
+# compared with the file cmd_build writes and this entry is not in it: stow adds
+# it to whatever the file holds.  home_conflict carries an arm of its own for it
+# instead.  which says nothing about it, which is right for the name itself - no
+# build accepts a layer providing one, and which says that instead - and is a
+# gap for '.stow-local-ignore' with a trailing newline, which composes, which
+# stow's '$' then covers, and which no apply links.  Naming that one wants
+# wording this table cannot supply, every line report_ignored prints about these
+# rows pointing at a file entry that is not there.
 STOW_IGNORE_LIST=(
   'RCS' 'RCS'
   '.+,v' '?*,v'
@@ -996,17 +1002,60 @@ STOW_IGNORE_LIST=(
   '^/COPYING' '/COPYING'
 )
 
-# The rows of that table matching a path, as indexes of its regexp column.
-STOW_IGNORED_BY=()
-
-# Fills STOW_IGNORED_BY for $1, and is non-zero unless it filled it.  Separate
-# from path_is_ignored rather than folded into it because the report tells the
-# two apart: an ignore file's pattern names a file and a line to edit, and one
-# of these has neither.
+# That table's glob column as two extglob alternations - the anchored rows and
+# the segment rows apart, because the first component is the whole of what an
+# anchored row can match.  One 'case' against one of these answers what a loop
+# over the table answers, and answers it in a fraction of the time: doctor tests
+# every composed path against this list twice over, and a walk of sixteen rows
+# per path is what made it four times slower in #104.
 #
-# Byte locale for path_is_ignored's reasons, and never nested inside it: the two
-# share one saved LC_ALL, and the one caller that wants both answers runs them
-# one after the other.
+# Derived here rather than written out, and this is the point of it.  These
+# thirteen globs stood as a hand-written 'case' in home_conflict as well until
+# #108, where the copy that had never been given the newline rules below made
+# doctor pass a setup apply then refused.  A copy cannot be kept correct by
+# saying it must be; there is one list, and everything that matches against it
+# reads it from here.
+STOW_TOP_ALT=
+STOW_SEG_ALT=
+derive_stow_alternations() {
+  local i glob
+  STOW_TOP_ALT=
+  STOW_SEG_ALT=
+  i=0
+  while [ "$i" -lt "${#STOW_IGNORE_LIST[@]}" ]; do
+    glob=${STOW_IGNORE_LIST[$((i + 1))]}
+    case "$glob" in
+      /*) STOW_TOP_ALT="${STOW_TOP_ALT:+$STOW_TOP_ALT|}${glob#/}" ;;
+      *) STOW_SEG_ALT="${STOW_SEG_ALT:+$STOW_SEG_ALT|}$glob" ;;
+    esac
+    i=$((i + 2))
+  done
+  # A pattern that arrives by expansion is never quote-processed, so the '#' of
+  # '#*#' and '.#?*' is a literal here where it would open a comment if these
+  # were written out as case arms.  No entry holds a '|', a '(' or a ')', which
+  # is what lets them be joined at all; the shape test in
+  # test_which_stows_default_list_table_covers_the_list_build_writes is what
+  # keeps that true of the next row somebody adds.
+  STOW_TOP_ALT="@($STOW_TOP_ALT)"
+  STOW_SEG_ALT="@($STOW_SEG_ALT)"
+}
+derive_stow_alternations
+
+# Whether extglob was already on when shale started.  stow_default_covers turns
+# it on for the length of one 'case' and must leave the shell as it found it:
+# BASHOPTS is inheritable, and shale's own matching of an ignore file's patterns
+# is written for the ordinary meaning of '?(' and '!(' rather than extglob's.
+# Read once, because 'shopt -q' is a fork-free builtin but not a free one, and
+# this is consulted on every composed path.
+EXTGLOB_HAD=0
+if shopt -q extglob; then
+  EXTGLOB_HAD=1
+fi
+
+# Non-zero unless stow's default list covers $1, a path relative to the top of
+# the tree.  The same question path_is_stow_ignored answers, without saying
+# which rows answered it - which is all the two doctor walks need, and they run
+# it once per composed path.
 #
 # Three things upstream's regexps do that the globs beside them do not, all
 # three measured against stow 2.3.1 and 2.4.1.  All three are a newline in a
@@ -1024,10 +1073,10 @@ STOW_IGNORED_BY=()
 # rather than as a second pattern.
 #
 # A newline inside a name is linked by stow and would be called ignored here:
-# 'a\nb~' is linked by both versions.  A row whose glob holds a wildcard is
-# therefore refused outright for a component that still holds a newline once
-# that trailing one is off.  The rows with no wildcard are literals, which
-# cannot diverge that way.
+# 'a\nb~' is linked by both versions.  A component that still holds one once
+# that trailing newline is off is therefore refused outright - a wildcard row
+# would match it where perl's '.' cannot, and a literal row cannot match a name
+# holding a newline at all.
 #
 # A newline in an *ancestor* component takes every segment row with it, literals
 # included, and this is the one that is not about the pattern at all.  Stow does
@@ -1040,10 +1089,84 @@ STOW_IGNORED_BY=()
 # match a segment row, whatever that component is, and the descent stops there.
 # The anchored rows are unaffected: they go through stow's path regexp against
 # the whole of '/$target', not through that basename.
+#
+# Locale is the caller's: path_is_stow_ignored runs this inside the byte locale
+# and home_conflict does not, which is the locale each of them matched in
+# before there was one matcher.
+stow_default_covers() {
+  local rest=$1 raw seg top=1 hit=1
+  shopt -s extglob
+  while :; do
+    raw=${rest%%/*}
+    seg=${raw%"$NL"}
+    case "$seg" in
+      # Refused rather than matched, and before either alternation: no row of
+      # the list can cover a component that still holds a newline.
+      *"$NL"*) ;;
+      *)
+        if [ "$top" -eq 1 ]; then
+          # Unquoted on purpose: the alternation is a pattern, and these two
+          # arms are the only places it is matched.
+          # shellcheck disable=SC2254
+          case "$seg" in
+            $STOW_TOP_ALT) hit=0 ;;
+          esac
+          [ "$hit" -ne 0 ] || break
+        fi
+        # shellcheck disable=SC2254
+        case "$seg" in
+          $STOW_SEG_ALT) hit=0 ;;
+        esac
+        [ "$hit" -ne 0 ] || break
+        ;;
+    esac
+    top=0
+    # Untrimmed on purpose: a directory called 'a\n' breaks the basename stow
+    # tests below it exactly as one called 'a\nb' does, and the trim above is
+    # about the pattern's end rather than about this.
+    case "$raw" in
+      *"$NL"*) break ;;
+    esac
+    case "$rest" in
+      */*) rest=${rest#*/} ;;
+      *) break ;;
+    esac
+  done
+  [ "$EXTGLOB_HAD" -eq 1 ] || shopt -u extglob
+  return "$hit"
+}
+
+# The rows of that table matching a path, as indexes of its regexp column.
+STOW_IGNORED_BY=()
+
+# Fills STOW_IGNORED_BY for $1, and is non-zero unless it filled it.  Separate
+# from path_is_ignored rather than folded into it because the report tells the
+# two apart: an ignore file's pattern names a file and a line to edit, and one
+# of these has neither.
+#
+# Byte locale for path_is_ignored's reasons, and never nested inside it: the two
+# share one saved LC_ALL, and the one caller that wants both answers runs them
+# one after the other.
+#
+# stow_default_covers is the gate rather than a second opinion, and that is the
+# whole of what keeps doctor and which from parting company over a path: where
+# it says no, no row is looked for and both answer no.  The loop below is
+# reached only for a path it has already covered, so its cost is paid on the
+# handful of paths that are on the list rather than on every path there is.
+#
+# It repeats the three newline rules stow_default_covers states, because it has
+# to say which rows answered and the rules decide which component each row is
+# tried against.  Two spellings of one set of rules is one more than anybody
+# would like; test_doctor_and_which_agree_about_stows_default_list is what holds
+# them to each other, over a corpus rather than an example.
 path_is_stow_ignored() {
   local rel=$1 i glob anchored wild rest raw seg matched try
   STOW_IGNORED_BY=()
   enter_byte_locale
+  if ! stow_default_covers "$rel"; then
+    leave_byte_locale
+    return 1
+  fi
   i=0
   while [ "$i" -lt "${#STOW_IGNORE_LIST[@]}" ]; do
     glob=${STOW_IGNORE_LIST[$((i + 1))]}
@@ -1896,38 +2019,37 @@ home_conflict() {
       "$HOME_CONFLICT_SKIP"/*) return 0 ;;
     esac
   fi
-  # The ignore list cmd_build writes, read as stow reads it, and it has to stay
-  # that list: a name missing here is a finding on a working setup for ever - a
-  # ~/.gitignore of the reader's own beside a layer that has one - and a name
-  # here that is not in the list is a refusal doctor goes quiet about.  Inline
-  # rather than a predicate of its own because this runs once per composed path
-  # and a bash function call is not free at that count - so this is a third
-  # spelling of the same list, beside the file cmd_build writes and
-  # STOW_IGNORE_LIST.  test_doctor_says_nothing_about_stows_default_list is what
-  # holds this one to the other two, by planting every name it covers in $HOME.
+  # The one entry stow adds to whatever the file holds rather than reading out
+  # of it, which is why STOW_IGNORE_LIST has no row for it and why this arm
+  # stands on its own.  Anchored at the top of the tree, and a literal, so the
+  # trailing-newline trim stow's '$' allows is the whole of the reading.
   #
-  # Stow compiles the list into two regexps, checked against both 2.3.1 and
-  # 2.4.1.  A pattern holding a '/' is matched against the whole path anchored
-  # at its ends, so the four below match at the top of the tree only and cover
-  # everything under a directory one of them names; stow adds
-  # '^/\.stow-local-ignore$' to whatever the file holds, which is the fourth.  A
-  # pattern without one is matched against a single path segment at any depth,
-  # and stow skips the directory as it descends, as the skip above does here.
+  # Both spellings, and the second is the reachable one: no build accepts a
+  # layer providing '.stow-local-ignore', and every build composes one called
+  # '.stow-local-ignore\n' without a word.  Stow covers it and links nothing
+  # there, so a finding at that path would be about a file no apply can reach.
   case "${srel%%/*}" in
-    .stow-local-ignore | COPYING | README* | LICENSE*)
+    .stow-local-ignore | ".stow-local-ignore$NL")
       [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
       return 0
       ;;
   esac
-  case "${srel##*/}" in
-    RCS | CVS | .cvsignore | .svn | _darcs | .hg | .git | .gitignore | .gitmodules | \
-      ?*,v | '.#'?* | ?*~ | '#'*'#')
-      # '.+,v', '\.\#.+', '.+~' and '\#.*\#' in glob: '.+' is one character or
-      # more, and '.*' is none or more.
-      [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
-      return 0
-      ;;
-  esac
+  # The rest of the list cmd_build writes, read as stow reads it, and it has to
+  # stay that list in both directions: a name missing is a finding on a working
+  # setup for ever - a ~/.gitignore of the reader's own beside a layer that has
+  # one - and a name that is not in the list is a refusal doctor goes quiet
+  # about.  This stood as a hand-written 'case' until #108 and had never been
+  # given the three newline rules, so doctor passed a setup apply then refused.
+  # There is one matcher now, and it reads the one list.
+  #
+  # stow_default_covers is given the whole path rather than the last component:
+  # the skip above means an ancestor on the list has already returned, but the
+  # newline rules are about ancestors this walk passed through without matching,
+  # and only the path carries them.
+  if stow_default_covers "$srel"; then
+    [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
+    return 0
+  fi
   # The ignore files' patterns, which cmd_build appends to that same file:
   # stow never looks at a path they match, so nothing standing in $HOME there is
   # a refusal any apply can meet.  Guarded on the count rather than left to the

--- a/tests/run
+++ b/tests/run
@@ -6457,6 +6457,235 @@ test_doctor_says_nothing_about_stows_default_list() {
   assert_eq 'shale: no problems found' "$shale_out" 'the third stdout'
 }
 
+# #108's reproduction, and the third of the newline rules #104 measured: stow
+# does not test the last component of a path.  Stow.pm's 'ignore' takes the
+# basename with '(my $basename = $target) =~ s!.+/!!' and '.+' cannot cross a
+# newline, so a newline anywhere before the last '/' leaves a mangled basename
+# no segment entry can match - '.+~' included.  Both versions link
+# 'a\nb/notes~'.
+#
+# The direction that costs is this one: doctor calling the path ignored is
+# doctor reporting green on a setup that apply then refuses, which is what #81
+# and #92 closed for every other finding.  So the two statuses are asserted
+# together, and against the same run.
+#
+# 'plain/notes~' is the control, and the regression that would be worse: it
+# genuinely is ignored, no apply goes near it, and a finding there is noise
+# about a file that is in nobody's way.
+test_doctor_names_a_conflict_below_a_newline_in_an_ancestor() {
+  local dir
+  dir=$(printf 'a\nb')
+  conf 'base common/base'
+  mklayer common/base "$dir/notes~"
+  mklayer common/base 'plain/notes~'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_write "$HOME/$dir" 'notes~' 'mine, and not a link'
+  sandbox_write "$HOME/plain" 'notes~' 'mine, and not a link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/$dir/notes~" 'stdout'
+  assert_not_contains "$shale_out" "$HOME/plain/notes~" 'the ignored control'
+  # The other half of the claim: stow refuses this apply, so a doctor that had
+  # passed it would have contradicted shale's own next command.
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+  assert_contains "$shale_err" "shale: stow failed; nothing in $HOME was relinked" \
+    'the apply stderr'
+  assert_eq 'mine, and not a link' "$(cat "$HOME/plain/notes~")" \
+    'the ignored control after the apply'
+}
+
+# The second rule: perl's '.' never matches a newline where the shell's '?' and
+# '*' do, so '.+~' does not cover 'a\nb~' and both versions link it.  A wildcard
+# row is refused outright for a component still holding one.
+#
+# 'notes~' is the control on the other side of the same row.
+test_doctor_names_a_conflict_at_a_newline_inside_a_name() {
+  local inside
+  inside=$(printf 'a\nb~')
+  conf 'base common/base'
+  mklayer common/base "$inside"
+  mklayer common/base 'notes~'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_write "$HOME" "$inside" 'mine, and not a link'
+  sandbox_write "$HOME" 'notes~' 'mine, and not a link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/$inside" 'stdout'
+  assert_not_contains "$shale_out" "$HOME/notes~" 'the ignored control'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+  assert_contains "$shale_err" "shale: stow failed; nothing in $HOME was relinked" \
+    'the apply stderr'
+}
+
+# The first rule, and the one that goes the other way: stow anchors every entry
+# with '$', which perl matches immediately before a final newline as well as at
+# the end, so '.+~' covers 'notes~\n' where the shell's '?*~' does not.  Both
+# versions skip it.
+#
+# So this is a finding shale must not raise.  A file of the reader's own at a
+# path no apply will ever touch is not in anybody's way, and naming it sends
+# them to move a file that did not need moving - which is why the apply below
+# is run and its status and its stderr both asserted: nothing about this setup
+# is wrong.
+test_doctor_says_nothing_at_a_name_ending_in_a_newline() {
+  local trailing
+  # printf -v rather than a command substitution, which strips exactly the
+  # trailing newline this name is about.
+  printf -v trailing 'notes~\n'
+  conf 'base common/base'
+  mklayer common/base "$trailing" 'a newline at the end of the name'
+  mklayer common/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_write "$HOME" "$trailing" 'mine, and not a link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_eq 'shale: no problems found' "$shale_out" 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  assert_eq 'mine, and not a link' "$(cat "$HOME/$trailing")" \
+    'the file stow left alone'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+}
+
+# The entry stow adds to whatever the list holds rather than reading out of it,
+# at the one spelling of it a layer can actually ship: every build refuses a
+# layer providing '.stow-local-ignore' and every build composes one called
+# '.stow-local-ignore\n' without a word, after which perl's '$' covers it before
+# that final newline exactly as it covers every other entry, and no apply links
+# it.
+#
+# So this is the same claim as the case above, for the one name that is not a
+# row of STOW_IGNORE_LIST and is matched by an arm of home_conflict's own.
+# Without that arm a file of the reader's own here is a finding for ever, about
+# a path no apply can reach.
+test_doctor_says_nothing_at_a_stow_local_ignore_ending_in_a_newline() {
+  local trailing
+  printf -v trailing '.stow-local-ignore\n'
+  conf 'base common/base'
+  mklayer common/base "$trailing" 'composed, and linked by no apply'
+  mklayer common/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_exists "$HOME/.dotfiles/current/$trailing" 'the composed copy'
+  sandbox_write "$HOME" "$trailing" 'mine, and not a link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_eq 'shale: no problems found' "$shale_out" 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  assert_eq 'mine, and not a link' "$(cat "$HOME/$trailing")" \
+    'the file stow left alone'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+}
+
+# extglob is off in the shell shale runs in, and every pattern shale matches is
+# written for that: '@(a|b).swp' in a .shale-ignore is the literal name
+# '@(a|b).swp' and covers nothing else, which is what cmd_build writes into the
+# list stow reads as well.
+#
+# stow_default_covers turns the option on for the length of one 'case' and puts
+# it back, and this is about the putting back.  home_conflict consults that
+# matcher before the ignore patterns, so an option left on there reads the
+# reader's own pattern as something it does not say, suppresses the conflict,
+# and puts doctor straight back to passing a setup apply refuses - #108's defect
+# by another route, on a setup with an ignore file rather than a newline in it.
+test_doctor_an_ignore_pattern_is_not_read_as_extglob() {
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mklayer common/base a.swp
+  mkignore common '@(a|b).swp'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_write "$HOME" a.swp 'mine, and not a link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/a.swp" 'stdout'
+  # The other half, and the reason the finding is right: stow was given the
+  # pattern as a literal too, so it refuses this apply.
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+  assert_contains "$shale_err" "shale: stow failed; nothing in $HOME was relinked" \
+    'the apply stderr'
+}
+
+# The drift guard for stow's own list on doctor's side, and the counterpart of
+# test_which_stows_default_list_table_covers_the_list_build_writes on which's.
+#
+# doctor carried a hand-written 'case' of its own until #108 - the whole list
+# spelled a third time, for the walk's sake - and it had never been given the
+# newline rules, so doctor suppressed a conflict at a path apply then refused.
+# The two answers are one matcher now, and this is what says so: for every name
+# below, doctor raising a conflict and which naming stow's list are opposite
+# answers to the same question, and any future copy that says otherwise fails
+# here rather than in somebody's $HOME.
+#
+# The names cover every shape the matcher has arms for: a segment row, an
+# anchored row at the top and the same name one level down, a near miss on
+# either side, and all three newline rules.
+test_doctor_and_which_agree_about_stows_default_list() {
+  local names i rel covered reported inside ancestor trailing plant
+  inside=$(printf 'a\nb~')
+  ancestor=$(printf 'a\nb/notes~')
+  printf -v trailing 'notes~\n'
+  names=('RCS/x' 'x,v' '.#lock' '.cvsignore' '.gitignore' '.gitmodules' 'notes~'
+    '#n#' 'README.md' 'COPYING' 'sub/README.md' 'sub/notes~' 'plain' 'notesx'
+    "$inside" "$ancestor" "$trailing")
+  conf 'base common/base'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    mklayer common/base "${names[$i]}"
+    i=$((i + 1))
+  done
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    rel=${names[$i]}
+    case "$rel" in
+      */*) sandbox_write "$HOME/${rel%/*}" "${rel##*/}" 'mine, and not a link' ;;
+      *) sandbox_write "$HOME" "$rel" 'mine, and not a link' ;;
+    esac
+    # Kept now: run_shale proves leaves of its own and leaves sandbox_path
+    # holding the last of them.
+    plant=$sandbox_path
+    run_shale doctor
+    reported=0
+    case "$shale_out" in
+      *'no apply put there'*) reported=1 ;;
+    esac
+    run_shale which "$rel"
+    assert_status 0 "$shale_status" "which on '$rel'"
+    covered=0
+    case "$shale_err" in
+      *"stow's default ignore list"*) covered=1 ;;
+    esac
+    if [ "$covered" -eq 1 ]; then
+      assert_eq 0 "$reported" \
+        "doctor raised a conflict at '$rel', which which calls ignored"
+    else
+      assert_eq 1 "$reported" \
+        "doctor was silent about '$rel', which which calls linked"
+    fi
+    # The plant and nothing else: the directory it needed stays, and stands at
+    # the same path the layer's directory does, which is no conflict either way.
+    rm -f "$plant" || fail "could not remove the plant for '$rel'"
+    i=$((i + 1))
+  done
+}
+
 # #92's guarantee, against the one input that would break it: a pattern shale
 # refuses stops every build and every apply, so doctor must not report it green.
 # The refusal is a finding, it blocks the build, and no line offering a build
@@ -11030,8 +11259,14 @@ shale:   that list has no line to edit: nothing but a different name gets this p
 # whitespace before its '#'.  The table is two single-quoted fields on one line
 # per row and no entry holds a single quote, which is what makes the column
 # extractable without a parser; the second assertion is what keeps that shape.
+#
+# The third is about what the globs may hold rather than how the rows are
+# written.  derive_stow_alternations joins the glob column into one extglob
+# alternation per arm, and a '|', a '(' or a ')' in an entry would be taken as
+# the alternation's own punctuation - a pattern that still compiles and no
+# longer means what the row says.
 test_which_stows_default_list_table_covers_the_list_build_writes() {
-  local written rows table misshapen
+  local written rows table misshapen unjoinable
   conf 'base personal/base'
   mklayer personal/base .zshrc
   run_shale build
@@ -11043,6 +11278,9 @@ test_which_stows_default_list_table_covers_the_list_build_writes() {
   assert_eq "$written" "$table" 'the table against the list build writes'
   misshapen=$(printf '%s\n' "$rows" | grep -vc "^  '[^']*' '[^']*'\$")
   assert_eq 0 "$misshapen" 'table rows that are not a regexp and a glob'
+  unjoinable=$(printf '%s\n' "$rows" | sed -e "s/^  '[^']*' '//" -e "s/'\$//" |
+    grep -c '[|()]')
+  assert_eq 0 "$unjoinable" 'table globs holding a character the alternation would take'
 }
 
 # A layer shipping the file shale reads: the table names the layer holding it


### PR DESCRIPTION
Closes #108.

`home_conflict`'s third copy of the list is deleted rather than kept in sync: the table's glob column is joined into an alternation used as a cheap gate, and the full row walk runs only on a hit. `doctor` is correct and ~2x faster on a realistic tree.

Recorded rather than fixed here: `which` still says nothing at a `.stow-local-ignore` whose name ends in a newline (needs wording the table cannot supply), and #109 covers the inherited-`extglob` question this branch deliberately preserved.