### PR TITLE
Say when a path reached the built tree and stopped there

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,28 @@ $ shale which .vimrc
 shale: no layer provides '.vimrc'
 ```
 
+`which` also answers the question that brings most people to it — why a file it names is not in
+`$HOME`. Where shale knows the reason it gives it: an ignore pattern of yours, stow's own default
+list, a `.git` no build composes. Where it does not, it says what it can see, which is that the file
+is in `current/` and nothing is at that path in your home directory:
+
+```
+$ shale which secret
+winner    base  /home/you/.dotfiles/personal/base/secret
+shale: note: 'secret' is in the built tree at /home/you/.dotfiles/current/secret, and nothing is at /home/you/secret
+shale:   something has linked other paths from that tree, though not necessarily since this one reached it
+shale:   run 'shale apply': a path still missing after one is a path stow declined to link
+shale:   stow reads /home/you/.stowrc as well, and shale does not act on what is in it
+shale:   shale doctor names the options such a file sets, any of which can keep this path out of an apply
+```
+
+That covers every cause at once: a `--ignore` in a stow resource file, an option shale does not
+model, a stow version that behaves differently. Run the apply it names — an apply builds first, so a
+file still missing after one is a file stow was offered and declined. A resource file setting
+`--dotfiles` is the one exception shale names rather than reasons about: stow links `dot-zshrc` as
+`.zshrc`, so shale says it cannot follow the rename and stops there. A path that is in `$HOME` gets
+no such note, whether it is a link into `current/`, a file of your own, or a link somewhere else.
+
 ## When two layers disagree about a path
 
 A file replaces a file and a directory merges into a directory, but neither may replace the other.

--- a/shale
+++ b/shale
@@ -1817,7 +1817,11 @@ shell_quote() {
 # that is not a regular file and for one that cannot be read: stow reads a
 # resource file under '-r' and shale runs as the same user, so a file shale
 # cannot open is one stow does not read either.  STOWRC_PATHS is 1 when one of
-# them is --dir or --target.
+# them is --dir or --target, and STOWRC_DOTFILES is 1 when one of them is
+# --dotfiles - the one option that decides where a path lands rather than
+# whether it lands, which which reads to know it cannot follow the rename.  Both
+# are set from the canonical name rather than from the token, an abbreviation
+# being what the file may spell it as.
 #
 # An option is in the set for what it is, not for what one version or one of
 # shale's own code paths makes of it: --verbose changes no link and is named,
@@ -1839,6 +1843,7 @@ stowrc_options() {
   local file=${1-} line lineno tok word rest ch eq skip matched name toks
   STOWRC_OPTIONS=()
   STOWRC_PATHS=0
+  STOWRC_DOTFILES=0
   { [ -f "$file" ] && [ -r "$file" ]; } || return 1
   lineno=0
   skip=0
@@ -1921,6 +1926,7 @@ EOF
           case "$name" in
             "$word"*)
               matched=1
+              [ "$name" != dotfiles ] || STOWRC_DOTFILES=1
               break
               ;;
           esac
@@ -3255,6 +3261,38 @@ obscured_ancestor() {
   done
 }
 
+# The other half of 'shale cannot see whether the path is there', and which's
+# own: zero when a directory on the way from $1 to the path $2 inside it is a
+# symlink that resolves to nothing shale can reach.  A link to nothing and a link
+# into a directory nobody can search are the same two answers here - -L yes and
+# -e no, -e following the link and failing either way - and they are not
+# separable without reading the link and walking what it names.  Under either,
+# every test below that component answers no exactly as the path's absence does.
+#
+# obscured_ancestor is left exactly as it stands rather than widened: it answers
+# for the shape this one does not - a real directory with its search bit off -
+# and build and doctor read it too, where the pair of them is one refusal to
+# search rather than this question.  The one caller runs both.
+#
+# A link that resolves to a file is not this: nothing can be below it, shale can
+# see that, and the note that follows is true of the path.
+unresolvable_ancestor() {
+  local here=$1 rest=$2 component
+  while :; do
+    if [ -L "$here" ] && [ ! -e "$here" ]; then
+      return 0
+    fi
+    case "$rest" in
+      */*)
+        component=${rest%%/*}
+        rest=${rest#*/}
+        ;;
+      *) return 1 ;;
+    esac
+    here=$here/$component
+  done
+}
+
 # How $1 is composed, in WHICH_KIND, and how it is shown, in WHICH_SHOW.  A
 # symlink is a leaf whatever it points at, because the composer treats one that
 # way: calling it a directory here promises a merge build refuses to perform.
@@ -3337,6 +3375,148 @@ report_ignored() {
       lines[${#lines[@]}]="a link an earlier apply made is still at $link, because stow skips an ignored path rather than unstowing it"
       lines[${#lines[@]}]='remove that link by hand: no build or apply removes it'
     fi
+  fi
+  emit ${lines[@]+"${lines[@]}"}
+}
+
+# Non-zero unless some path in the built tree under $1 - relative to $CUR, and ''
+# for the whole of it - is linked at the matching path in $HOME.  That is the
+# whole of what tells a tree an apply has landed from one nothing has ever
+# applied: shale keeps no state, so there is nothing on disk that says when the
+# last apply ran, and stow leaves no mark of its own either.
+#
+# The first hit ends the walk, so an applied tree costs a directory read or two;
+# the whole tree is read only where the answer is 'nothing at all', which is the
+# answer that pays for it.  Both are reached only from the note below, which is
+# already looking at a path that is in the tree and not in $HOME.
+#
+# -ef against the built tree rather than -L at the leaf: a folded directory is
+# one link with real files below it - shale passes --no-folding, so one comes
+# from a stow run that did not - and testing for a link at each leaf would read
+# that whole subtree as unlinked.  A path that no apply ever
+# links - the built list itself, anything either ignore list covers - is counted
+# as unlinked here, which is why the note hedges rather than concluding.
+#
+# A dangling link is the one shape -ef cannot answer for at all, and a tree whose
+# files are all symlinks into nothing is a tree stow links and -ef reads as empty
+# - which would be the note saying nothing is linked with a link from that tree
+# in $HOME.  home_conflict meets the same shape and answers it the same way, with
+# the readlink that link_points_into_the_tree spends; the guard is what keeps
+# that fork off every path, there being at most a handful of them in any $HOME.
+# Its 'cannot say' - no readlink on the machine - answers 'linked' here, which is
+# the hedged line rather than the one that concludes.
+#
+# BUILT_TREE_UNREAD is what keeps 'nothing is linked' off a walk that could not
+# see: a directory that cannot be listed answers every glob with nothing, exactly
+# as an empty one does, and the two are not the same answer to give.  The caller
+# clears it, this being a recursion, and reads it only where the walk found no
+# link at all - a walk that found one has read enough whatever it could not open
+# afterwards.
+BUILT_TREE_UNREAD=0
+built_tree_is_linked() {
+  local rel=$1 here e base srel link
+  here=$CUR${rel:+/$rel}
+  if { [ ! -r "$here" ] || [ ! -x "$here" ]; }; then
+    BUILT_TREE_UNREAD=1
+    return 1
+  fi
+  for e in "$here"/* "$here"/.*; do
+    base=${e##*/}
+    # Dropped by name, as at every glob in this script: bash 3.2 matches '.' and
+    # '..' with "$here"/.* where 5.2's globskipdots does not.
+    case "$base" in
+      . | ..) continue ;;
+    esac
+    # Also where an unmatched glob lands, its literal being at no path.
+    { [ -e "$e" ] || [ -L "$e" ]; } || continue
+    srel=${rel:+$rel/}$base
+    link=$HOME_PREFIX/$srel
+    [ ! "$link" -ef "$e" ] || return 0
+    if [ -L "$link" ] && [ ! -e "$link" ]; then
+      ! link_points_into_the_tree "$link" || return 0
+    fi
+    if [ -d "$e" ] && [ ! -L "$e" ]; then
+      ! built_tree_is_linked "$srel" || return 0
+    fi
+  done
+  return 1
+}
+
+# The fact that $1 reached the built tree and $HOME has nothing at it, on stderr
+# with which's other notes.  The caller has established both halves.
+#
+# This is what is left when nothing above it knows a reason: stow declines a path
+# for reasons of its own that shale cannot enumerate - an --ignore in a resource
+# file, whose values are perl regexps shale will not match; an option shale does
+# not model; a difference between one stow version and the next.  Observing that
+# the path is not linked needs none of that, and is what the reader asked about.
+#
+# What it may not do is claim the apply that would have linked it has run.
+# Nothing here can date the last apply against this build, so the two states are
+# separated only as far as they can be - whether anything at all is linked - and
+# the remedy settles the rest: an apply builds first, so a path still missing
+# after one is a path stow was offered and declined.
+#
+# 'something has linked', never 'an apply has': -ef is true of a link a hand
+# made and of an absolute one pointing at the right file, and stow refuses to
+# write that second shape at all - so what the walk found is a link into the
+# tree, and which of them wrote it is not shale's to say.
+#
+# --dotfiles is where the whole inference stops holding, and the one option in a
+# resource file that has to be looked for by name: it links 'dot-zshrc' as
+# '.zshrc', so the path this note is about can be in $HOME under another name,
+# nothing in the tree matches the path the walk compares against, and 'still
+# missing after an apply' stops meaning declined.  The option name is read, never
+# a pattern - which is the line #96 drew - and where it is set the two lines that
+# reason give way to two that say shale cannot follow the rename.
+report_unlinked() {
+  local rel=$1 lines entry files renamed named i
+  # Both files, in doctor's order and spelt as doctor spells them - './.stowrc'
+  # is read from the directory apply runs stow in, which is $DOTFILES.  Read
+  # before the lines below, which turn on what is in them.
+  files=()
+  renamed=0
+  named=0
+  for entry in "${HOME-}/.stowrc" "$DOTFILES/.stowrc"; do
+    { [ -e "$entry" ] || [ -L "$entry" ]; } || continue
+    files[${#files[@]}]=$entry
+    if stowrc_options "$entry"; then
+      named=1
+      [ "$STOWRC_DOTFILES" -eq 0 ] || renamed=1
+    fi
+  done
+  lines=("note: '$rel' is in the built tree at $CUR/$rel, and nothing is at $HOME_PREFIX/$rel")
+  if [ "$renamed" -eq 1 ]; then
+    lines[${#lines[@]}]='a stow resource file sets --dotfiles, which links a name beginning dot- under one beginning a full stop'
+    lines[${#lines[@]}]="so this path may be in ${HOME-} under a name shale cannot work out, and shale does not translate one"
+  else
+    BUILT_TREE_UNREAD=0
+    if built_tree_is_linked ''; then
+      lines[${#lines[@]}]='something has linked other paths from that tree, though not necessarily since this one reached it'
+    elif [ "$BUILT_TREE_UNREAD" -eq 1 ]; then
+      # Neither of the two below, and for the reason the whole note exists:
+      # where shale could not look it does not conclude.  A tree it cannot read
+      # is doctor's finding to name, and the build an apply runs replaces it.
+      lines[${#lines[@]}]="shale could not read all of $CUR, so it cannot tell whether anything from that tree is linked"
+    else
+      lines[${#lines[@]}]="no path in that tree is linked in ${HOME-} at all, which is what a build nobody has applied looks like"
+    fi
+    lines[${#lines[@]}]="run 'shale apply': a path still missing after one is a path stow declined to link"
+  fi
+  # Named where one exists, and no pattern in it read: stow's own two resource
+  # files are the reachable cause shale can point at without interpreting
+  # anything, and doctor is where their options are listed.  The line sending a
+  # reader to that list is printed only where there is one to read: an empty
+  # file, a directory and a dangling link are all files stow reads nothing out
+  # of, and doctor names no option for any of them either.
+  if [ "${#files[@]}" -gt 0 ]; then
+    i=0
+    while [ "$i" -lt "${#files[@]}" ]; do
+      lines[${#lines[@]}]="stow reads ${files[$i]} as well, and shale does not act on what is in it"
+      i=$((i + 1))
+    done
+    [ "$named" -eq 0 ] ||
+      lines[${#lines[@]}]='shale doctor names the options such a file sets, any of which can keep this path out of an apply'
   fi
   emit ${lines[@]+"${lines[@]}"}
 }
@@ -4212,6 +4392,7 @@ cmd_doctor() {
 # layers say, so it is the same before the first build as after it.
 cmd_which() {
   local arg=${1-} rel path i n lower upper keyword column width obscured ignored
+  local explained
 
   parse_config || exit 1
   # Refused rather than answered around: a pattern shale will not read is one it
@@ -4341,15 +4522,28 @@ cmd_which() {
   # look at.  Not conditional on the ignore answer either - an ancestor holding
   # a newline takes the list's rows off this path and leaves the composer's
   # skip exactly where it was.
+  #
+  # Each of the five below says why this path is not in $HOME, and each records
+  # that it did: the residual note at the end is the one for a path none of them
+  # can account for, and two notes making the one point read as two problems.
+  explained=0
   case "/$rel/" in
     */.git/*)
       emit "note: no build composes a .git — shale skips one at every depth, so this path never reaches $CUR"
+      explained=1
       ;;
   esac
-  [ "$ignored" -eq 0 ] || report_ignored "$rel"
+  if [ "$ignored" -ne 0 ]; then
+    report_ignored "$rel"
+    explained=1
+  fi
 
   if [ "$upper" -ge 0 ]; then
     emit "note: 'build' would fail here — $rel is a ${WHICH_KINDS[$lower]} in '${WHICH_NAMES[$lower]}' and a ${WHICH_KINDS[$upper]} in '${WHICH_NAMES[$upper]}'"
+    # A tree built before the collision arrived can hold this path with nothing
+    # at it in $HOME, and the residual note's remedy is an apply - which builds
+    # first, dies here, and leaves the path exactly where it was.
+    explained=1
   fi
   # Second, and after the pair above rather than instead of it: build reaches
   # the conflict first and dies there, so the note in build's order is the one
@@ -4359,11 +4553,45 @@ cmd_which() {
   # layer does.
   if [ "$rel" = .stow-local-ignore ]; then
     emit "note: 'build' would fail here — shale writes $CUR/.stow-local-ignore itself, and no build accepts a layer providing one"
+    # The tree holds that path after any earlier build, and no apply has ever
+    # linked it: stow reads it and leaves it where it is.  Accounted for by the
+    # line above, whose remedy is the layer rather than another apply.
+    explained=1
   fi
   # At any depth, which is where the composer drops it: the table above names
   # the layer holding this file truthfully, and no build puts it in the tree.
   if [ "${rel##*/}" = "$IGNORE_NAME" ]; then
     emit "note: no build composes a $IGNORE_NAME — shale reads the one at the top of a clone root and copies none of them"
+    # Accounted for, like the three above: only a hand puts one of these in the
+    # built tree, and the line above says why no build did.
+    explained=1
+  fi
+
+  # Last, and the residual: everything above names a reason shale knows, and
+  # this is the fact that is left when it knows none - the path is in the built
+  # tree and $HOME has nothing at it.  It is what happened rather than a model of
+  # what stow does, so it covers an --ignore in a resource file, an option shale
+  # does not model and a difference between stow versions alike.
+  #
+  # -e and -L at both ends, neither implying the other.  A layer's symlink into
+  # nothing is composed and linked like any other file - checked against stow
+  # 2.3.1 and 2.4.1 - and the link an apply leaves for it in $HOME is a path -e
+  # answers no for: calling that file missing while it sits in $HOME is the one
+  # wrong answer this note must not give.  A folded directory is the same shape
+  # from the other side, and is why the test is against whatever is at the path
+  # in $HOME rather than for a link at it - every file under a folded directory
+  # answers -e through the one link above it.
+  #
+  # Nothing is claimed about a path shale cannot look at, and there are two such
+  # directories above it in $HOME: one that cannot be searched, and one that is a
+  # link resolving to nothing shale can reach.  Every test below either answers
+  # no, which is what the file not being there answers too.
+  if [ "$explained" -eq 0 ] && [ -n "${HOME-}" ] &&
+    { [ -e "$CUR/$rel" ] || [ -L "$CUR/$rel" ]; } &&
+    [ ! -e "$HOME_PREFIX/$rel" ] && [ ! -L "$HOME_PREFIX/$rel" ] &&
+    ! obscured_ancestor "$HOME_PREFIX" "$rel" &&
+    ! unresolvable_ancestor "$HOME_PREFIX" "$rel"; then
+    report_unlinked "$rel"
   fi
 }
 

--- a/tests/run
+++ b/tests/run
@@ -10477,8 +10477,11 @@ test_which_every_spelling_of_the_path_agrees() {
   conf 'base personal/base' 'local local'
   mklayer personal/base .config/x
   mklayer local .config/x
-  run_shale build
-  assert_status 0 "$shale_status" 'the build'
+  # An apply rather than a build, every spelling below being asserted silent:
+  # nothing is linked in $HOME until one has run, and the note which prints about
+  # an unapplied tree would then arrive on all seven answers alike.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
   run_shale which .config/x
   assert_status 0 "$shale_status" 'the relative spelling'
   expected=$shale_out
@@ -11224,8 +11227,11 @@ test_which_a_dot_git_says_no_build_composes_one() {
   mklayer common/base .config/nvim/.git/HEAD
   mklayer common/base .gitconfig
   mklayer common/base .zshrc
-  run_shale build
-  assert_status 0 "$shale_status" 'the build'
+  # An apply rather than a build: the near miss below is asserted silent, and
+  # every path in a tree no apply has landed is unlinked - which says so in a
+  # note of its own, which is not what this case is about.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
   assert_missing "$HOME/.dotfiles/current/.git" 'the built tree'
   assert_missing "$HOME/.dotfiles/current/.config/nvim/.git" 'the built tree'
   run_shale which .git/config
@@ -11281,6 +11287,451 @@ test_which_stows_default_list_table_covers_the_list_build_writes() {
   unjoinable=$(printf '%s\n' "$rows" | sed -e "s/^  '[^']*' '//" -e "s/'\$//" |
     grep -c '[|()]')
   assert_eq 0 "$unjoinable" 'table globs holding a character the alternation would take'
+}
+
+# The residual answer, and the one that needs no model of stow at all: a path
+# that is in the built tree with nothing at it in $HOME did not get linked,
+# whatever the cause.  A ~/.stowrc's --ignore is a cause shale cannot name - its
+# values are perl regexps, and no regexp shale did not write reaches a matcher -
+# so nothing here matches anything.  which reads the two trees and reports what
+# it finds.
+#
+# Both supported stows drop the file and exit 0 saying nothing: checked against
+# 2.3.1 and 2.4.1, which is what makes silence here a defect on both rather than
+# a version difference.  The resource file is named because it exists, which is
+# a fact shale can see without reading a line of it.
+test_which_a_path_a_stowrc_dropped_says_it_reached_the_tree() {
+  conf 'base common/base'
+  mklayer common/base secret
+  mklayer common/base .zshrc
+  sandbox_write "$HOME" .stowrc '--ignore=secret'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply stderr'
+  assert_missing "$HOME/secret"
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  run_shale which secret
+  assert_status 0 "$shale_status"
+  assert_eq "winner    base  $HOME/.dotfiles/common/base/secret" "$shale_out" 'stdout'
+  assert_eq "shale: note: 'secret' is in the built tree at $HOME/.dotfiles/current/secret, and nothing is at $HOME/secret
+shale:   something has linked other paths from that tree, though not necessarily since this one reached it
+shale:   run 'shale apply': a path still missing after one is a path stow declined to link
+shale:   stow reads $HOME/.stowrc as well, and shale does not act on what is in it
+shale:   shale doctor names the options such a file sets, any of which can keep this path out of an apply" \
+    "$shale_err" 'stderr'
+  # The control beside it, and the whole of what keeps this from being a line
+  # every answer carries: the file that was linked gets nothing.
+  run_shale which .zshrc
+  assert_status 0 "$shale_status" 'the linked path'
+  assert_empty "$shale_err" 'the linked path stderr'
+}
+
+# The other resource file, and a pattern that takes the whole tree with it: the
+# note has to hold where *nothing* is linked as well, and it may not then claim
+# an apply declined this path - which is the one thing it cannot see.
+test_which_a_stowrc_that_drops_everything_is_not_read_as_a_missing_apply() {
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  sandbox_write "$HOME/.dotfiles" .stowrc '--ignore=.*'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_missing "$HOME/.zshrc"
+  run_shale which .zshrc
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: note: '.zshrc' is in the built tree at $HOME/.dotfiles/current/.zshrc, and nothing is at $HOME/.zshrc" \
+    'stderr'
+  assert_contains "$shale_err" \
+    "shale:   stow reads $HOME/.dotfiles/.stowrc as well, and shale does not act on what is in it" 'stderr'
+  # Nothing is linked, so this reads as an unapplied tree and says only that.
+  assert_contains "$shale_err" 'shale:   no path in that tree is linked in' 'stderr'
+  assert_not_contains "$shale_err" 'something has linked other paths' 'stderr'
+}
+
+# The shape -ef cannot answer for, from the other side of the same walk: an apply
+# writes an ordinary link for a layer's symlink into nothing, and that link
+# dangles.  A tree whose files are all of that shape is one -ef reads as having
+# nothing linked, and the note would then say so with a link from that tree
+# sitting in $HOME.  home_conflict meets it on its own walk and spends the same
+# readlink on it.
+test_which_a_tree_linked_only_by_a_dangling_link_is_not_called_unapplied() {
+  conf 'base common/base'
+  mklayer common/base secret
+  sandbox_mkdir "$HOME/.dotfiles/common/base"
+  sandbox_leaf "$sandbox_dir" .dangling new
+  ln -s nowhere-at-all "$sandbox_path" || fail 'could not create the symlink'
+  sandbox_write "$HOME" .stowrc '--ignore=secret'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  # The whole of what that apply linked, and it resolves to nothing.
+  assert_dangling_symlink "$HOME/.dangling" 'the only link the apply wrote'
+  assert_missing "$HOME/secret"
+  run_shale which secret
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    'shale:   something has linked other paths from that tree, though not necessarily since this one reached it' \
+    'stderr'
+  assert_not_contains "$shale_err" 'no path in that tree is linked' 'stderr'
+}
+
+# --dotfiles is the one option a resource file can set that decides where a path
+# lands rather than whether it lands: stow links 'dot-zshrc' as '.zshrc', so the
+# file is in $HOME under a name shale did not compose, nothing in the tree
+# matches the path the walk compares against, and 'a path still missing after an
+# apply is one stow declined' would be said of a path that is not missing at all.
+# Both versions do it - 2.3.1's --help does not list the option and Stow.pm
+# implements it - so the note stops reasoning and says what it cannot follow.
+#
+# The option's name is read and no pattern in the file is, which is the line #96
+# drew: an --ignore value is a perl regexp and stays unread.
+test_which_a_stowrc_setting_dotfiles_is_not_read_as_a_declined_path() {
+  conf 'base common/base'
+  mklayer common/base dot-zshrc
+  sandbox_write "$HOME" .stowrc '--dotfiles'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/dot-zshrc"
+  assert_missing "$HOME/dot-zshrc"
+  run_shale which dot-zshrc
+  assert_status 0 "$shale_status"
+  assert_eq "shale: note: 'dot-zshrc' is in the built tree at $HOME/.dotfiles/current/dot-zshrc, and nothing is at $HOME/dot-zshrc
+shale:   a stow resource file sets --dotfiles, which links a name beginning dot- under one beginning a full stop
+shale:   so this path may be in $HOME under a name shale cannot work out, and shale does not translate one
+shale:   stow reads $HOME/.stowrc as well, and shale does not act on what is in it
+shale:   shale doctor names the options such a file sets, any of which can keep this path out of an apply" \
+    "$shale_err" 'stderr'
+  # Neither of the two lines that reason from the walk, both of which are false
+  # of a path stow renamed.
+  assert_not_contains "$shale_err" 'stow declined to link' 'stderr'
+  assert_not_contains "$shale_err" 'nobody has applied' 'stderr'
+  assert_not_contains "$shale_err" 'something has linked' 'stderr'
+  # An unambiguous abbreviation is the same option to stow, which parses its
+  # resource file with Getopt::Long: '--dotf' applies alike on 2.3.1 and 2.4.1.
+  sandbox_write "$HOME" .stowrc '--dotf'
+  run_shale which dot-zshrc
+  assert_status 0 "$shale_status" 'the abbreviation'
+  assert_contains "$shale_err" 'shale:   a stow resource file sets --dotfiles' \
+    'the abbreviation stderr'
+  # A resource file setting something else leaves the reasoning where it was -
+  # and on this tree it reasons wrongly, which is the whole of why the option is
+  # read: the one file there is linked, at a name shale did not compose, and the
+  # walk that compares $HOME against the tree path by path can only miss it.
+  sandbox_write "$HOME" .stowrc '--ignore=nothing-of-the-kind'
+  run_shale which dot-zshrc
+  assert_status 0 "$shale_status" 'without the option'
+  assert_not_contains "$shale_err" '--dotfiles' 'stderr without the option'
+  assert_contains "$shale_err" "shale:   run 'shale apply': a path still missing after one is a path stow declined to link" \
+    'stderr without the option'
+  # A file stow reads no option out of is still named, because stow reads it -
+  # and the line sending a reader to the list doctor prints is not, because
+  # doctor names no option for it either.
+  sandbox_write "$HOME" .stowrc
+  run_shale which dot-zshrc
+  assert_status 0 "$shale_status" 'the empty resource file'
+  assert_contains "$shale_err" "shale:   stow reads $HOME/.stowrc as well" \
+    'the empty resource file stderr'
+  assert_not_contains "$shale_err" 'shale doctor names the options' \
+    'the empty resource file stderr'
+}
+
+# The state the note must never claim: a tree nobody has applied has every path
+# in it unlinked, and 'stow declined this one' would be false of all of them.
+# Only what is on disk is stated, and the remedy is the apply that settles it -
+# an apply builds first, so a path missing after one was offered to stow.
+test_which_a_built_tree_no_apply_has_landed_says_which_it_is() {
+  local expected home home_slash
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale which .zshrc
+  assert_status 0 "$shale_status"
+  expected="shale: note: '.zshrc' is in the built tree at $HOME/.dotfiles/current/.zshrc, and nothing is at $HOME/.zshrc
+shale:   no path in that tree is linked in $HOME at all, which is what a build nobody has applied looks like
+shale:   run 'shale apply': a path still missing after one is a path stow declined to link"
+  assert_eq "$expected" "$shale_err" 'stderr'
+  # The path in the first line is a join and the directory in the second is
+  # printed on its own, which are the two spellings of $HOME shale keeps apart.
+  # They name one directory whatever the environment spells it as, shale
+  # stripping a trailing slash from HOME before either is built.
+  home=$HOME
+  home_slash=$home///
+  HOME=$home_slash
+  run_shale which .zshrc
+  HOME=$home
+  assert_status 0 "$shale_status" 'under a trailing slash'
+  assert_eq "$expected" "$shale_err" 'stderr under a trailing slash'
+  # And the apply the note prescribes ends it.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  run_shale which .zshrc
+  assert_status 0 "$shale_status" 'after the apply'
+  assert_empty "$shale_err" 'stderr after the apply'
+}
+
+# A build newer than the last apply, which is the state shale cannot tell from a
+# path stow declined: nothing on disk dates one against the other.  So the note
+# says an apply has run and stops there, and the wording that would have been
+# wrong here is the one it does not use.
+test_which_a_path_newer_than_the_apply_is_not_called_declined() {
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the first apply'
+  mklayer common/base .vimrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale which .vimrc
+  assert_status 0 "$shale_status"
+  assert_eq "shale: note: '.vimrc' is in the built tree at $HOME/.dotfiles/current/.vimrc, and nothing is at $HOME/.vimrc
+shale:   something has linked other paths from that tree, though not necessarily since this one reached it
+shale:   run 'shale apply': a path still missing after one is a path stow declined to link" \
+    "$shale_err" 'stderr'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the second apply'
+  run_shale which .vimrc
+  assert_status 0 "$shale_status" 'after the second apply'
+  assert_empty "$shale_err" 'stderr after the second apply'
+}
+
+# The silence around all of it.  A note saying a file is not in $HOME while it
+# sits there is worse than no note at all, so every shape an apply leaves is
+# asserted silent: a file at the top, one inside a directory, a name with a
+# space in it, the directory itself, and a relative dangling symlink - which is
+# the shape that answers -e no while the link is plainly there, and is linked by
+# both 2.3.1 and 2.4.1.
+#
+# Twice over, with and without an ignore file: the patterns are read on every
+# which, and a matcher that fell through to the wrong answer would show here.
+test_which_says_nothing_about_a_path_an_apply_linked() {
+  local rels rel round
+  rels=('.zshrc' '.config/nvim/init.lua' 'bin/tool' 'a b/c d' 'notes.txt')
+  conf 'base common/base'
+  for rel in ${rels[@]+"${rels[@]}"}; do
+    mklayer common/base "$rel"
+  done
+  sandbox_mkdir "$HOME/.dotfiles/common/base"
+  sandbox_leaf "$sandbox_dir" .dangling new
+  ln -s nowhere-at-all "$sandbox_path" || fail 'could not create the symlink'
+  for round in bare ignore; do
+    [ "$round" = bare ] || mkignore common '*.swp'
+    run_shale apply
+    assert_status 0 "$shale_status" "the $round apply"
+    assert_empty "$shale_err" "the $round apply stderr"
+    for rel in ${rels[@]+"${rels[@]}"}; do
+      assert_symlink_to "$HOME/$rel" "$HOME/.dotfiles/current/$rel" "the $round link for '$rel'"
+      run_shale which "$rel"
+      assert_status 0 "$shale_status" "the $round which '$rel'"
+      assert_empty "$shale_err" "the $round which '$rel' stderr"
+    done
+    # The directories the files above are in, which stow makes as directories of
+    # their own under --no-folding rather than linking.
+    for rel in .config .config/nvim bin 'a b'; do
+      assert_real_dir "$HOME/$rel" "the $round directory '$rel'"
+      run_shale which "$rel"
+      assert_status 0 "$shale_status" "the $round which '$rel'"
+      assert_empty "$shale_err" "the $round which '$rel' stderr"
+    done
+    # -e is false for this one and -L is true, and the file is in $HOME.
+    [ ! -e "$HOME/.dangling" ] || fail 'the dangling link resolves'
+    [ -L "$HOME/.dangling" ] || fail 'no link at the dangling path'
+    run_shale which .dangling
+    assert_status 0 "$shale_status" "the $round which '.dangling'"
+    assert_empty "$shale_err" "the $round which '.dangling' stderr"
+  done
+}
+
+# Two more shapes $HOME can hold at the path, neither of them this note's
+# business: a file of the reader's own, which is a conflict doctor reports, and a
+# link into somewhere else.  Both are a path with something at it, and calling
+# either of them missing is the false positive.
+test_which_says_nothing_where_home_holds_the_path() {
+  local elsewhere
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mklayer common/base .vimrc
+  sandbox_write "$HOME" .vimrc 'mine, not a layer copy'
+  run_shale apply
+  # Both versions refuse the whole apply over it, in shale's own words.
+  assert_status 1 "$shale_status" 'the apply over a real file'
+  assert_contains "$shale_err" "shale: stow failed; nothing in $HOME was relinked" \
+    'the apply stderr'
+  run_shale which .vimrc
+  assert_status 0 "$shale_status" 'the real file'
+  assert_empty "$shale_err" 'the real file stderr'
+  # A link, and pointing outside the built tree.
+  sandbox_write "$CASE_DIR/elsewhere" .vimrc 'somewhere else'
+  elsewhere=$sandbox_path
+  sandbox_target "$HOME" .vimrc
+  rm -f "$sandbox_path" || fail 'could not remove the file'
+  sandbox_leaf "$HOME" .vimrc new
+  ln -s "$elsewhere" "$sandbox_path" || fail 'could not create the symlink'
+  run_shale which .vimrc
+  assert_status 0 "$shale_status" 'the foreign link'
+  assert_empty "$shale_err" 'the foreign link stderr'
+}
+
+# The folded directory on its own, because it is the one shape that has nothing
+# at all at the leaf and is still a file in $HOME: ~/.config is one link into
+# the built tree and every file below it is reached through it.  shale passes
+# --no-folding, so no apply of its own makes one - a stow run before shale, or
+# by hand, is where it comes from, and it is here as a link made by hand.
+test_which_says_nothing_about_a_path_below_a_folded_directory() {
+  conf 'base common/base'
+  mklayer common/base .config/nvim/init.lua
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  sandbox_leaf "$HOME" .config new
+  ln -s .dotfiles/current/.config "$sandbox_path" ||
+    fail 'could not create the folded link'
+  # Nothing is at the leaf, and the file is in $HOME through the link above it.
+  [ ! -L "$HOME/.config/nvim/init.lua" ] || fail 'the leaf is a link of its own'
+  [ -e "$HOME/.config/nvim/init.lua" ] || fail 'the folded file is not readable'
+  run_shale which .config/nvim/init.lua
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+}
+
+# The same rule on the other side of the note: the walk that says whether
+# anything from the tree is linked may not answer 'nothing' for a tree it could
+# not read.  A directory that cannot be listed answers every glob with nothing,
+# exactly as an empty one does, and 'no apply has landed' would be false of a
+# $HOME full of that tree's links.
+test_which_a_built_tree_it_cannot_read_is_never_called_unapplied() {
+  skip_if_root
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mklayer common/base .vimrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  # One link gone by hand is what brings the note out; the other stays, so the
+  # tree plainly is applied and only the walk cannot see it.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.vimrc" || fail 'could not remove the link'
+  # Searchable and unlistable: the path itself is still testable, and the glob
+  # that would find the link beside it returns nothing.
+  chmod 0300 "$HOME/.dotfiles/current" || fail 'could not remove the read bit'
+  run_shale which .vimrc
+  chmod 0755 "$HOME/.dotfiles/current" || fail 'could not restore the mode'
+  assert_status 0 "$shale_status"
+  assert_eq "shale: note: '.vimrc' is in the built tree at $HOME/.dotfiles/current/.vimrc, and nothing is at $HOME/.vimrc
+shale:   shale could not read all of $HOME/.dotfiles/current, so it cannot tell whether anything from that tree is linked
+shale:   run 'shale apply': a path still missing after one is a path stow declined to link" \
+    "$shale_err" 'stderr'
+  # And with the tree readable again, the same path gets the answer the walk can
+  # stand behind.
+  run_shale which .vimrc
+  assert_status 0 "$shale_status" 'once it can be read'
+  assert_contains "$shale_err" 'shale:   something has linked other paths from that tree' \
+    'stderr once it can be read'
+}
+
+# A path shale cannot look at is not a path shale reports on.  Three directories
+# above it answer 'no' to every test below them exactly as the file's absence
+# does, and none of the three is distinguishable from it: one whose search bit is
+# off, one that is a link into a directory whose search bit is off, and one that
+# is a link to nothing.  The last two are one answer here - -L yes and -e no,
+# which is what a link shale cannot follow gives whichever it is.
+test_which_says_nothing_where_it_cannot_look_in_home() {
+  local outside
+  skip_if_root
+  conf 'base common/base'
+  mklayer common/base .config/x
+  mklayer common/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  chmod 0000 "$HOME/.config" || fail 'could not remove the search bit'
+  run_shale which .config/x
+  chmod 0755 "$HOME/.config" || fail 'could not restore the mode'
+  assert_status 0 "$shale_status"
+  assert_eq "winner    base  $HOME/.dotfiles/common/base/.config/x" "$shale_out" 'stdout'
+  assert_empty "$shale_err" 'stderr'
+  # A link in its place, pointing into a directory nobody can search: -d follows
+  # it and fails, so the search-bit test above never sees this one.
+  sandbox_mkdir "$CASE_DIR/outside/inner"
+  outside=$sandbox_dir
+  sandbox_target "$HOME" .config
+  rm -rf "$sandbox_path" || fail 'could not remove the directory'
+  sandbox_leaf "$HOME" .config new
+  ln -s "$outside" "$sandbox_path" || fail 'could not create the symlink'
+  chmod 0000 "${outside%/*}" || fail 'could not remove the search bit'
+  run_shale which .config/x
+  chmod 0755 "${outside%/*}" || fail 'could not restore the mode'
+  assert_status 0 "$shale_status" 'the unsearchable link target'
+  assert_empty "$shale_err" 'the unsearchable link target stderr'
+  # And the same two answers from a link to nothing at all, which is the one
+  # shape that needs no permissions to make.  sandbox_leaf will not hand back a
+  # path that is a symlink, which this one is, so the directory is resolved and
+  # the leaf removed from it.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.config" || fail 'could not remove the link'
+  sandbox_leaf "$HOME" .config new
+  ln -s nowhere-at-all "$sandbox_path" || fail 'could not create the symlink'
+  run_shale which .config/x
+  assert_status 0 "$shale_status" 'the link to nothing'
+  assert_empty "$shale_err" 'the link to nothing stderr'
+  # The other side of it: once that ancestor resolves to a directory shale can
+  # search, the path is one shale can speak for again.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.config" || fail 'could not remove the link'
+  sandbox_leaf "$HOME" .config new
+  ln -s "$outside" "$sandbox_path" || fail 'could not create the symlink'
+  run_shale which .config/x
+  assert_status 0 "$shale_status" 'the readable link target'
+  assert_contains "$shale_err" "shale: note: '.config/x' is in the built tree at" \
+    'the readable link target stderr'
+}
+
+# One note per path.  Every note above this one names a reason a path is not in
+# $HOME, and the residual fact is true of all of them - so a path with a reason
+# gets the reason, and the fact is left for the paths shale has none for.
+test_which_a_path_with_a_reason_gets_the_reason_and_not_the_fact() {
+  local rel
+  conf 'base common/base'
+  mkignore common '.DS_Store'
+  mklayer common/base .DS_Store
+  mklayer common/base 'notes~'
+  mklayer common/base .git/config
+  mklayer common/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  for rel in .DS_Store 'notes~' .git/config; do
+    assert_missing "$HOME/$rel" "'$rel' in \$HOME"
+    run_shale which "$rel"
+    assert_status 0 "$shale_status" "which '$rel'"
+    assert_contains "$shale_err" 'shale: note: ' "which '$rel' stderr"
+    assert_not_contains "$shale_err" 'is in the built tree at' "which '$rel' stderr"
+  done
+  # The file shale writes itself, which no apply has ever linked and which a
+  # layer providing one is told about in build's words instead.
+  mklayer common/base .stow-local-ignore 'a layer may not provide this'
+  run_shale which .stow-local-ignore
+  assert_status 0 "$shale_status" 'the built list'
+  assert_contains "$shale_err" "shale: note: 'build' would fail here" 'the built list stderr'
+  assert_not_contains "$shale_err" 'is in the built tree at' 'the built list stderr'
+  # The ignore file shale reads, which no build composes either.  Only a hand
+  # puts one in the built tree, so one is put there by hand: the reason is the
+  # note above, and the fact must not arrive under it saying the same thing.
+  mklayer common/base .shale-ignore 'read by nothing'
+  sandbox_write "$HOME/.dotfiles/current" .shale-ignore 'planted, not composed'
+  run_shale which .shale-ignore
+  assert_status 0 "$shale_status" 'the ignore file'
+  assert_contains "$shale_err" 'shale: note: no build composes a .shale-ignore' \
+    'the ignore file stderr'
+  assert_not_contains "$shale_err" 'is in the built tree at' 'the ignore file stderr'
+  # The other 'build would fail here', which is the collision between two layers:
+  # the tree still holds the copy an earlier build composed, the link that apply
+  # made is gone from $HOME, and the residual note's remedy is an apply that dies
+  # on the collision without touching the path.
+  rm -f "$HOME/.zshrc" || fail 'could not remove the link'
+  conf 'base common/base' 'local local'
+  mklayer local .zshrc/inside 'a directory where base has a file'
+  run_shale which .zshrc
+  assert_status 0 "$shale_status" 'the collision'
+  assert_contains "$shale_err" "shale: note: 'build' would fail here — .zshrc is a file in 'base' and a directory in 'local'" \
+    'the collision stderr'
+  assert_not_contains "$shale_err" 'is in the built tree at' 'the collision stderr'
 }
 
 # A layer shipping the file shale reads: the table names the layer holding it
@@ -11922,6 +12373,7 @@ ${h}=\$trip/root/home${nl}\
 ${h}=\$trip/root/link${nl}\
 ${h}=\$trip/root/sub/../../outside${nl}\
 ${h}=\$home_link${nl}\
+${h}=\$home${nl}\
 ${h}=\$home_ok${nl}\
 ${h}=\$home_rel${nl}\
 ${h}=\$CASE_DIR/unmarked${nl}"


### PR DESCRIPTION
Closes #106.

`which` states the observable fact — the path is in `current/` and nothing is at the matching place in `$HOME` — rather than parsing a resource file's perl regexes, which #96 settled shale must not do. That covers causes shale does not model.

Where shale cannot tell, it does not conclude: a build newer than the last apply is indistinguishable from a declined path on the floor (`-nt` follows symlinks), an unreadable tree takes its own arm, and a resource file setting `--dotfiles` is named rather than reasoned about.