### PR TITLE
Normalise the shell options that change what a word means

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ component, `[abc]` and `[!abc]` match one character, and everything else is lite
 no `/` matches a path component at any depth; one with a `/` anywhere is anchored at the top of the
 tree. A directory that matches takes everything under it. Anything shale cannot translate — a
 backslash, a `**`, a trailing `/`, an unclosed `[` — is refused by name, with the file and line, and
-stops the build rather than reaching stow. That subset does not change with the shell you run shale
-from: a shell that exports `SHELLOPTS`, `BASH_ENV`, or `BASHOPTS` on bash 4.1 and later, passes its
-own `extglob` or `nocasematch` to every script it starts, and shale turns those off for itself
-before reading a pattern.
+stops the build rather than reaching stow. Nothing about what shale does changes with the shell you
+run it from: a shell that exports `SHELLOPTS`, `BASH_ENV`, or `BASHOPTS` on bash 4.1 and later
+passes its own options to every script it starts, and shale turns off the ones that would change an
+answer — the `extglob` and `nocasematch` that rewrite a pattern, and the `keyword` and `errexit`
+that rewrite what the script itself means — before it does anything. `set -v` and `set -x` are left
+alone, so `bash -x shale build` still works.
 
 The file is still composed into `current/`; the pattern changes only what stow links. So a pattern
 that matches more than it was meant to leaves a real file unlinked with `shale apply` exiting 0, and

--- a/shale
+++ b/shale
@@ -12,7 +12,7 @@ fi
 
 set -uo pipefail
 
-# What a pattern means, fixed here rather than left to the shell that started
+# What the shell means, fixed here rather than left to the shell that started
 # shale.  The glob subset an ignore file may use is a documented contract -
 # '*', '?', '[abc]', '[!abc]', and everything else a literal - and half of the
 # options below rewrite it.  Two of them are ordinary things to have in an rc
@@ -40,6 +40,25 @@ set -uo pipefail
 # boundary.
 #
 # Each name earns its place:
+#   set +e          errexit arrives the same way and ends the run at the first
+#                   command whose status this script reads rather than acts on -
+#                   which is most of them, shale being written to diagnose every
+#                   failure in its own words and a meta case pinning that it
+#                   never sets errexit itself.  Measured: doctor stopped after
+#                   the config check, printed no summary line, and exited 1 - a
+#                   report with three of its eight sections in it, a status that
+#                   looks right, and nothing saying the rest never ran.
+#   set +k          keyword makes a 'name=value' word an assignment wherever it
+#                   appears in a command rather than only ahead of one, so every
+#                   'local x=$1' below declared nothing and assigned into a
+#                   temporary environment instead.  On 5.2 that is a crash
+#                   naming a line number.  On the 3.2 floor, which is what macOS
+#                   ships, it is worse: the config parser read its own 'local' as
+#                   the layer path and refused a shale.conf that is correct, by
+#                   name and line number, with nothing in the message hinting at
+#                   the shell.  It is a parse-time option, so this line has to
+#                   run before the functions below are read - bash parses one
+#                   complete command at a time, so it does.
 #   set +f          noglob arrives through an exported SHELLOPTS on every bash
 #                   there is, the floor included, and stops every listing below
 #                   from expanding at all.
@@ -78,9 +97,46 @@ set -uo pipefail
 # it - so it is left alone rather than named, the name itself being one the
 # floor guard bans.
 #
-# Every name below exists on bash 3.2, so this cannot fail and no status has to
-# be dropped - which matters, errexit being inheritable through SHELLOPTS on
-# every bash there is and shale being written never to need it.
+# Four 'set -o' options reach shale and are not turned off here.
+#
+# noexec and onecmd are the two that cannot be, and they fail the same way: a
+# shale started under either exits 0 having composed nothing, linked nothing and
+# said nothing.  Under noexec bash reads the whole script and executes none of
+# it, so the line that would clear it does not run either.  onecmd looks
+# defendable and is not: bash runs one command and exits, and a comment line
+# spends it - so the '#!' on line 1 of this file is the one command every run of
+# it gets, and nothing below here executes at all.  Measured on 3.2.57 and
+# 5.2.21: a two-line script of 'set +t' and an echo prints the echo, and the
+# same script with any '#' line above it prints nothing.  Both are named here so
+# that the next reader does not go looking for the guard that would work.
+#
+# verbose and xtrace are the two that could be and deliberately are not.  They
+# add lines about the run - to stderr, and on doctor to stdout as well, that
+# being where a status is read through a '2>&1' - and change nothing else:
+# measured on both bashes, the composed tree and every exit status are identical
+# with each of them on and off.  Turning them off would defeat 'bash -x shale
+# build', which is how this script gets debugged.
+#
+# xtrace had one consequence beyond the noise, and it is fixed where it happens
+# rather than by clearing the option here.  The subshell that runs stow has both
+# its streams captured, so the trace of that subshell arrived as stow's output
+# and shale reported 'stow exited 0 and wrote output' over its own '++ cd' and
+# '++ stow' lines.  cmd_apply clears xtrace over that capture alone and puts it
+# back, which leaves every other command in the run traced.
+#
+# That leaves 20 of the 27 'set -o' options both bashes carry, and not one of
+# them changes anything shale does.  Two are shale's own - nounset and pipefail
+# - and the rest are readline and job-control settings a non-interactive shell
+# does not act on.  Measured rather than assumed, each of the 20 over a build,
+# an apply, a which and three doctors on both bashes, and the nine that could
+# plausibly reach a file operation over the whole suite as well.  Two of them
+# harden shale by accident, which is worth knowing and not worth relying on:
+# posix and privileged each stop bash reading BASH_ENV, the route this block
+# declines to defend against.
+#
+# Every name below exists on bash 3.2, so no line here can fail on a status -
+# and 'set +e' is the first of them, so an inherited errexit is gone before any
+# of the rest could be acted on.
 #
 # The order is not arbitrary and the overlap in it is not redundancy.  'The
 # dotglob option is disabled when GLOBIGNORE is unset' - bash(1), the same
@@ -91,6 +147,8 @@ set -uo pipefail
 # sentence promises - rather than this script asking for dotglob off.  The day
 # the GLOBIGNORE line moves or goes, the option it was silently carrying goes
 # with it.  So the last word on each option is the line that names it.
+set +e
+set +k
 set +f
 unset GLOBIGNORE
 shopt -u dotglob extglob failglob nocaseglob nocasematch nullglob
@@ -4055,7 +4113,7 @@ cmd_build() {
 }
 
 cmd_apply() {
-  local status err
+  local status err had_xtrace
 
   parse_config || exit 1
 
@@ -4096,13 +4154,40 @@ cmd_apply() {
   # apply that linked everything from one that linked most of it.  Both streams
   # go into the one capture, because letting stdout past means duplicating fd 1,
   # and that dup fails outright on a 'shale apply >&-' - no stow, nothing linked.
+  #
+  # Which makes this the one place in the script where an inherited xtrace is
+  # not merely loud.  The trace of the subshell goes to that subshell's stderr,
+  # which is the capture, so 'shale apply' under one reported 'stow exited 0 and
+  # wrote output' and printed shale's own '++ cd' and '++ stow' lines back as
+  # stow's.  Everything else the option does is a line about shale prefixed by
+  # PS4; this was shale asserting something untrue about another program.
+  #
+  # So it is cleared over the capture and put back, rather than in the block at
+  # the top of the file that clears the options which change an answer.  The
+  # narrow window is the point: 'bash -x shale apply' still traces every other
+  # command, which is what the trace is for.  The price is the cd and the stow
+  # inside the window, which now have no trace line anywhere - paid for a
+  # capture holding what stow wrote and nothing else.  Read from $- because that
+  # is the only spelling of the question that works on the 3.2 floor and does
+  # not cost a fork.
+  #
+  # No restore is owed on the paths that do not reach it: every trap that can
+  # fire in this window exits.
   status=0
+  had_xtrace=0
+  case $- in
+    *x*)
+      had_xtrace=1
+      set +x
+      ;;
+  esac
   err=$(
     (
       cd "$DOTFILES" 2>/dev/null || exit 125
       stow -d "$DOTFILES" -t "$HOME" -R --no-folding current
     ) 2>&1
   ) || status=$?
+  [ "$had_xtrace" -eq 0 ] || set -x
   # Before every message below, all of which point at what stow reported
   # 'above'.  Nothing was written under 125 - stow never ran - so that arm is
   # covered by this being empty.

--- a/tests/run
+++ b/tests/run
@@ -221,6 +221,10 @@ SHALE_RUNS=0
 STUB_PATHS=0
 # One file per inherit_shell_line call, for the same reason.
 SHELL_ENVS=0
+# The SHELLOPTS every run of shale in this case is started with, set by
+# inherit_shell_option and empty for the shell this harness runs in - which is
+# the only correct default, an inherited one being the thing under test.
+INHERIT_SHELLOPTS=
 # Set to 1 in the copy run_inner_suite builds, by a line appended after this
 # one.  A plain assignment, not ${INNER_SUITE-}: innerness is a property of the
 # harness file, and anything inherited from the environment would make a
@@ -719,7 +723,14 @@ shale() {
     chmod u-x "$locked" || fail "could not remove the search bit from $locked"
   fi
   if [ "${1-}" != --script ]; then
-    "$SHALE" ${1+"$@"}
+    # 'env', not a 'SHELLOPTS=x cmd' prefix: SHELLOPTS is readonly in every bash
+    # there is, and a temporary assignment to a readonly name is an error in
+    # this shell rather than a variable in the child's environment.
+    if [ -n "$INHERIT_SHELLOPTS" ]; then
+      env "SHELLOPTS=$INHERIT_SHELLOPTS" "$SHALE" ${1+"$@"}
+    else
+      "$SHALE" ${1+"$@"}
+    fi
     status=$?
     # Before the caller sees the status, so a case cannot assert on a run whose
     # mode it forgot to restore and leave the sandbox undeletable.
@@ -921,6 +932,26 @@ inherit_shell_line() {
   SHELL_ENVS=$((SHELL_ENVS + 1))
   sandbox_write "$CASE_DIR" "shell-env.$SHELL_ENVS.sh" ${1+"$@"}
   export BASH_ENV=$sandbox_path
+}
+
+# inherit_shell_option NAME - starts every shale in the rest of this case from a
+# shell that has the 'set -o' option NAME on.
+#
+# The second of those three routes, and for a 'set -o' option it is the one a
+# user actually meets: BASH_ENV is a file somebody wrote on purpose, while a
+# shell that has SHELLOPTS in its environment at all re-exports it to every
+# child from then on, so one 'export SHELLOPTS' in a profile hands the whole
+# set down for the life of the session.  It carries these options on bash 3.2
+# as well as 5.2, which BASHOPTS does not, so a case written this way exercises
+# the same thing on the floor as in the container.
+#
+# Kept apart from inherit_shell_line rather than folded into it: a BASH_ENV
+# file setting the same option would prove the option's effect and not the
+# route, and the route is what the block at the top of the script is written
+# against.
+inherit_shell_option() {
+  [ -n "${1-}" ] || guard_trip 'inherit_shell_option was given no option name'
+  INHERIT_SHELLOPTS=$1
 }
 
 # stub_path_without TOOL... - a directory holding a link to every tool shale and
@@ -12700,10 +12731,18 @@ test_meta_dot_globs_answer_the_same_under_both_glob_meanings() {
 # in the script being one and its name being banned by the floor guard;
 # globskipdots, which
 # test_meta_dot_globs_answer_the_same_under_both_glob_meanings covers by running
-# the whole script under both of its meanings; and every option that reaches
-# neither matching nor expansion.  set -k, set -t, set -v and set -x all still
-# change what a run does and none of them is normalised - they are loud rather
-# than quiet, and they are not this claim.
+# the whole script under both of its meanings; and the 20 'set -o' options that
+# were measured changing nothing shale does.
+#
+# Seven of the 27 do change something.  noglob is the oldest of them and its
+# case is above, reached through a BASH_ENV file rather than SHELLOPTS; keyword
+# and errexit are turned off by the same block and have a case each below,
+# asserted the same way; verbose and xtrace are left in force on purpose and
+# have a case each holding that decision as well as the answers; and noexec and
+# onecmd cannot be turned off from inside a script that has a '#!' line - which
+# is why they have a paragraph in the script and no case here.  Nothing can
+# assert a defence that does not exist, and a case pinning 'shale does nothing
+# and exits 0' would be pinning the defect.
 
 # The tree the cases below share, built to be sensitive to every option in the
 # set at once.  'notes.txt' against an upper-case '*.TXT' is what nocasematch
@@ -12768,14 +12807,11 @@ option_unlinked_note() {
   printf "shale:   run 'shale apply': a path still missing after one is a path stow declined to link\n"
 }
 
-# The answers that fixture has, under any shell that started shale.  Every
-# assertion is labelled with the option in force, so a failure names it rather
-# than leaving a dozen near-identical cases to be told apart by line number.
-assert_option_answers() {
+# What a build of that fixture composes, on its own because the two cases for
+# the options left in force assert it and cannot assert the rest - stderr under
+# either of them is the script.
+assert_option_tree() {
   local label=$1
-  run_shale build
-  assert_status 0 "$shale_status" "$label: the build"
-  assert_empty "$shale_err" "$label: the build stderr"
   # LC_ALL on the sort, not on the run: the order a glob expands in is the
   # locale's, and this is the harness's own listing rather than shale's answer.
   assert_eq '.
@@ -12794,6 +12830,17 @@ assert_option_answers() {
 ./sub/.nested' \
     "$(cd "$HOME/.dotfiles/current" && find . -print | LC_ALL=C sort)" \
     "$label: the composed tree"
+}
+
+# The answers that fixture has, under any shell that started shale.  Every
+# assertion is labelled with the option in force, so a failure names it rather
+# than leaving a dozen near-identical cases to be told apart by line number.
+assert_option_answers() {
+  local label=$1
+  run_shale build
+  assert_status 0 "$shale_status" "$label: the build"
+  assert_empty "$shale_err" "$label: the build stderr"
+  assert_option_tree "$label"
   # The whole of stderr on every one of these rather than a fragment, because
   # what an inherited option does to them is add a line or swap one note for
   # the other, and a 'contains' on the first line would see neither.
@@ -12976,6 +13023,192 @@ test_meta_globasciiranges_turned_off_changes_no_answer() {
   assert_option_answers 'globasciiranges off'
 }
 
+# The same claim reached through the other route, for the two 'set -o' options
+# that reach the parser and the exit rather than the matcher.
+# inherit_shell_option is SHELLOPTS rather than a BASH_ENV file, which is what
+# a user meets: one 'export SHELLOPTS' anywhere in a profile hands every option
+# in it to every child for the life of the session, on the bash 3.2 floor as
+# well as on 5.2.
+
+# 'set -k' makes a 'name=value' word an assignment wherever it appears in a
+# command, so the script's own 'local x=$1' declared nothing.  On 5.2 that ended
+# the run with 'x: unbound variable' and a line number.  On the floor, which is
+# macOS's /bin/bash, the config parser read its own 'local' as the layer path
+# and refused a shale.conf that is correct - which is the reason this one is
+# normalised rather than left to be loud.
+test_meta_an_inherited_keyword_does_not_change_an_answer() {
+  option_fixture
+  inherit_shell_option keyword
+  assert_option_answers 'keyword'
+}
+
+# The half of that which is worse than a crash, asserted on its own because a
+# fixture whose answers all match cannot say why the mismatch mattered.  No
+# message may name the config, and none may name a valid layer path as invalid:
+# the file is right, and a user sent to fix it is a user shale has lied to.
+test_meta_an_inherited_keyword_never_blames_the_config() {
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  inherit_shell_option keyword
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_not_contains "$shale_err" 'invalid layer path' 'the build stderr'
+  assert_not_contains "$shale_err" "$HOME/.dotfiles/shale.conf" 'the build stderr'
+  assert_eq 'common/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the winner'
+  # Every other command too: the parse the option broke is the one every one of
+  # them starts with.
+  run_shale which .zshrc
+  assert_status 0 "$shale_status" 'which'
+  assert_not_contains "$shale_err" 'invalid layer path' 'the which stderr'
+  run_shale doctor
+  assert_not_contains "$shale_out" 'invalid layer path' 'the doctor stdout'
+}
+
+# errexit reads as already handled, on the grounds that shale does not set it
+# and a meta case greps for that - which is true and is not the question.  An
+# inherited one ends the run at the first command whose status shale reads
+# rather than acts on, and doctor is made of those: this fixture's report
+# stopped after the config section, printed no summary line, and exited 1.  The
+# status is right, the two lines it did print are right, and the three checks
+# that had not run yet are the ones naming the file in the way of the next
+# apply.  A report
+# that stops talking and still exits like a report is the quiet half of this
+# issue, so the summary line is what is asserted.
+#
+# The config error is what reaches it: parse_config answers non-zero for a
+# config with a bad line, doctor reads that status rather than acting on it,
+# and errexit acts on it instead.  A clean config leaves this case green under
+# a shale with no 'set +e' in it at all, which is why the bad line is here.
+test_meta_an_inherited_errexit_does_not_cut_a_report_short() {
+  conf 'base common/base' 'lonely'
+  mklayer common/base .zshrc
+  sandbox_write "$HOME" .zshrc 'mine, and not a link'
+  inherit_shell_option errexit
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  # The section that ran before the truncation, and the two that did not.
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/shale.conf:2: expected 'NAME PATH [URL]', got only 'lonely'" \
+    'the doctor stdout'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" \
+    'the doctor stdout'
+  assert_contains "$shale_out" \
+    "shale: there is no built tree at $HOME/.dotfiles/current" 'the doctor stdout'
+  # The line a reader scans for.  Its absence is what made the truncation quiet.
+  assert_contains "$shale_out" 'shale: 2 problems found' 'the doctor stdout'
+}
+
+# The two that are deliberately left in force, and the guard on that decision.
+#
+# Each asserts both halves: that the option changes no answer - the composed
+# tree, the exit status and shale's own lines are what they are without it -
+# and that the run is still tracing, which is the half that goes red if
+# somebody adds 'set +v' or 'set +x' to the block.  That is the point of them.
+# Turning either off would defeat 'bash -x shale build', which is how this
+# script gets debugged, and neither can be mistaken for shale's answer: every
+# line shale writes carries the 'shale: ' prefix and no trace line does.
+#
+# The exception to that last sentence is apply, where the trace of one subshell
+# went into a capture shale reads as another program's output.  That is not a
+# line about shale and it is not left: cmd_apply clears the option over the
+# capture alone, and the case below apply's own is what holds it.
+#
+# assert_option_answers is not used, and cannot be: it asserts the whole of
+# stderr, which under either of these is the script.  What is shared with it is
+# the fixture and the composed tree.
+test_meta_an_inherited_xtrace_changes_no_answer_and_is_left_in_force() {
+  option_fixture
+  # What the trace lines are prefixed with, said here rather than assumed: PS4
+  # defaults to this and is an ordinary exported variable, so a developer who
+  # has set one would otherwise make the assertion below read the wrong thing.
+  # bash repeats its first character once per level of nesting.
+  export PS4='+ '
+  inherit_shell_option xtrace
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_option_tree 'xtrace'
+  run_shale which notes.txt
+  assert_status 0 "$shale_status" 'which notes.txt'
+  assert_contains "$shale_out" \
+    "winner    base  $HOME/.dotfiles/common/base/notes.txt" 'which notes.txt stdout'
+  # The trace lines alone, with the '+ ' prefixes taken off - nothing shale
+  # prints begins with one - and asserted to reach a command that works on the
+  # built tree.  A 'set +x' added to the block would leave the four lines above
+  # it traced and this empty, so a 'contains +' would pass a mutant that turned
+  # the option off.
+  assert_contains "$(printf '%s\n' "$shale_err" | sed -n 's/^++* //p')" \
+    "$HOME/.dotfiles/current" 'the which stderr, trace lines only'
+  assert_contains "$shale_err" \
+    "shale: note: 'notes.txt' is in the built tree at" 'the which stderr'
+}
+
+# The same for verbose, whose output is the script's lines rather than the
+# commands they became.  The line asserted is the last of the script's own
+# dispatch, so a 'set +v' anywhere above it - which is anywhere at all - leaves
+# this case red rather than passing on the handful of lines that had already
+# been echoed before it.
+test_meta_an_inherited_verbose_changes_no_answer_and_is_left_in_force() {
+  option_fixture
+  inherit_shell_option verbose
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_option_tree 'verbose'
+  run_shale which notes.txt
+  assert_status 0 "$shale_status" 'which notes.txt'
+  assert_contains "$shale_out" \
+    "winner    base  $HOME/.dotfiles/common/base/notes.txt" 'which notes.txt stdout'
+  assert_contains "$shale_err" "    usage_error \"unknown command '\$cmd'\"" \
+    'the which stderr'
+  assert_contains "$shale_err" \
+    "shale: note: 'notes.txt' is in the built tree at" 'the which stderr'
+}
+
+# The one place leaving xtrace in force was not free, and the guard cmd_apply
+# puts on it.  Both of stow's streams go into one capture, so the trace of the
+# subshell holding stow landed in it: apply then said 'stow exited 0 and wrote
+# output', said it does not read what stow writes, and printed shale's own '++
+# cd' and '++ stow' lines as though stow had written them.  stow wrote nothing.
+# Three 'shale: ' lines of it, and every one untrue - which is not the noise the
+# option is allowed to add but shale asserting something about another program.
+#
+# Its own fixture rather than option_fixture: that one plants two files in $HOME
+# for doctor to find, and stow refuses an apply over either of them, so nothing
+# would reach the capture at all.
+#
+# The trace has to still be running afterwards, or the fix would be a 'set +x'
+# with the restore forgotten and this case would pass on it.  The lock cleanup
+# runs from the EXIT trap, which is after everything cmd_apply does, so it is
+# the trace line that says the option came back.
+test_meta_an_inherited_xtrace_is_not_reported_as_stows_output() {
+  local trace
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  export PS4='+ '
+  inherit_shell_option xtrace
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc" 'the applied link'
+  assert_not_contains "$shale_err" 'shale: stow exited 0 and wrote output' \
+    'the apply stderr'
+  # The second line of the same message, so a rewording of the first does not
+  # leave this case passing over a report that is still being made.  Not the
+  # bare 'shale: ' prefix: the trace of report itself carries that string.
+  assert_not_contains "$shale_err" 'shale does not read what stow writes' \
+    'the apply stderr'
+  trace=$(printf '%s\n' "$shale_err" | sed -n 's/^++* //p')
+  # The price, asserted rather than left to be discovered: the two commands
+  # inside the window are the two the trace no longer has.  stow ran - the link
+  # above is the proof - and the line saying so is what was traded for the three
+  # untrue ones.
+  assert_not_contains "$trace" 'stow -d' 'the apply stderr, trace lines only'
+  # And the option came back on the far side, which is the half a fix that
+  # cleared it and forgot the restore would fail.  cleanup runs from the EXIT
+  # trap, after everything in cmd_apply.
+  assert_contains "$trace" "rmdir $HOME/.dotfiles/.lock" \
+    'the apply stderr, trace lines only'
+}
+
 # The drift guard for the set above: the script normalises a list, the cases
 # above cover a list, and nothing else makes them the same list.  Adding a name
 # to the script without a case leaves it asserted by nothing, and a case for a
@@ -13018,6 +13251,55 @@ test_meta_every_normalised_shell_option_has_a_case() {
       'add a test_meta_an_inherited_<name>_ case, and this list, in the same change'
   [ -z "$extra" ] ||
     fail "this case names an option the script no longer normalises:$extra" \
+      'the case for it is passing without exercising anything'
+}
+
+# The same guard for the other half of that block.  The 'set -o' options are
+# turned off a letter at a time rather than by name, so this reads the letters
+# and holds the long name each of them stands for beside the case that covers
+# it - a letter with no case is an option nothing asserts, and a case for a
+# letter the script no longer clears is a case exercising nothing.
+#
+# 'set -uo pipefail' and every other line that turns an option on is not read:
+# only '^set +'.  A letter the script both clears and sets would be a
+# contradiction this cannot see, and there is no such letter.
+test_meta_every_normalised_set_option_has_a_case() {
+  local word letters letter covered name missing extra
+  letters=
+  # Unquoted on purpose: every such line is 'set +<letter>', so splitting it
+  # into words and keeping the ones that start with '+' collects the letters
+  # however many lines there are.
+  # shellcheck disable=SC2013
+  for word in $(grep '^set +' "$SHALE"); do
+    case "$word" in
+      +*) letters="$letters ${word#+}" ;;
+    esac
+  done
+  [ -n "$letters" ] ||
+    fail "the script has no top-level 'set +' line, and this case reads them" \
+      'it guards nothing at zero'
+  covered=' e:errexit f:noglob k:keyword '
+  missing=
+  extra=
+  # Unquoted on purpose: the letters collected above, split into words.
+  # shellcheck disable=SC2086
+  for letter in $letters; do
+    case "$covered" in
+      *" $letter:"*) ;;
+      *) missing="$missing $letter" ;;
+    esac
+  done
+  for name in $covered; do
+    case " $letters " in
+      *" ${name%%:*} "*) ;;
+      *) extra="$extra ${name#*:}" ;;
+    esac
+  done
+  [ -z "$missing" ] ||
+    fail "the script clears a 'set -o' option no case above covers:$missing" \
+      'add a test_meta_an_inherited_<name>_ case, and this list, in the same change'
+  [ -z "$extra" ] ||
+    fail "this case names an option the script no longer clears:$extra" \
       'the case for it is passing without exercising anything'
 }
 


### PR DESCRIPTION
Closes #114.

`SHELLOPTS=keyword` made shale on bash 3.2 — macOS's /bin/bash — print a false diagnosis about a valid config, sending the user to fix a correct file. On bash 5 it crashed instead.

The audit covers all 27 `set -o` options on both bashes: `keyword` and `errexit` are cleared, `noexec` and `onecmd` are named as undefendable (a script's `#!` line spends `onecmd`'s single command), `verbose` and `xtrace` are deliberately left in force.

Leaving `xtrace` in force made shale report its own trace as stow's output; the stow capture now clears and restores it, so `bash -x shale build` still traces throughout.

#114's text lists `errexit` as already handled on the grounds that shale does not set it. Not setting an option is not the same as not inheriting one; the issue is wrong on that line.