### PR TITLE
Copy a layer's directory modes, and never widen one in $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,11 @@ overwrites, and how to carry on from a block that stopped.
   symlinks in `$HOME` point at nothing. Apply relinks immediately afterwards.
 - No build is incremental: every one composes every layer from scratch, so a one-character edit
   costs what a first build costs. Roughly two milliseconds a file — 4.1 seconds for a 2000-file
-  tree, 31 milliseconds for a seven-file one, on the container these were measured in.
+  tree, 31 milliseconds for a seven-file one, on the container these were measured in. A directory
+  costs more than a file, because its mode is read and set: budget about three milliseconds each —
+  once per directory and not once per layer providing it, since only the layer that wins a path pays
+  — which a directory-heavy tree notices and an ordinary one does not. An `apply` adds one more read
+  for each of those directories that was already in `$HOME`.
 - When a whole directory leaves every layer, stow does not visit it and the links inside it are left
   dangling by an apply that still exits 0. `shale doctor` finds them and prints what to do about
   them; [docs/migrating.md](docs/migrating.md) covers the case in full.
@@ -450,6 +454,16 @@ overwrites, and how to carry on from a block that stopped.
   still there, because that build will not run: clear the lock and doctor says so instead.
 - Git cannot store an empty directory, so a layer that needs one ships a `.gitkeep`, which will
   appear in `$HOME`.
+- Git records no permission bits for a directory, and only the executable bit for a file, so a
+  freshly cloned layer has whatever modes the clone's umask gave it — `755` on most machines, `775`
+  on Debian and Ubuntu, and `644` for a file you committed at `600`. Shale copies the working tree
+  faithfully, and the working tree after a clone is not what was committed. Where a mode matters,
+  `chmod` it in the layer: every build and apply reproduces it from there.
+- Shale sets the mode of a directory it creates in `$HOME`, and never widens one that was already
+  there. So a `~/.ssh` you keep at `700` survives a layer that a clone left at `755`. `apply` says
+  in one line that it left such a directory alone, `doctor` names each one and both ways to settle
+  it, and `doctor` stays green — nothing is broken, and the directory shale kept is the safer of
+  the two.
 
 ## Licence
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -339,6 +339,77 @@ Git cannot store an empty directory. Ship a `.gitkeep` in it, and expect it in `
 it like any other file and stow links it. `~/.config/zsh/rc.d/.gitkeep` is the price of a fragment
 directory that starts out empty.
 
+## Permissions on a directory
+
+A file arrives in `$HOME` with the mode it has in the layer, and so does the directory holding it, as
+long as shale is the one that created it. `~/.ssh` at `700` in a layer is `700` in
+`~/.dotfiles/current` and `700` in `$HOME`, on a machine at any umask. Nothing about the machine you
+build on decides it.
+
+One bit is shale's rather than the layer's: the owner's `rwx` is always on. A layer directory at
+`550` composes as `750`. Shale has to be able to write into a directory it has just created — the
+next layer composes into it, and an interrupted build has to be able to delete the tree it left
+behind — and a directory in `$HOME` you cannot enter is not an arrangement any dotfile wants. The
+group and world bits, which are the ones that decide whether `~/.ssh` is safe, are copied exactly.
+
+Where two layers provide the same directory, the mode is the last one's, exactly as its files are.
+That includes a layer that provides only one file inside it: a `local` layer adding
+`~/.ssh/known_hosts` hands the mode of `~/.ssh` to `local`, whatever the base layer says. Put the
+mode you want on the directory in every layer that has it.
+
+Directories in `$HOME` are set by `apply` after stow has run, because stow does not carry a mode:
+under `--no-folding` it creates each directory with the umask of whoever ran it and never with the
+mode of the built tree.
+
+**A directory that was already in `$HOME` before the apply is only ever narrowed.** Keep `~/.ssh` at
+`700` and add a layer whose `.ssh` is `755` — the mode a clone gives it — and the apply leaves your
+`700` alone. The same layer against a `~/.ssh` that does not exist yet, or one at `755`, gives you the
+layer's mode exactly. The rule is the asymmetry: a mode fix that quietly opens `~/.ssh` is worse than
+the mode being wrong.
+
+`apply` says so in one line, with the count and no more, because after a clone this is the ordinary
+state rather than a rare one and it lasts until you change something:
+
+```
+shale: 1 directory in /home/you was left as it is: shale never widens one that was already there; 'shale doctor' names it
+```
+
+`shale doctor` is where the detail is. It names each path, the mode it has and the mode the layer
+gives, as a note rather than a problem — the directory that survives is the *safer* of the two, so
+nothing here is broken and `doctor` still exits 0:
+
+```
+shale: an apply left 1 directory in /home/you as it is
+shale:   /home/you/.ssh is 0700, and the layer that provides it gives 0755
+shale:   shale sets the mode of a directory it creates in /home/you, and never widens one that was already there
+shale:   to take the mode the layer gives, chmod that directory yourself
+shale:   to keep the mode it has, set that mode on the directory in the layer: 'shale which' names the layer for a path
+shale: no problems found, but read the note above
+```
+
+`apply` exits 0 either way — nothing it was asked to do was left undone. A mode it cannot set at all
+is a different thing: that is named on stderr and `apply` exits 1 with the links in place.
+
+Nothing is set on a path an ignore list blocks, in `$HOME` or below it. No apply links anything
+there, so the `~/.cache` a layer names in `.shale-ignore` is yours and shale does not touch its mode
+— the same paths `shale which` reports as ignored.
+
+`setgid`, `setuid` and the sticky bit are copied with the rest. A layer directory that is `2775` makes
+`$HOME`'s `2775`, and everything created inside it afterwards takes that directory's group. That is
+rarely what anyone intends and is easy to acquire by accident, since a directory created inside a
+`setgid` parent inherits the bit: check with `ls -ld` if a layer of yours lives on a shared volume.
+
+**Git records none of this.** A tree entry has no permission bits at all, and a blob's are one
+executable bit, so a freshly cloned layer has whatever the clone's umask gave it — `755` on most
+machines, `775` on Debian and Ubuntu, and `644` for a `config` you committed at `600`. Shale copies
+what is in the working tree, faithfully, and what is in the working tree after a clone is not what
+you committed. Where a mode matters, set it after cloning:
+
+```sh
+chmod 700 ~/.dotfiles/personal/base/.ssh ~/.dotfiles/personal/base/.gnupg
+chmod 600 ~/.dotfiles/personal/base/.ssh/config
+```
+
 ## What a layer must not ship
 
 Never a `.stow-local-ignore` at the top of a layer. Shale writes the one in `current/` itself — it is

--- a/shale
+++ b/shale
@@ -1828,10 +1828,103 @@ older_than_layer() {
   OLDER_COUNT=$((OLDER_COUNT + 1))
 }
 
+# One 'rwx' triad of an ls mode string as its octal digit, in TRIAD.  Non-zero
+# on any character that is not one ls writes there, which is the whole of what
+# tells a mode string from a line that is not one.
+#
+# The execute position carries three bits at once: 'x' is execute, 's' and 't'
+# are execute *and* the set-id or sticky bit, and 'S' and 'T' are that bit with
+# no execute under it.  The high bit itself is dir_mode's to collect; what this
+# has to get right is that 's' means +1 here and 'S' does not.
+mode_triad() {
+  local t=$1 n=0
+  case "${t:0:1}" in
+    r) n=4 ;;
+    -) ;;
+    *) return 1 ;;
+  esac
+  case "${t:1:1}" in
+    w) n=$((n + 2)) ;;
+    -) ;;
+    *) return 1 ;;
+  esac
+  case "${t:2:1}" in
+    x | s | t) n=$((n + 1)) ;;
+    - | S | T) ;;
+    *) return 1 ;;
+  esac
+  TRIAD=$n
+  return 0
+}
+
+# The permission bits of the directory $1, as the four octal digits chmod takes:
+# DIR_MODE_RAW is what is there, DIR_MODE is that with the owner's rwx forced on.
+# Non-zero when they could not be read, which the caller reports: a mode nobody
+# can name is not one to guess at.
+#
+# ls, because there is no other portable reader.  No shell builtin gives a mode;
+# 'test' answers for this process's access and says nothing about the group's or
+# the world's, which is the half that matters here; stat is not on the
+# portability floor and its format strings differ between the two userlands
+# anyway.  The digits are built by concatenation rather than by addition, so
+# nothing here has to be told that a shell reads 0700 as octal in one place and
+# as seven hundred in another.
+#
+# Only the first ten characters are read, and they are the file type followed by
+# the nine mode characters wherever ls runs: the name is last on the line, so
+# neither a strange one nor an eleventh column - the '+' or '@' a system with
+# ACLs or extended attributes adds - moves them.  The path is absolute at every
+# call site, so no operand here can be read as an option.
+#
+# The owner's rwx is forced on rather than copied, and that is the one bit of
+# this that is not the layer's mode.  Shale has to write into the directory it
+# has just created - the next layer composes into it, and cleanup has to be able
+# to delete a tree an interrupted build left behind, which 'rm -rf' cannot do
+# through a directory it may not read.  A directory in $HOME that its owner
+# cannot enter is also not an arrangement any dotfile wants, and stow could not
+# descend one to link what is inside it.  So 0500 in a layer arrives as 0700,
+# and the group and world bits - which are the whole of what makes a .ssh
+# directory unsafe - arrive exactly as the layer has them.
+#
+# ls keeps its own stderr, as chmod does at the two call sites that run one: on
+# the paths that reach either, which errno it is - the tool missing, the path
+# gone, a directory that cannot be searched - is what tells the reader what to
+# do, and no line shale writes from here knows it.
+dir_mode() {
+  local path=$1 line perm hi owner group other
+  line=$(ls -ld "$path") || return 1
+  perm=${line:1:9}
+  [ "${#perm}" -eq 9 ] || return 1
+  hi=0
+  case "${perm:2:1}" in
+    s | S) hi=$((hi + 4)) ;;
+  esac
+  case "${perm:5:1}" in
+    s | S) hi=$((hi + 2)) ;;
+  esac
+  case "${perm:8:1}" in
+    t | T) hi=$((hi + 1)) ;;
+  esac
+  mode_triad "${perm:0:3}" || return 1
+  owner=$TRIAD
+  mode_triad "${perm:3:3}" || return 1
+  group=$TRIAD
+  mode_triad "${perm:6:3}" || return 1
+  other=$TRIAD
+  DIR_MODE_RAW=$hi$owner$group$other
+  DIR_MODE=$hi'7'$group$other
+  return 0
+}
+
 # Copies one layer directory over the composed tree, entry by entry, last write
 # winning per path.  No bulk cp: it would name neither layer in a collision.
+#
+# $4 is 1 where a directory above this one is on an ignore list, which is
+# scan_ignored_links's carry and is here for the same reason: a pattern matches
+# a directory and covers everything under it, so a per-path test at each entry
+# would call a descendant of a matched directory unignored.
 compose_dir() {
-  local src=$1 dst=$2 rel=$3 e base srel dpath here
+  local src=$1 dst=$2 rel=$3 inherited=$4 e base srel dpath here mode ignored
   here=$src${rel:+/$rel}
   # nullglob makes a directory that cannot be listed indistinguishable from an
   # empty one, so without this its whole subtree is dropped from the build and
@@ -1872,7 +1965,53 @@ compose_dir() {
       else
         mkdir "$dpath" || die "could not create $dpath"
       fi
-      compose_dir "$src" "$dst" "$srel"
+      # The ignore lists, in scan_ignored_links's order and with its carry.
+      # Guarded on the pattern count for the reason that one is: the ordinary
+      # config has no ignore line at all, and the call would still pay for two
+      # locale switches at every directory of every layer.
+      ignored=$inherited
+      if [ "$ignored" -eq 0 ]; then
+        if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$srel"; then
+          ignored=1
+        elif path_is_stow_ignored "$srel"; then
+          ignored=1
+        fi
+      fi
+      # A directory's mode is copied from the layer, where a file's comes with
+      # it in cp -RPp.  Only the layer that wins the path does either half of
+      # it, and that is what makes the cost one read and one chmod per composed
+      # directory rather than one of each per directory per layer: the mode a
+      # losing layer would set is overwritten by the winner a moment later, and
+      # a build's whole answer for the path is the winner's.
+      #
+      # Which leaves a directory a losing layer created holding mkdir's own
+      # mode until the winner reaches it, and that is writable by construction
+      # rather than by luck: it is 0777 against the same umask that made the
+      # parent this mkdir has just written into, so a umask that took the
+      # owner's bits off would have stopped the build at current.new.  Measured
+      # under 'umask 0700', where it does, on this and on the version before it.
+      #
+      # Written before the recursion rather than after it, which is safe only
+      # because dir_mode forces the owner's rwx on: the entries below are
+      # composed into this directory a moment later.
+      #
+      # Recorded for apply at the same point, and this is the whole of what
+      # apply acts on in $HOME.  An ignored path is kept out of it, because no
+      # apply links anything into one: the directory is composed and stow is
+      # told to skip it, so a $HOME directory of that name is the user's,
+      # holding their files and nothing of shale's, and setting a mode on it
+      # would be shale acting on a path 'which' reports as never touched.
+      if wins_this_path "$srel"; then
+        dir_mode "$e" || die "could not read the mode of $e" \
+          'shale copies a layer directory mode onto the one it composes'
+        mode=$DIR_MODE
+        chmod "$mode" "$dpath" || die "could not set the mode $mode on $dpath"
+        if [ "$ignored" -eq 0 ]; then
+          DIR_MODE_PATHS+=("$srel")
+          DIR_MODE_BITS+=("$mode")
+        fi
+      fi
+      compose_dir "$src" "$dst" "$srel" "$ignored"
     else
       if [ -d "$dpath" ] && [ ! -L "$dpath" ]; then
         conflict "$srel" file "$e"
@@ -3037,6 +3176,125 @@ ignored_link_finding() {
   fi
 }
 
+# The directories an apply is leaving as they are, in WIDE_DIR_*, walking the
+# built tree with scan_ignored_links's carry: an ignored path is not one any
+# apply sets a mode on, so it is not one to report a mode for either.
+#
+# The test is apply's own, made from the two trees rather than from anything an
+# apply recorded, so doctor answers this without a build: a bit the built tree
+# has and the $HOME directory has not is a widening, and a widening is what an
+# apply declines.  The other direction needs no report - the next apply narrows
+# the directory and says nothing, which is what it is for.
+#
+# Two reads for each directory that is in both trees, which is what this check
+# costs and where doctor's time goes on a wide tree.  Paid here rather than in
+# apply, which is the everyday command and now prints only a count.
+#
+# Either read may fail and neither failure is doctor's to report: a directory
+# that goes while a walk is in flight is the one shape that reaches it, and this
+# check has nothing to say about a path that is no longer there.  The two other
+# walks answer the same way, by returning where they cannot read.
+scan_home_dir_modes() {
+  local rel=$1 inherited=$2 cap=$3 here e base srel ignored target want have
+  here=$CUR${rel:+/$rel}
+  { [ -r "$here" ] && [ -x "$here" ]; } || return 0
+  list_dir "$here" 1
+  for e in ${DIR_ENTRIES[@]+"${DIR_ENTRIES[@]}"}; do
+    base=${e##*/}
+    case "$base" in
+      . | ..) continue ;;
+      '*' | '.*')
+        { [ -e "$e" ] || [ -L "$e" ]; } || continue
+        ;;
+    esac
+    # Directories only: a file in $HOME is a link into this tree and has no mode
+    # of its own to compare.
+    { [ -d "$e" ] && [ ! -L "$e" ]; } || continue
+    srel=${rel:+$rel/}$base
+    ignored=$inherited
+    if [ "$ignored" -eq 0 ]; then
+      if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$srel"; then
+        ignored=1
+      elif path_is_stow_ignored "$srel"; then
+        ignored=1
+      fi
+    fi
+    if [ "$ignored" -eq 0 ]; then
+      target=$HOME_PREFIX/$srel
+      if [ -d "$target" ] && [ ! -L "$target" ] && dir_mode "$e" 2>/dev/null; then
+        want=$DIR_MODE_RAW
+        if dir_mode "$target" 2>/dev/null; then
+          have=$DIR_MODE_RAW
+          if [ "$want" != "$have" ] && [ $(((8#$want) & ~(8#$have))) -ne 0 ]; then
+            WIDE_DIR_COUNT=$((WIDE_DIR_COUNT + 1))
+            if [ "$WIDE_DIR_COUNT" -le "$cap" ]; then
+              WIDE_DIR_PATHS+=("$target")
+              WIDE_DIR_HAVE+=("$have")
+              WIDE_DIR_WANT+=("$want")
+            fi
+          fi
+        fi
+      fi
+    fi
+    scan_home_dir_modes "$srel" "$ignored" "$cap"
+  done
+}
+
+# What apply's one line points at.  Each of these is a directory whose mode the
+# built tree and $HOME disagree about in the one direction an apply will not
+# resolve, and it stays that way until somebody changes one of them - which is
+# the ordinary state after a clone rather than a rare one, git recording no mode
+# for a directory and a cloned .ssh layer therefore arriving at the umask's.
+#
+# A note, and this is the one thing about it worth arguing over.  The direction
+# decides it: where the layer is the tighter of the two, an apply narrows the
+# directory and no difference is left, so the only state that can persist is the
+# layer being looser - which is to say the directory in $HOME is safer than the
+# layer asks for, and shale declining to open it is shale working.  Nothing is
+# broken, nothing is blocked, and the apply exits 0.  A finding here would make
+# doctor red by default for everyone who has cloned a layer with a .ssh in it,
+# and #92's guarantee runs the other way: a green doctor means a green apply,
+# which spends the signal on a machine that is fine.
+#
+# One note rather than one per path, in the shape the .stowrc and built-tree
+# notes use, so the summary counts this class once however many directories are
+# in it.
+audit_home_dir_modes() {
+  local cap n i rest lines
+  [ -d "$CUR" ] || return 0
+  [ ! -L "$CUR" ] || return 0
+  [ -n "${HOME-}" ] || return 0
+
+  WIDE_DIR_COUNT=0
+  WIDE_DIR_PATHS=()
+  WIDE_DIR_HAVE=()
+  WIDE_DIR_WANT=()
+  # audit_ignored_links' cap, for its reasons.
+  cap=10
+  scan_home_dir_modes '' 0 "$cap"
+  n=$WIDE_DIR_COUNT
+  [ "$n" -gt 0 ] || return 0
+
+  if [ "$n" -eq 1 ]; then
+    lines=("an apply left 1 directory in $HOME as it is")
+  else
+    lines=("an apply left $n directories in $HOME as they are")
+  fi
+  i=0
+  while [ "$i" -lt "${#WIDE_DIR_PATHS[@]}" ]; do
+    lines+=("${WIDE_DIR_PATHS[$i]} is ${WIDE_DIR_HAVE[$i]}, and the layer that provides it gives ${WIDE_DIR_WANT[$i]}")
+    i=$((i + 1))
+  done
+  if [ "$n" -gt "$cap" ]; then
+    rest=$((n - cap))
+    lines+=("and $rest more, not named here")
+  fi
+  lines+=("shale sets the mode of a directory it creates in $HOME, and never widens one that was already there")
+  lines+=('to take the mode the layer gives, chmod that directory yourself')
+  lines+=("to keep the mode it has, set that mode on the directory in the layer: 'shale which' names the layer for a path")
+  note ${lines[@]+"${lines[@]}"}
+}
+
 # Non-zero unless the next apply removes the orphaned link $1 by itself, so that
 # the remedy printed for it is the one that works: $1 is the link's path
 # normalised, $2 is $HOME normalised, and $3 is 'relative' or 'absolute' for the
@@ -3892,6 +4150,10 @@ cmd_build() {
 
   DIVERGED_PATHS=()
   DIVERGED_LAYERS=()
+  # Blanked here rather than at the top of the file, so that the list apply
+  # replays is this build's and never a previous one's.
+  DIR_MODE_PATHS=()
+  DIR_MODE_BITS=()
   OLDER_COUNT=0
   CONFLICT_PATHS=()
   CONFLICT_MINE=()
@@ -3901,7 +4163,7 @@ cmd_build() {
     SRC_INDEX=$i
     SRC_NAME=${LAYER_NAMES[$i]}
     dir=$DOTFILES/${LAYER_PATHS[$i]}
-    compose_dir "$dir" "$NEW" ''
+    compose_dir "$dir" "$NEW" '' 0
     report "composed layer '$SRC_NAME' from $dir"
     i=$((i + 1))
   done
@@ -4113,7 +4375,7 @@ cmd_build() {
 }
 
 cmd_apply() {
-  local status err had_xtrace
+  local status err had_xtrace i n rel bits pre have target failed kept
 
   parse_config || exit 1
 
@@ -4173,6 +4435,23 @@ cmd_apply() {
   #
   # No restore is owed on the paths that do not reach it: every trap that can
   # fire in this window exits.
+  # Which of the directories the build recorded are already in $HOME, taken
+  # before stow runs because afterwards there is no telling one stow has just
+  # made from one that was there all along - and that is the whole of what
+  # decides whether the mode below may widen it.  Tests only, no fork.
+  DIR_MODE_PRE=()
+  i=0
+  n=${#DIR_MODE_PATHS[@]}
+  while [ "$i" -lt "$n" ]; do
+    target=$HOME_PREFIX/${DIR_MODE_PATHS[$i]}
+    if [ -d "$target" ] && [ ! -L "$target" ]; then
+      DIR_MODE_PRE+=(1)
+    else
+      DIR_MODE_PRE+=(0)
+    fi
+    i=$((i + 1))
+  done
+
   status=0
   had_xtrace=0
   case $- in
@@ -4212,11 +4491,111 @@ cmd_apply() {
   # tree and said so.  These lines claim only that stow wrote and what it would
   # mean *if* what follows names a path stow skipped - not everything on that
   # stream is about a path, and reading it would be shale interpreting output.
-  [ -n "$err" ] || return 0
-  warn "stow exited 0 and wrote output" \
-    'shale does not read what stow writes; its output follows unchanged' \
-    "if it names a path stow skipped, that path is not linked from $CUR into $HOME"
-  printf '%s\n' "$err" >&2
+  #
+  # Before the modes below rather than after them, and before anything below can
+  # exit: what stow said about the tree it linked is the reader's first business
+  # whatever shale then makes of the directories, and a mode shale could not set
+  # used to swallow both this warning and stow's own text with it.
+  if [ -n "$err" ]; then
+    warn "stow exited 0 and wrote output" \
+      'shale does not read what stow writes; its output follows unchanged' \
+      "if it names a path stow skipped, that path is not linked from $CUR into $HOME"
+    printf '%s\n' "$err" >&2
+  fi
+
+  # The directory modes the build composed, put onto the directories in $HOME.
+  # Stow does not carry them: it creates each directory with mkdir and no mode,
+  # so what lands is 0777 against the caller's umask whatever $CUR holds -
+  # measured on 2.3.1 and on 2.4.1, which agree.  So without this the mode a
+  # layer puts on .ssh reaches the built tree and stops there, and $HOME gets
+  # 0755 on a machine at the common umask and 0775 - group writable, which
+  # OpenSSH's StrictModes refuses - on a Debian or Ubuntu one.
+  #
+  # In the order the build recorded them, which is the order the layers were
+  # composed in.  Parents come before their children, and every mode has the
+  # owner's rwx in it, so nothing here can shut the walk out of a directory
+  # below it.
+  #
+  # A directory that was already in $HOME before this apply is only ever
+  # narrowed, never widened, and that asymmetry is the point of the whole pass.
+  # Git records no mode for a directory, so a freshly cloned layer has whatever
+  # the clone's umask gave it - 0755, or 0775 on Debian and Ubuntu - and a
+  # ~/.ssh the user keeps at 0700 with a private key in it would be opened up by
+  # an apply, silently, on the ordinary clone-and-apply path.  A mode fix that
+  # exposes ~/.ssh is worse than the bug it fixes.  A directory stow made in
+  # this apply has no such history and gets the layer's mode exactly, which is
+  # what keeps the built tree and $HOME agreeing on every path shale created.
+  #
+  # Two shapes are passed over, and neither is silence about a mode that was
+  # meant to land: a path that is not a directory now was never linked into -
+  # stow skipped it, or nothing of the tree reached it - and a symlink at the
+  # path is not shale's directory, chmod would follow it and change the mode of
+  # whatever it points at, somewhere else entirely.
+  failed=0
+  kept=0
+  i=0
+  n=${#DIR_MODE_PATHS[@]}
+  while [ "$i" -lt "$n" ]; do
+    rel=${DIR_MODE_PATHS[$i]}
+    bits=${DIR_MODE_BITS[$i]}
+    pre=${DIR_MODE_PRE[$i]}
+    target=$HOME_PREFIX/$rel
+    i=$((i + 1))
+    { [ -d "$target" ] && [ ! -L "$target" ]; } || continue
+    if [ "$pre" -eq 1 ]; then
+      if ! dir_mode "$target"; then
+        emit "could not read the mode of $target"
+        failed=$((failed + 1))
+        continue
+      fi
+      have=$DIR_MODE_RAW
+      # Nothing to do, and the commonest case by far: every directory of the
+      # last apply arrives here already holding the mode this one would set.
+      [ "$have" != "$bits" ] || continue
+      # A bit the layer has and the directory has not is a widening, and every
+      # one of them is refused together: a mode is one answer rather than nine,
+      # and half of one is a directory neither side asked for.  8# because a
+      # leading 1 through 7 in the set-id digit is not a leading zero, and bash
+      # would read the whole thing as decimal.
+      if [ $(((8#$bits) & ~(8#$have))) -ne 0 ]; then
+        kept=$((kept + 1))
+        continue
+      fi
+    fi
+    # chmod's own line is let through rather than suppressed, for dir_mode's
+    # reason: which errno it is is what tells the reader what to do.
+    chmod "$bits" "$target" && continue
+    emit "could not set the mode $bits on $target"
+    failed=$((failed + 1))
+  done
+
+  # One line, whatever the count, and the detail is doctor's.  This is a
+  # standing condition rather than an event: after a clone the layer's .ssh is
+  # 0755 - git having recorded no mode for it - and a ~/.ssh the user keeps at
+  # 0700 diverges from it on every apply until one side is changed, which is the
+  # default state for anyone with a .ssh layer rather than a rare one.  A block
+  # of lines there would be a block on every apply, which is #75's rule; saying
+  # nothing at all would be an apply quietly declining what a layer asked for,
+  # which is #92's.  So: the count here, the paths and the modes in doctor.
+  #
+  # A warning rather than a failure, and the status stays 0: what shale declined
+  # to do leaves the safer of the two modes in place and nothing about the apply
+  # undone.
+  if [ "$kept" -eq 1 ]; then
+    warn "1 directory in $HOME was left as it is: shale never widens one that was already there; 'shale doctor' names it"
+  elif [ "$kept" -gt 0 ]; then
+    warn "$kept directories in $HOME were left as they are: shale never widens one that was already there; 'shale doctor' names them"
+  fi
+
+  if [ "$failed" -eq 1 ]; then
+    die "could not set the mode on 1 directory; $HOME is linked" \
+      'the links are in place and correct; the permissions on the directory holding them are not' \
+      "a directory under $HOME that shale did not create and does not own is the usual cause"
+  elif [ "$failed" -gt 0 ]; then
+    die "could not set the mode on $failed directories; $HOME is linked" \
+      'the links are in place and correct; the permissions on the directories holding them are not' \
+      "a directory under $HOME that shale did not create and does not own is the usual cause"
+  fi
   return 0
 }
 
@@ -4239,10 +4618,10 @@ cmd_doctor() {
   # git is not here: it is wanted for one thing only, and whether that thing is
   # wanted is not known until the layers have been looked at.  Its check is below
   # them.
-  for tool in cp mkdir mv rm rmdir stow; do
+  for tool in chmod cp ls mkdir mv rm rmdir stow; do
     command -v "$tool" >/dev/null 2>&1 && continue
-    # stow is wanted only by apply, so it stops no build on its own; the other
-    # five do, and no line below may then offer one.
+    # stow is wanted only by apply, so it stops no build on its own; every other
+    # name here does, and no line below may then offer one.
     [ "$tool" = stow ] || BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
     finding "$tool is not installed" \
       "install it with your system package manager: shale installs nothing"
@@ -4595,6 +4974,11 @@ cmd_doctor() {
   # The built tree again, and only where there are patterns: what the ignore
   # list covers, against what $HOME still links.
   audit_ignored_links
+
+  # The built tree once more, against the modes of the same directories in
+  # $HOME: the detail behind the one line an apply prints when it leaves one as
+  # it is.
+  audit_home_dir_modes
 
   # Last, because it is the only check that walks the whole of $HOME and the only
   # one that means anything only once everything above it is sound.

--- a/tests/run
+++ b/tests/run
@@ -968,7 +968,7 @@ inherit_shell_option() {
 # redirects to a file, and reads that file with PATH restored.
 stub_path_without() {
   local all omit tool found
-  all=' env bash cat sed chkstow cp git mkdir mv readlink rm rmdir stow '
+  all=' env bash cat sed chkstow chmod cp git ls mkdir mv readlink rm rmdir stow '
   omit=" ${*-} "
   # First, and fatal: a name that is in no list matches nothing, leaves a
   # complete PATH, and passes the case having removed nothing at all - the one
@@ -1112,6 +1112,23 @@ assert_real_dir() {
   fi
   if [ ! -d "$path" ]; then
     fail "$label: not a directory: $path"
+  fi
+  return 0
+}
+
+# assert_mode PATH EXPECTED [LABEL] - the mode of PATH as the ten characters ls
+# writes at the head of a long listing, 'drwx------' and the like.
+#
+# ls rather than stat, whose format strings are not the same on the two
+# userlands this suite has to run on; the ten characters are, and an eleventh
+# column for an ACL or an extended attribute lands after them rather than in
+# them.  Nothing here follows a symlink: -d is what makes ls answer for the link
+# itself, and a mode assertion on the wrong file would otherwise pass.
+assert_mode() {
+  local path=$1 expected=$2 label=${3-mode} out
+  out=$(ls -ld "$path") || fail "$label: could not read the mode of $path"
+  if [ "${out:0:10}" != "$expected" ]; then
+    fail "$label: expected mode $expected, got ${out:0:10}: $path"
   fi
   return 0
 }
@@ -2255,6 +2272,191 @@ test_build_the_exec_bit_follows_the_winning_layer() {
   [ ! -x "$HOME/.dotfiles/current/.local/bin/down" ] ||
     fail 'down is executable: the winning layer did not have the exec bit'
   [ ! -x "$HOME/.dotfiles/current/.zshrc" ] || fail '.zshrc is executable'
+}
+
+# A layer's file modes are cp -RPp's to carry; its directory modes are shale's,
+# and before this they were nobody's - a directory was created by mkdir and took
+# whatever the caller's umask left, so the same layer produced a different tree
+# on every machine.  The four umasks are the ones people actually have: 0022 is
+# the common default and 0002 ships on Debian and Ubuntu with user-private
+# groups, which is the one that turns a 0700 .ssh into a group-writable
+# directory that OpenSSH's StrictModes then refuses.
+#
+# The file beside it is asserted in the same loop: cp -RPp already carried its
+# mode, and a directory pass that reached a file would be a regression nothing
+# else here would see.
+test_build_a_directory_mode_comes_from_the_layer_and_not_the_umask() {
+  local um saved
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  chmod 0600 "$sandbox_dir/config" || fail 'could not set the layer file mode'
+  saved=$(umask)
+  for um in 0022 0002 0077 0000; do
+    umask "$um"
+    run_shale build
+    umask "$saved"
+    assert_status 0 "$shale_status" "umask $um exit status"
+    assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' "umask $um"
+    assert_mode "$HOME/.dotfiles/current/.ssh/config" '-rw-------' "umask $um"
+  done
+}
+
+# The file modes inside the directory whose mode is being set, pinned whole
+# rather than by the exec bit alone: the directory pass runs a chmod for every
+# directory it composes, and one written a level out - or a chmod -R - would
+# leave every file in the tree executable, or every private one readable, with
+# the build still exiting 0.  cp -RPp is what carries these, and nothing in the
+# directory pass may touch them.
+test_build_a_file_mode_is_untouched_by_the_directory_pass() {
+  local um saved
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mklayer personal/base .local/bin/up
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  chmod 0600 "$sandbox_dir/config" || fail 'could not set the layer file mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.local/bin"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  chmod 0755 "$sandbox_dir/up" || fail 'could not set the layer file mode'
+  saved=$(umask)
+  for um in 0000 0077; do
+    umask "$um"
+    run_shale build
+    umask "$saved"
+    assert_status 0 "$shale_status" "umask $um exit status"
+    assert_mode "$HOME/.dotfiles/current/.ssh/config" '-rw-------' "umask $um"
+    assert_mode "$HOME/.dotfiles/current/.local/bin/up" '-rwxr-xr-x' "umask $um"
+  done
+}
+
+# The rule where two layers provide one directory, which is the rule their files
+# already have: the layer that wins is the last one listed that provides it.
+# Both directions, because a rule that only ever tightens and a rule that only
+# ever loosens would each pass half of this.
+#
+# The trap it pins is the one worth having a case for: a base layer with .ssh at
+# 0700 and a local layer that adds one file to the same directory hands the mode
+# to the local layer, whatever the base layer says.
+test_build_a_directory_mode_follows_the_winning_layer() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .config/git/config
+  mklayer local .config/nvim/init.lua
+  mklayer personal/base .ssh/config
+  mklayer local .ssh/known_hosts
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/local/.config"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/local/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_mode "$HOME/.dotfiles/current/.config" 'drwxr-xr-x' 'loosened by local'
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'tightened by local'
+}
+
+# The owner's rwx is the one part of a directory mode shale does not copy, and
+# this is what it buys: a layer directory shale cannot write into cannot be
+# composed into either, and the next layer, the next build and cleanup's rm -rf
+# all have to get inside the one this build made.  The group and world bits are
+# copied whole, which is the half that decides whether a directory is safe.
+test_build_a_layer_directory_the_owner_cannot_write_gets_the_write_bit() {
+  conf 'base personal/base'
+  mklayer personal/base .private/inner/f
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.private"
+  chmod 0550 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.dotfiles/current/.private" 'drwxr-x---' 'the composed directory'
+  # The second build is the assertion that matters: it composes into the
+  # directory the first one made, and reaps that tree afterwards.
+  run_shale build
+  assert_status 0 "$shale_status" 'the second build'
+  assert_empty "$shale_err" 'the second build stderr'
+  assert_eq 'personal/base/.private/inner/f' \
+    "$(cat "$HOME/.dotfiles/current/.private/inner/f")" 'the composed file'
+  assert_missing "$HOME/.dotfiles/current.old"
+  # The layer's own directory, put back: the runner's own rm -rf cannot descend
+  # one the owner may not write, and says so on an otherwise green run.
+  chmod 0755 "$HOME/.dotfiles/personal/base/.private" ||
+    fail 'could not restore the layer directory mode'
+}
+
+# The same clamp from the other side, and the reason it is not a preference: a
+# scratch tree holding a directory its owner cannot write is a tree rm -rf
+# cannot remove, so a build interrupted after one had been composed would leave
+# current.new behind and every later build would die trying to reap it.
+test_build_an_interrupt_leaves_no_scratch_tree_it_cannot_remove() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .private/inner/f
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.private"
+  chmod 0500 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  # The copy of the file inside it: by then the directory above has been created
+  # and given its mode, which is the state this is about.
+  # shellcheck disable=SC2016  # the body runs in the stub, not here
+  stub_interrupt cp '*.private/inner/f' '"$real" "$@" || exit $?'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  # 128 + SIGINT: shale re-raises the signal rather than inventing a status.
+  assert_status 130 "$shale_status"
+  assert_missing "$HOME/.dotfiles/current.new"
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the interrupt'
+  assert_empty "$shale_err" 'the build after the interrupt stderr'
+  chmod 0755 "$HOME/.dotfiles/personal/base/.private" ||
+    fail 'could not restore the layer directory mode'
+}
+
+# The two ways the mode of a composed directory can fail to be what the layer
+# says, both of which stop the build rather than leaving a tree whose modes
+# nobody can account for.  Neither tool is stubbed for the whole run: it is the
+# first call matching the built tree that fails, so the failure lands where the
+# message says it does.
+test_build_a_directory_mode_it_cannot_set_stops_the_build() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  # Set rather than inherited: the mode is in the message this asserts on, and
+  # the umask of whoever runs the suite must not decide what it says.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  stub_fail_once chmod '*current.new/.ssh'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: could not set the mode 0755 on $HOME/.dotfiles/current.new/.ssh" 'stderr'
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+test_build_a_directory_mode_it_cannot_read_stops_the_build() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  stub_fail_once ls '*'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: could not read the mode of $HOME/.dotfiles/personal/base/.ssh" 'stderr'
+  assert_contains "$shale_err" \
+    'shale:   shale copies a layer directory mode onto the one it composes' 'stderr'
+  assert_missing "$HOME/.dotfiles/current"
 }
 
 test_build_is_idempotent_and_drops_a_file_deleted_from_a_layer() {
@@ -5088,6 +5290,230 @@ test_apply_makes_real_directories_with_per_file_links() {
   assert_missing "$HOME/.dotfiles/current/.config/nvim/shada" 'the built tree'
 }
 
+# The other half of --no-folding: stow makes a real directory at every level,
+# and it makes it with mkdir and no mode, so what lands is 0777 against the
+# caller's umask and never the mode of the directory in the built tree.  That
+# was measured against GNU Stow 2.3.1 and 2.4.1, which agree on it, so the mode
+# in $HOME is shale's to set after stow has run and nobody else's.
+#
+# .ssh and .gnupg because they are where a reader meets this: 0700 in the layer
+# and 0775 in $HOME on an ordinary Ubuntu machine is a directory OpenSSH refuses
+# to use.  .config beside them at 0755 under a 0077 umask is the same claim
+# pointed the other way - the mode is the layer's, not the tightest thing going.
+test_apply_a_directory_mode_reaches_home_whatever_the_umask() {
+  local um saved
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mklayer personal/base .gnupg/gpg.conf
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.gnupg"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  saved=$(umask)
+  for um in 0022 0002 0077 0000; do
+    umask "$um"
+    run_shale apply
+    umask "$saved"
+    assert_status 0 "$shale_status" "umask $um exit status"
+    assert_empty "$shale_err" "umask $um stderr"
+    assert_mode "$HOME/.ssh" 'drwx------' "umask $um"
+    assert_mode "$HOME/.gnupg" 'drwx------' "umask $um"
+    assert_mode "$HOME/.config" 'drwxr-xr-x' "umask $um"
+    assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' "umask $um built tree"
+    assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
+  done
+}
+
+# The two-layer rule as it lands in $HOME, which is the tree the rule is about.
+test_apply_a_directory_mode_follows_the_winning_layer() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .ssh/config
+  mklayer local .ssh/known_hosts
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/local/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_mode "$HOME/.ssh" 'drwx------' 'the last layer that provides it'
+  assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
+  assert_symlink_to "$HOME/.ssh/known_hosts" \
+    "$HOME/.dotfiles/current/.ssh/known_hosts"
+}
+
+# A mode that could not be set is the failure this whole change exists to stop
+# being silent, so it is named and it costs the exit status - after every other
+# one has been attempted, so one directory shale does not own cannot hide the
+# rest.  The links are already in place at that point, and the message says so
+# rather than sending the reader to apply again.
+test_apply_a_mode_it_cannot_set_is_named_and_the_links_are_still_made() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  # The apply's chmod and not the build's: the sandbox home is the one path
+  # ending in '/home/.ssh', and the built tree's ends in 'current.new/.ssh'.
+  # One word, because the stub writes the pattern into a case arm.
+  stub_fail_once chmod '*/home/.ssh'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale apply
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" "shale: could not set the mode 0700 on $HOME/.ssh" 'stderr'
+  assert_contains "$shale_err" \
+    "shale: could not set the mode on 1 directory; $HOME is linked" 'stderr'
+  assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
+}
+
+# The clone case, which is the ordinary one rather than a corner: git records no
+# mode for a directory, so a freshly cloned .ssh layer is whatever the clone's
+# umask gave it - 0755 on most machines - while the ~/.ssh the user already has,
+# holding a private key, is 0700.  Copying the layer's mode there would open it
+# up, silently, on the path everybody takes.  So a directory that was in $HOME
+# before the apply is only ever narrowed, and shale says which ones it left.
+#
+# The status stays 0: nothing the apply was asked to do was left undone, and the
+# mode that survives is the safer of the two.
+test_apply_never_widens_a_directory_that_was_already_there() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_mode "$HOME/.ssh" 'drwx------' 'the directory that was already there'
+  # The links are made all the same: this is about the directory's mode and
+  # nothing else.
+  assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
+  # The built tree keeps the layer's mode, because it is shale's own tree.
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwxr-xr-x' 'the built tree'
+  # One line and no more.  What is left is the ordinary state of anyone who has
+  # cloned a layer with a .ssh in it, so it is printed on every apply for as
+  # long as it lasts, and a block of lines there would be a block on every
+  # apply.  The paths and the modes are doctor's, which is where a standing
+  # condition goes; this line is the pointer to it.
+  assert_contains "$shale_err" \
+    "shale: 1 directory in $HOME was left as it is: shale never widens one that was already there; 'shale doctor' names it" \
+    'stderr'
+  assert_not_contains "$shale_err" '0755' 'the mode detail belongs to doctor'
+  assert_eq 1 "$(printf '%s\n' "$shale_err" | grep -c '^shale: ')" 'lines shale printed'
+  # Twice, because a mode shale is deliberately not setting is a standing
+  # difference between the layer and $HOME rather than a one-run event, and the
+  # second apply is the one people run.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the second apply'
+  assert_mode "$HOME/.ssh" 'drwx------' 'the second apply'
+  assert_contains "$shale_err" \
+    "shale: 1 directory in $HOME was left as it is: shale never widens one that was already there; 'shale doctor' names it" \
+    'the second apply stderr'
+}
+
+# The other direction, which is #119's own case and is not a widening: a ~/.ssh
+# that is already there at 0755 and a layer that says 0700 is narrowed, without
+# a word, because that is the mode the layer asked for and nothing is lost by
+# it.
+test_apply_narrows_a_directory_that_was_already_there() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.ssh" 'drwx------' 'the directory that was already there'
+}
+
+# A path an ignore file blocks is composed into the built tree and skipped by
+# stow, so nothing of shale's is ever linked into the $HOME directory of that
+# name: it is the user's, holding the user's files, and 'shale which' says so in
+# as many words.  Setting a mode on it would be shale acting on the one class of
+# path it promises not to touch.
+#
+# The pattern is anchored, so it matches '.cache' and not the 'inner' below it -
+# which is what makes this a case about the carry rather than about the matcher.
+# Without it, a descendant of a matched directory reads as unignored, and the
+# apply chmods a directory two levels inside one it was told to skip.
+test_apply_says_nothing_at_a_path_an_ignore_file_blocks() {
+  conf 'base personal/base'
+  mklayer personal/base .cache/inner/junk
+  mklayer personal/base .zshrc
+  mkignore personal /.cache
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache/inner"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.cache/inner"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  sandbox_mkdir "$HOME/.cache"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.cache" 'drwx------' 'the ignored directory'
+  assert_mode "$HOME/.cache/inner" 'drwx------' 'below the ignored directory'
+  assert_missing "$HOME/.cache/inner/junk" 'the file no apply links'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+}
+
+# The same claim for the list stow ships, which no ignore file has to mention
+# and which every apply uses: .hg is on it, so nothing is linked into ~/.hg and
+# its mode is not shale's to set.
+test_apply_says_nothing_at_a_path_stows_own_list_blocks() {
+  conf 'base personal/base'
+  mklayer personal/base .hg/store/f
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.hg"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.hg/store"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.hg/store"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  sandbox_mkdir "$HOME/.hg"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.hg" 'drwx------' 'the ignored directory'
+  assert_mode "$HOME/.hg/store" 'drwx------' 'below the ignored directory'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+}
+
+# Everything stow wrote survives a mode shale could not set.  The two are
+# unrelated failures of one apply and the reader needs both: what stow says is
+# about which paths were linked, and it used to be swallowed whole - warning and
+# replayed text alike - by the exit that a failed chmod takes.
+#
+# The rig for stow's half is the .dotfiles path of
+# test_apply_a_layer_shipping_a_dotfiles_path_is_reported; the assertion here is
+# only that the lines are all present together.
+test_apply_a_mode_it_cannot_set_keeps_what_stow_wrote() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .dotfiles/notes
+  mklayer personal/base .config/nvim/init.lua
+  stub_fail_once chmod '*/home/.config'
+  saved=$PATH
+  PATH=$stub_path:$PATH
+  run_shale apply
+  PATH=$saved
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" 'shale: stow exited 0 and wrote output' 'stderr'
+  assert_contains "$shale_err" 'WARNING: skipping target' 'the replayed stow output'
+  assert_contains "$shale_err" \
+    "shale: could not set the mode on 1 directory; $HOME is linked" 'stderr'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+}
+
 # The generated list is stow's own built-in one, so an apply leaves out exactly
 # what plain stow leaves out.  Each name below is a different entry of that
 # list, and the two carrying an inline comment upstream - '.+~' and '\#.*\#' -
@@ -7670,7 +8096,7 @@ test_doctor_names_every_tool_shale_runs() {
   local tool saved
   conf 'base personal/base'
   mklayer personal/base .zshrc
-  for tool in cp mkdir mv rm rmdir stow; do
+  for tool in chmod cp ls mkdir mv rm rmdir stow; do
     stub_path_without "$tool"
     saved=$PATH
     PATH=$stub_path
@@ -7689,23 +8115,23 @@ test_doctor_names_every_tool_shale_runs() {
 
 # The whole list at once, which is the state the issue this came from described:
 # a machine with a shell and nothing else.  The second layer has a url and no
-# directory, which is what puts git among the seven: on a machine with nothing
+# directory, which is what puts git among the nine: on a machine with nothing
 # there is a clone to do.
 # shellcheck disable=SC2123
 test_doctor_names_all_the_missing_tools_in_one_run() {
   local tool saved
   conf 'base personal/base' "vim vim $CASE_DIR/repos/absent"
   mklayer personal/base .zshrc
-  stub_path_without cp git mkdir mv rm rmdir stow
+  stub_path_without chmod cp git ls mkdir mv rm rmdir stow
   saved=$PATH
   PATH=$stub_path
   run_shale doctor
   PATH=$saved
   assert_status 1 "$shale_status"
-  for tool in cp git mkdir mv rm rmdir stow; do
+  for tool in chmod cp git ls mkdir mv rm rmdir stow; do
     assert_contains "$shale_out" "shale: $tool is not installed" "$tool"
   done
-  assert_contains "$shale_out" 'shale: 7 problems found' 'stdout'
+  assert_contains "$shale_out" 'shale: 9 problems found' 'stdout'
 }
 
 # chkstow degrades the report rather than being a defect in the setup, so it
@@ -7723,6 +8149,148 @@ test_doctor_a_missing_chkstow_warns_without_failing() {
   assert_status 0 "$shale_status"
   assert_contains "$shale_out" 'shale: chkstow is not installed' 'stdout'
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# ------------------------------------------ doctor's directory-mode cases
+#
+# The other half of the one line an apply prints when it leaves a directory as
+# it is.  doctor makes the same judgement from the two trees rather than from
+# anything the apply recorded, so these cases are what say the two agree.
+
+# The detail, and the standing condition it describes: a cloned .ssh layer is
+# 0755 because git records no mode for a directory, the ~/.ssh holding the key
+# is 0700, and no apply resolves that on its own.
+#
+# A note, and the exit status is the claim: the only difference that can persist
+# is the layer being looser than $HOME - the other direction is narrowed by the
+# next apply and gone - so what is left is a directory safer than the layer asks
+# for, which is shale working rather than a problem.  A finding would make
+# doctor red by default for everyone who has cloned a layer with a .ssh in it,
+# and a red doctor on a machine that is fine is a signal nobody reads twice.
+test_doctor_names_a_directory_an_apply_left_as_it_is() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: an apply left 1 directory in $HOME as it is" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.ssh is 0700, and the layer that provides it gives 0755" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   shale sets the mode of a directory it creates in $HOME, and never widens one that was already there" \
+    'stdout'
+  assert_contains "$shale_out" \
+    'shale:   to take the mode the layer gives, chmod that directory yourself' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   to keep the mode it has, set that mode on the directory in the layer: 'shale which' names the layer for a path" \
+    'stdout'
+  # One note for the class however many directories are in it, so the summary
+  # counts it once.
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  # Standing rather than one-run: another apply changes nothing about it, and
+  # doctor says the same thing afterwards.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the second apply'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the second apply'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.ssh is 0700, and the layer that provides it gives 0755" 'the second report'
+  # And it ends when either side is changed, which is what makes it worth
+  # printing rather than nagging.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the layer was fixed'
+  assert_empty "$shale_err" 'the apply after the layer was fixed'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the layer was fixed'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  assert_not_contains "$shale_out" 'left 1 directory' 'stdout'
+}
+
+# The note may not swallow a real problem, and a real problem may not swallow
+# the note: one run holding both has to exit 1 for the finding, print the
+# finding's own count, and still carry every line of the note.
+#
+# The finding is a directory that left every layer, whose links an apply cannot
+# prune - the same rig test_doctor_the_built_tree_note_is_not_counted_as_a_problem
+# builds - because it is a finding that needs no missing tool and no lock.
+test_doctor_a_left_directory_note_sits_beside_a_real_finding() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that orphans the link'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor exit status'
+  # The finding decides the status and the count, and says so on its own terms.
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # The note is still whole beside it.
+  assert_contains "$shale_out" \
+    "shale: an apply left 1 directory in $HOME as it is" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.ssh is 0700, and the layer that provides it gives 0755" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   to take the mode the layer gives, chmod that directory yourself' 'stdout'
+}
+
+# The other direction is not a finding: the built tree is tighter than $HOME, so
+# the next apply narrows the directory and says nothing.  Reporting it would be
+# doctor naming a difference that fixes itself.
+test_doctor_says_nothing_where_the_next_apply_narrows_the_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.ssh"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_not_contains "$shale_out" 'left as it is' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# doctor's walk has its own copy of the ignore carry, so it gets its own case: a
+# mode difference at a path no apply touches is not a difference doctor may
+# report, or the report sends a reader to fix something shale would never act
+# on.
+test_doctor_says_nothing_about_the_mode_of_an_ignored_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .cache/inner/junk
+  mklayer personal/base .zshrc
+  mkignore personal /.cache
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache/inner"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.cache/inner"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  sandbox_mkdir "$HOME/.cache"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_not_contains "$shale_out" 'left as it is' 'stdout'
+  assert_not_contains "$shale_out" "$HOME/.cache is" 'stdout'
 }
 
 # ------------------------------------------ doctor's apply-conflict cases


### PR DESCRIPTION
Closes #119.

A layer's directory modes came from the caller's umask, so a committed `.ssh` at `700` arrived group-writable on Debian and Ubuntu, where OpenSSH's StrictModes then refuses it. File modes were already preserved.

Stow carries no mode at all — under `--no-folding` it mkdirs with none — so `current/` and `$HOME` were both umask-derived and agreed by coincidence. #119's account of the mechanism is wrong on that point, and a fix confined to `build` would have changed nothing a user sees; `apply` sets the modes itself after stow returns.

`current/` takes the layer's mode exactly, with the owner's rwx clamped on so an interrupted build cannot leave a tree its owner cannot remove. In `$HOME` shale sets the mode of a directory it creates, and **never widens one that was already there** — git stores no directory modes, so a cloned `.ssh` layer is `755`, and widening a `~/.ssh` the user keeps at `700` would have reintroduced this issue's own harm on the default path. `apply` says in one line that it left such a directory alone; `doctor` names each one with both remedies and stays green, because the directory shale kept is the safer of the two.

A path an ignore rule covers is no longer recorded, so `apply` cannot chmod a `$HOME` directory it links nothing into.

Recorded rather than fixed: #123, #124, #125.