### PR TITLE
Build shale's own directories at one mode, whatever the umask

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,13 @@ overwrites, and how to carry on from a block that stopped.
   on Debian and Ubuntu, and `644` for a file you committed at `600`. Shale copies the working tree
   faithfully, and the working tree after a clone is not what was committed. Where a mode matters,
   `chmod` it in the layer: every build and apply reproduces it from there.
+- The built tree is `700`, so nothing but you can walk it. Nothing shale runs needs to — stow reads
+  it as you — but if your `$HOME` is group-readable by design and something else reads a file shale
+  linked, it resolves the link into `~/.dotfiles/current` and stops there. There is no option to
+  relax it, and a `chmod` does not hold: a build renames a fresh tree over the old one rather than
+  chmodding it. `shale doctor` notes a `current` whose permission bits are not `700`. Only those
+  bits are shale's — a setgid bit inherited from `~/.dotfiles` gives you `2700` on every build, and
+  `doctor` says nothing about that.
 - Shale sets the mode of a directory it creates in `$HOME`, and never widens one that was already
   there. So a `~/.ssh` you keep at `700` survives a layer that a clone left at `755`. `apply` says
   in one line that it left such a directory alone, `doctor` names each one and both ways to settle

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -410,6 +410,41 @@ chmod 700 ~/.dotfiles/personal/base/.ssh ~/.dotfiles/personal/base/.gnupg
 chmod 600 ~/.dotfiles/personal/base/.ssh/config
 ```
 
+## Permissions on the built tree itself
+
+`~/.dotfiles/current` is `700`, and so are `current.new`, any `current.old` and the lock at
+`~/.dotfiles/.lock`. No layer provides those, so there is no mode to copy: shale picks one, and picks
+the narrowest, on every machine at every umask.
+
+It matters more than it looks. Every symlink shale makes in `$HOME` resolves *through* that
+directory, so its mode is what decides who may read the file at the end of the link and who may
+replace it — and what is inside it is a copy of every file of every layer, at whatever mode the layer
+has. Read the paragraph above again: a clone gives you `644` on a `config` you committed at `600`.
+`700` on the tree is what contains that mistake.
+
+The cost is that nothing but you can walk the built tree. Nothing shale runs needs to — stow reads it
+as you, and so does every other command here — but if your `$HOME` is group-readable by design and
+something else reads a file shale linked, it resolves the link into this directory and stops. There
+is no option to relax it, and a `chmod` will not hold: a build does not chmod `current`, it renames a
+fresh `700` tree over the old one. `shale doctor` says so where it finds one that is not `700`, as a
+note:
+
+```
+shale: /home/you/.dotfiles/current is mode 0755, and shale builds its permission bits at 0700
+shale:   every symlink shale makes in /home/you resolves through that directory, so its mode decides who can read what they point at and who can replace it
+shale:   the next build renames a fresh tree over it, made with 0700 and with whatever set-id or sticky bit /home/you/.dotfiles gives a new directory, so a chmod here does not hold
+```
+
+Only the permission bits are shale's. A `setgid`, `setuid` or sticky bit on the built tree came from
+`~/.dotfiles` and shale neither sets nor clears it: no umask masks one, a new directory takes the
+set-group-ID bit from the directory it is made in, and the rename that installs a build carries it
+across. So a `~/.dotfiles` on a shared volume gives you `2700` here rather than `0700`, on every
+build, and `doctor` says nothing about it — that bit is yours. It is the mode of a genuinely wide
+tree, `2755` say, that `doctor` reports, and it reports the whole of it so you can see both halves.
+
+The modes *inside* the tree are the layers' and are untouched by this: `current/.ssh` is whatever the
+section above says it is.
+
 ## What a layer must not ship
 
 Never a `.stow-local-ignore` at the top of a layer. Shale writes the one in `current/` itself — it is

--- a/shale
+++ b/shale
@@ -181,6 +181,49 @@ OLD=$DOTFILES/current.old
 # every configured path component start with a letter, digit or '_'.
 LOCK=$DOTFILES/.lock
 
+# The mode of every directory shale makes for itself: the lock, the tree a build
+# composes into, and - by the two renames that install it - $CUR and the $OLD it
+# replaced.  Every one of them was 0777 against the caller's umask, so on the
+# Debian and Ubuntu default the directory every symlink in $HOME resolves
+# through was group-writable, and anyone sharing the group could replace what
+# those links point at.
+#
+# Fixed rather than taken from the umask because shale creates these: unlike a
+# layer's directory there is no intent to honour, and the only question is what
+# shale should pick.  0700 rather than any other fixed mode because it is the
+# only one no umask can narrow - 0755 would open the tree on a machine at
+# 'umask 077', which is the direction #119's rule in $HOME exists to refuse.
+#
+# What it buys is not only the write bit.  The built tree holds a copy of every
+# file of every layer at whatever mode the layer has, and git records no mode
+# but the executable bit, so a .ssh/config committed at 0600 arrives from a
+# clone at 0644 - measured, under 'umask 002', with the directory above it at
+# 0775.  This mode is the whole of what keeps that off the rest of the machine.
+#
+# What it costs is a built tree no other user can walk.  Nothing shale runs
+# needs to - stow, chkstow and every command here run as the owner - but a
+# $HOME that is group-readable by design, with something else reading a file
+# shale linked, resolves that link through this directory and stops here.  There
+# is no flag to relax it and a chmod does not hold, the next build renaming a
+# fresh tree into place; doctor says so where it finds one.
+#
+# The permission bits are the whole of what this decides.  A set-id or sticky bit
+# is the parent's: no umask masks one, mkdir(2) takes the set-group-ID bit from
+# the directory it is created in, and a rename carries it across - so under a
+# setgid ~/.dotfiles every tree here is 2700, and shale neither chose that bit
+# nor can clear it.  GNU chmod will not either, given a four-digit octal: 'chmod
+# 0700' on a setgid directory leaves 2700 and only 'chmod 00700' clears it,
+# measured on coreutils 9.4.  Nothing here tries to, and doctor compares the
+# permission bits alone for the same reason.
+OWN_DIR_MODE=0700
+# The same permission bits as a umask, which is how make_own_dir applies them.
+# Derived rather than written, so those bits cannot drift apart in a later edit -
+# and only those: the mask discards anything above them, which is right because a
+# umask cannot carry a set-id or sticky bit anyway.
+printf -v OWN_DIR_UMASK '%04o' "$((0777 & ~8#$OWN_DIR_MODE))"
+# make_own_dir's cache of the umask it has to put back.  Empty until one is read.
+UMASK_SAVED=
+
 # First line prefixed 'shale: ', continuation lines 'shale:   ', on stdout.
 report() {
   local line prefix
@@ -1553,6 +1596,34 @@ defer_signals() {
 DEFERRED=
 arm_traps
 
+# ----------------------------------------------------- shale's own directories
+
+# mkdir at $OWN_DIR_MODE.  Every directory shale creates goes through this, and
+# the mode is not negotiable at any of them: see OWN_DIR_MODE.  Non-zero exactly
+# as mkdir's own status, and mkdir's own stderr, so each caller keeps the arms it
+# had.
+#
+# The umask rather than a chmod after the mkdir, because the kernel applies the
+# umask inside mkdir(2): there is no instant at which the directory exists at a
+# wider mode.  A chmod one command later would leave one, and $NEW is what a
+# build composes into - a file planted in that window is a file the build renames
+# into $CUR.
+#
+# Put back immediately, because the umask is also what decides the mode of the
+# .stow-local-ignore this build writes, of the tree git clone lands, and of every
+# directory stow creates in $HOME.  Read back once and cached rather than read at
+# each call: this runs once per directory of the composed tree per layer, and
+# '$(umask)' is a fork where the two builtins around it are not.
+make_own_dir() {
+  local path=$1 status
+  [ -n "$UMASK_SAVED" ] || UMASK_SAVED=$(umask)
+  umask "$OWN_DIR_UMASK"
+  mkdir "$path"
+  status=$?
+  umask "$UMASK_SAVED"
+  return "$status"
+}
+
 # -------------------------------------------------------------------- the lock
 
 # mkdir is the atomic primitive - it fails when the directory exists, on every
@@ -1580,7 +1651,7 @@ acquire_lock() {
       'install it with your system package manager: shale installs nothing'
   # mkdir's own diagnostic is suppressed because each arm below says more about
   # this particular directory, and its remedy, than 'File exists' does.
-  if mkdir "$LOCK" 2>/dev/null; then
+  if make_own_dir "$LOCK" 2>/dev/null; then
     LOCKED=$LOCK
     return 0
   fi
@@ -1614,7 +1685,7 @@ acquire_lock() {
   # Nothing is there, so the holder released between the mkdir above and these
   # tests.  One more attempt, so that only a mkdir that fails against an empty
   # path reaches the message below, which is about permissions.
-  if mkdir "$LOCK" 2>/dev/null; then
+  if make_own_dir "$LOCK" 2>/dev/null; then
     LOCKED=$LOCK
     return 0
   fi
@@ -1963,7 +2034,7 @@ compose_dir() {
           continue
         fi
       else
-        mkdir "$dpath" || die "could not create $dpath"
+        make_own_dir "$dpath" || die "could not create $dpath"
       fi
       # The ignore lists, in scan_ignored_links's order and with its carry.
       # Guarded on the pattern count for the reason that one is: the ordinary
@@ -1984,12 +2055,13 @@ compose_dir() {
       # losing layer would set is overwritten by the winner a moment later, and
       # a build's whole answer for the path is the winner's.
       #
-      # Which leaves a directory a losing layer created holding mkdir's own
+      # Which leaves a directory a losing layer created holding make_own_dir's
       # mode until the winner reaches it, and that is writable by construction
-      # rather than by luck: it is 0777 against the same umask that made the
-      # parent this mkdir has just written into, so a umask that took the
-      # owner's bits off would have stopped the build at current.new.  Measured
-      # under 'umask 0700', where it does, on this and on the version before it.
+      # rather than by luck: $OWN_DIR_MODE carries the owner's rwx whatever the
+      # caller's umask, so the next layer can compose into it and cleanup's
+      # rm -rf can delete it.  It was mkdir's own 0777-against-the-umask until
+      # every directory shale creates became a fixed mode, and a 'umask 0700'
+      # run stopped at current.new there.
       #
       # Written before the recursion rather than after it, which is safe only
       # because dir_mode forces the owner's rwx on: the entries below are
@@ -2914,6 +2986,47 @@ scan_built_tree() {
       common_ancestor "$e"
     fi
   done
+}
+
+# The mode of the built tree itself, which is shale's own and not a layer's: it
+# is the one directory in the whole design that every symlink shale makes in
+# $HOME resolves through, so what may be read out of the tree - and, group-write
+# being the shape #124 was raised for, what may be swapped underneath those
+# links - is decided here and nowhere else.
+#
+# A note and never a finding, for the reason the mode notes in $HOME are notes:
+# nothing is broken and no build or apply is blocked.  What the reader is owed is
+# that the chmod they just made will not survive, because $CUR is not chmodded by
+# a build - it is a fresh tree renamed over the old one, and the fresh one is
+# made at $OWN_DIR_MODE.  Whoever widened it deliberately, to let something else
+# read a linked file, has to know that; whoever finds it widened has to know it
+# fixes itself.
+#
+# The raw mode, not dir_mode's owner-forced one: this reports what is there.
+# Silent where ls cannot read it, that being the walks' business rather than
+# this one's - and $CUR unreadable is a note of its own from audit_built_tree.
+audit_current_mode() {
+  { [ -d "$CUR" ] && [ ! -L "$CUR" ]; } || return 0
+  dir_mode "$CUR" 2>/dev/null || return 0
+  # The permission bits and not the whole mode, because the set-id and sticky
+  # bits are not shale's to choose and comparing them made this report fire on
+  # shale's own output: no umask masks the set-group-ID bit, mkdir takes it from
+  # the parent, so a ~/.dotfiles on a shared volume gives every tree a build
+  # makes 2700 rather than 0700 - and the rename carries it across, so the note
+  # said a build would settle it and no build could.  Measured, and it is the
+  # ~/.dotfiles with a shared group - the setup this whole mode is for - that
+  # got the false note.  8# because 2700 has no leading zero and bash would
+  # otherwise read it as decimal.
+  [ $((8#$DIR_MODE_RAW & 0777)) -ne $((8#$OWN_DIR_MODE & 0777)) ] || return 0
+  # The raw mode in the message even so: a 2755 is genuinely wide and the reader
+  # needs the digit shale is not talking about as well as the ones it is.  The
+  # last line says what the next build actually leaves rather than $OWN_DIR_MODE
+  # flat, because against a 2755 it leaves 2700 - the bits shale chose, and the
+  # one it inherited - and a remedy a reader can disprove in one command is
+  # worse than none.
+  note "$CUR is mode $DIR_MODE_RAW, and shale builds its permission bits at $OWN_DIR_MODE" \
+    "every symlink shale makes in $HOME resolves through that directory, so its mode decides who can read what they point at and who can replace it" \
+    "the next build renames a fresh tree over it, made with $OWN_DIR_MODE and with whatever set-id or sticky bit $DOTFILES gives a new directory, so a chmod here does not hold"
 }
 
 # The report #66 put in build, moved here because build is the loop a user runs
@@ -4146,7 +4259,7 @@ cmd_build() {
   # SCRATCH still empty and orphan the scratch tree.  Naming a path that does
   # not exist yet costs nothing - cleanup's rm -rf is a no-op on it.
   SCRATCH=$NEW
-  mkdir "$NEW" || die "could not create $NEW"
+  make_own_dir "$NEW" || die "could not create $NEW"
 
   DIVERGED_PATHS=()
   DIVERGED_LAYERS=()
@@ -4356,6 +4469,26 @@ cmd_build() {
   if [ "$n" -eq 0 ] && [ "$OLDER_COUNT" -eq 0 ]; then
     rm -rf "$OLD" || warn "could not remove $OLD"
   else
+    # The one directory of shale's own that no mkdir here made: it is the whole
+    # of the last build's $CUR, arrived by rename with the mode that build gave
+    # it.  A no-op on every build but the first after an upgrade, where the tree
+    # it renames was made at 0777 against a umask and would sit group-writable
+    # for the one build this keeps it - holding a copy of every file in every
+    # layer, which is the whole of what $OWN_DIR_MODE is for.  Set only where
+    # the tree is kept, because the arm above deletes it unread.
+    #
+    # A warning rather than a die: the build is done and correct, and this is a
+    # mode on a tree the next build removes.
+    #
+    # The permission bits only, like everything else here: GNU chmod given a
+    # four-digit octal leaves a directory's set-group-ID bit alone - 'chmod 0700'
+    # on one holding it yields 2700, and only 'chmod 00700' clears it, measured
+    # on coreutils 9.4 - so this cannot strip a bit that came from $DOTFILES, and
+    # is not meant to.
+    if [ -d "$OLD" ] && [ ! -L "$OLD" ]; then
+      chmod "$OWN_DIR_MODE" "$OLD" ||
+        warn "could not set the mode $OWN_DIR_MODE on $OLD"
+    fi
     # The older direction keeps current.old and says nothing; only this one is
     # reported here.  See older_than_layer.
     i=0
@@ -4967,6 +5100,11 @@ cmd_doctor() {
       note ${lines[@]+"${lines[@]}"}
     fi
   done
+
+  # Ahead of the walk below it, and of everything that walk says about what is
+  # inside the built tree: the mode of the tree itself is what decides who else
+  # can see any of it.
+  audit_current_mode
 
   # The two walks, in size order: the built tree, then the whole of $HOME.
   audit_built_tree

--- a/tests/run
+++ b/tests/run
@@ -2459,6 +2459,105 @@ test_build_a_directory_mode_it_cannot_read_stops_the_build() {
   assert_missing "$HOME/.dotfiles/current"
 }
 
+# The other half of the mode question, and the half no layer has a say in: the
+# directories shale makes for itself.  Every one of them was 0777 against the
+# caller's umask, so on the 0002 that ships with Debian and Ubuntu the directory
+# every symlink in $HOME resolves through was group-writable - and what is
+# inside it is a copy of every file of every layer, at whatever mode a clone gave
+# them.  The four umasks are the ones the case above uses, for its reasons.
+#
+# current.old is asserted beside current because it is the one of the four that
+# no mkdir makes: it is the last build's current, arrived by rename, and a
+# rename carries the mode the tree already had rather than taking a new one.
+test_build_shale_s_own_directories_have_one_mode_whatever_the_umask() {
+  local um saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  # Dated into the past so that the touch below is newer by a whole second:
+  # bash 3.2 compares -nt in seconds, and a same-second edit is not newer there
+  # however it is written.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  saved=$(umask)
+  for um in 0022 0002 0077 0000; do
+    umask "$um"
+    run_shale build
+    umask "$saved"
+    assert_status 0 "$shale_status" "umask $um first build"
+    assert_mode "$HOME/.dotfiles/current" 'drwx------' "umask $um current"
+    # The divergence that makes the build keep the tree it replaced, so that
+    # there is a current.old to read a mode off at all.
+    sandbox_mkdir "$HOME/.dotfiles/current"
+    touch "$sandbox_dir/.zshrc" || fail 'could not date the built copy'
+    umask "$um"
+    run_shale build
+    umask "$saved"
+    assert_status 0 "$shale_status" "umask $um second build"
+    assert_mode "$HOME/.dotfiles/current" 'drwx------' "umask $um current"
+    assert_mode "$HOME/.dotfiles/current.old" 'drwx------' "umask $um current.old"
+  done
+}
+
+# The scratch tree, which no build that finishes leaves behind: a stub mv is what
+# stops one with it still standing.  The reap at the end is the constraint the
+# mode has to satisfy as well as being narrow - a directory its owner cannot
+# enter is one rm -rf cannot remove, so a mode without the owner's rwx in it
+# would wedge every later build on 'could not remove current.new'.  The loop
+# proves it four times over before the last build proves it again from clean.
+# shellcheck disable=SC2123  # PATH is prefixed on purpose and restored below
+test_build_the_scratch_tree_has_that_mode_whatever_the_umask() {
+  local um saved_path saved_umask
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/git/config
+  stub_mv '*/current.new' 1
+  saved_path=$PATH
+  saved_umask=$(umask)
+  PATH=$stub_path:$PATH
+  for um in 0022 0002 0077 0000; do
+    umask "$um"
+    run_shale build
+    umask "$saved_umask"
+    assert_status 1 "$shale_status" "umask $um exit status"
+    assert_mode "$HOME/.dotfiles/current.new" 'drwx------' "umask $um"
+  done
+  PATH=$saved_path
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps the scratch tree'
+  assert_empty "$shale_err" 'the build that reaps the scratch tree stderr'
+  assert_missing "$HOME/.dotfiles/current.new"
+}
+
+# The umask that used to stop a build outright, and the reason it no longer can:
+# every directory shale creates now carries the owner's rwx whatever the caller
+# masked off, so the scratch tree, the lock and each directory a losing layer
+# composes are enterable by construction.  Against 0200 the built tree used to
+# be 0577 - a directory shale had created a moment earlier and could not write
+# into - and the build died on 'cannot create directory .../current.new/.config'
+# with mkdir's own line in front of it.
+#
+# 0200 rather than the 0700 that shows it loudest, because the harness opens its
+# own capture files under whatever umask the case leaves in force, and one that
+# masks the owner's read makes them unreadable to the assertions.  0200 masks
+# only the write, which is the bit this is about.
+test_build_survives_a_umask_that_masks_off_the_owner() {
+  local saved
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .config/git/config
+  mklayer local .config/nvim/init.lua
+  mklayer personal/base .zshrc
+  saved=$(umask)
+  umask 0200
+  run_shale build
+  umask "$saved"
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.dotfiles/current" 'drwx------'
+  assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+  assert_eq 'local/.config/nvim/init.lua' \
+    "$(cat "$HOME/.dotfiles/current/.config/nvim/init.lua")" 'the built tree'
+}
+
 test_build_is_idempotent_and_drops_a_file_deleted_from_a_layer() {
   local first
   conf 'base personal/base'
@@ -4090,6 +4189,52 @@ test_lock_a_second_concurrent_build_refuses_and_leaves_current_whole() {
   assert_missing "$HOME/.dotfiles/.lock"
 }
 
+# The lock is the fourth of shale's own directories and the only one a finished
+# run never leaves behind, so a hold is what makes it readable at all - and it
+# reads the scratch tree in the same instant, which is the only moment both
+# exist.  0000 rather than the four-umask loop the build cases run: the lock
+# comes from the same mkdir they do, and what this has to show is that the widest
+# umask a machine can have does not reach it.
+#
+# Recorded between the hold and the release rather than asserted there, for the
+# reason the case above records: an assertion that fails inside the window leaves
+# the held build spinning until its own bound expires.
+# shellcheck disable=SC2123  # PATH is prefixed on purpose and restored below
+test_lock_has_shale_s_own_mode_and_not_the_umask() {
+  local saved saved_umask first first_status lock_seen scratch_seen out err
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/git/config
+  stub_hold mkdir '*/current.new'
+  sandbox_leaf "$CASE_DIR" held.out new
+  out=$sandbox_path
+  sandbox_leaf "$CASE_DIR" held.err new
+  err=$sandbox_path
+  saved=$PATH
+  saved_umask=$(umask)
+  PATH=$stub_path:$PATH
+  umask 0000
+  shale build >"$out" 2>"$err" &
+  first=$!
+  umask "$saved_umask"
+  if ! wait_for "$stub_path/holding"; then
+    release_hold
+    PATH=$saved
+    fail 'the build never reached its hold'
+  fi
+  lock_seen=$(ls -ld "$HOME/.dotfiles/.lock" 2>&1)
+  scratch_seen=$(ls -ld "$HOME/.dotfiles/current.new" 2>&1)
+  release_hold
+  first_status=0
+  wait "$first" || first_status=$?
+  PATH=$saved
+  assert_status 0 "$first_status" 'the held build'
+  assert_eq 'drwx------' "${lock_seen:0:10}" 'the lock while the build held it'
+  assert_eq 'drwx------' "${scratch_seen:0:10}" 'the scratch tree while the build held it'
+  assert_missing "$HOME/.dotfiles/.lock"
+  assert_mode "$HOME/.dotfiles/current" 'drwx------' 'the built tree'
+}
+
 test_lock_is_released_on_success() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
@@ -5325,6 +5470,42 @@ test_apply_a_directory_mode_reaches_home_whatever_the_umask() {
     assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' "umask $um built tree"
     assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
   done
+}
+
+# Twice, because an apply reads the built tree and the second one reads it again
+# through a $HOME full of links into it: stow runs as the owner and so does
+# everything else here, which is the whole of what makes a built tree nobody but
+# the owner can enter workable.  A first apply that succeeded and a second that
+# could not descend current/ is the shape a mode that only looked tight enough
+# would leave.
+#
+# The modes in $HOME are asserted beside it, and they are the layer's rather than
+# the built tree's: the two trees are owned by different people, and shale's own
+# mode may not leak into the one it does not own.  .config at 0755 is what says
+# so - 0700 in $HOME would be this fix reaching a directory it has no business in.
+test_apply_works_twice_over_a_built_tree_only_its_owner_can_enter() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the first apply'
+  assert_empty "$shale_err" 'the first apply stderr'
+  assert_mode "$HOME/.dotfiles/current" 'drwx------' 'the built tree'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the second apply'
+  assert_empty "$shale_err" 'the second apply stderr'
+  assert_mode "$HOME/.dotfiles/current" 'drwx------' 'the built tree'
+  assert_mode "$HOME/.ssh" 'drwx------' 'the layer mode in the home directory'
+  assert_mode "$HOME/.config" 'drwxr-xr-x' 'the layer mode in the home directory'
+  # Read through the links rather than only listed: the mode of the directory
+  # they resolve through is what decides whether any of this is reachable.
+  assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.zshrc")" 'through the link'
+  assert_eq 'personal/base/.ssh/config' "$(cat "$HOME/.ssh/config")" 'through the link'
 }
 
 # The two-layer rule as it lands in $HOME, which is the tree the rule is about.
@@ -6793,6 +6974,11 @@ test_doctor_notes_nothing_it_accounts_for() {
   mklayer personal/base .zshrc
   mklayer local .zshrc
   sandbox_mkdir "$HOME/.dotfiles/current"
+  # Made by hand, so it has the suite's umask rather than the mode a build gives
+  # it, and the whole-report assertion below would catch the note that says so.
+  # That note is another check's, with a case of its own; this one is about the
+  # names the stray scan skips.
+  chmod 0700 "$sandbox_dir" || fail 'could not set the built tree mode'
   run_shale doctor
   assert_status 0 "$shale_status"
   assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
@@ -8291,6 +8477,112 @@ test_doctor_says_nothing_about_the_mode_of_an_ignored_directory() {
   assert_status 0 "$shale_status" 'doctor exit status'
   assert_not_contains "$shale_out" 'left as it is' 'stdout'
   assert_not_contains "$shale_out" "$HOME/.cache is" 'stdout'
+}
+
+# The built tree's own mode, which is shale's rather than any layer's and is the
+# one directory every symlink in $HOME resolves through.  A note and never a
+# finding: nothing is blocked, and the reader who chmodded it deliberately is
+# owed the fact that the next build will not keep it.
+test_doctor_names_a_built_tree_whose_mode_was_changed_by_hand() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  chmod 0755 "$sandbox_dir" || fail 'could not widen the built tree'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current is mode 0755, and shale builds its permission bits at 0700" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   the next build renames a fresh tree over it, made with 0700 and with whatever set-id or sticky bit $HOME/.dotfiles gives a new directory, so a chmod here does not hold" \
+    'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  # The claim the last line of the note makes, run rather than quoted.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after the chmod'
+  assert_mode "$HOME/.dotfiles/current" 'drwx------' 'after the build'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the build'
+  assert_not_contains "$shale_out" 'shale builds its permission bits at' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The setgid digit, which is not a permission bit and is what a directory
+# inherits from a setgid parent: doctor reports the mode it read rather than the
+# nine bits of it, so a reader chasing why a build keeps replacing the directory
+# is shown the whole thing.
+test_doctor_names_the_whole_mode_of_a_built_tree_it_did_not_make() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  chmod 2750 "$sandbox_dir" || fail 'could not set the built tree mode'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current is mode 2750, and shale builds its permission bits at 0700" \
+    'stdout'
+}
+
+# The other side of the case above, and the one it could not reach: a mode shale
+# produced itself must never be reported.  No umask masks the set-group-ID bit -
+# mkdir(2) takes it from the parent - so a ~/.dotfiles on a shared volume gives
+# every tree shale builds a bit shale did not choose, and a whole-mode compare
+# nagged about shale's own output on every doctor run for ever.  The note's last
+# line made it worse by promising a build would settle it, which a build does
+# not: the rename carries the bit across.
+#
+# A ~/.dotfiles with a shared group is the setup this whole issue is about, so
+# the false note landed on exactly the people the fix is for.
+#
+# Whether mkdir propagates the bit is the kernel's business rather than shale's,
+# and this case does not assert that it did: it asserts the report, which is the
+# claim.  The case below pins the compare itself on every machine.
+test_doctor_says_nothing_about_a_tree_it_built_under_a_setgid_dotfiles() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 2755 "$sandbox_dir" || fail 'could not set the set-group-ID bit'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_empty "$shale_err" 'the build stderr'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  # The line the note used to make, run rather than quoted: a second build must
+  # not be able to change what the first one left, or the remedy is a lie.
+  run_shale build
+  assert_status 0 "$shale_status" 'the second build'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the second build'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# The compare itself, on every machine rather than only where a kernel hands the
+# bit down: 2700 is the exact shape a build under a setgid ~/.dotfiles leaves,
+# made here by hand so nothing about it depends on mkdir(2).  The permission bits
+# are shale's and are all doctor may compare; the set-id and sticky bits are the
+# parent's, and shale neither sets nor clears them.
+test_doctor_compares_only_the_permission_bits_of_the_built_tree() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  chmod 2700 "$sandbox_dir" || fail 'could not set the built tree mode'
+  assert_mode "$HOME/.dotfiles/current" 'drwx--S---' 'the built tree'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  # And the sticky bit, which reaches the same digit by another route.
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  chmod 1700 "$sandbox_dir" || fail 'could not set the built tree mode'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status, sticky'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report, sticky'
 }
 
 # ------------------------------------------ doctor's apply-conflict cases


### PR DESCRIPTION
Closes #124.

`~/.dotfiles/current` was created with `0777 & ~umask`, so on Debian and Ubuntu — where `umask 002` ships with user-private groups — the directory every symlink in `$HOME` resolves through was group-writable, and nothing said so.

All four of shale's own directories are now `0700` at every umask. The umask is set around `mkdir` rather than chmodded afterwards, so there is no instant at which the directory exists wider — confirmed by strace: the only `fchmodat` calls in a build are #119's layer-mode copies. That matters because `current.new` is what a build composes into.

`doctor` compares permission bits only. `mkdir(2)` inherits setgid from the parent and no umask can mask it, so a shared-group `~/.dotfiles` gives shale's own tree `2700`; comparing the whole mode made `doctor` nag permanently about its own output, on exactly the setups this issue exists for.

Recorded rather than fixed: #127 covers `~/.dotfiles` itself and the clone roots, which a narrow `current/` does not protect.