### PR TITLE
Say how many links an apply left dangling

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,10 @@ overwrites, and how to carry on from a block that stopped.
   — which a directory-heavy tree notices and an ordinary one does not. An `apply` adds one more read
   for each of those directories that was already in `$HOME`.
 - When a whole directory leaves every layer, stow does not visit it and the links inside it are left
-  dangling by an apply that still exits 0. `shale doctor` finds them and prints what to do about
-  them; [docs/migrating.md](docs/migrating.md) covers the case in full.
+  dangling by an apply that still exits 0. That apply counts them and says so in one line; `shale
+  doctor` names them and prints what to do about them, and goes on finding them on every later run,
+  which `apply` does not — it speaks only for the apply you just ran.
+  [docs/migrating.md](docs/migrating.md) covers the case in full.
 - A shale that is killed outright — `kill -9`, or the machine losing power — leaves its lock
   directory behind, and a `~/.dotfiles/current.new` as well if it died mid-build. Shale never
   reclaims a lock, because nothing it can read tells a live holder from a dead one. `doctor` reports

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -329,9 +329,18 @@ When a file leaves a layer, the next `shale apply` prunes its link. When an enti
 every layer, the links inside it are left dangling and the apply still exits 0: stow's unstow phase
 only visits directories the package still has.
 
-Nothing says so at the moment it happens — that apply prints its `composed layer` line per layer and
-nothing else, and exits 0 — so run `shale doctor` after a change that takes a whole directory out of
-every layer. It is what finds them:
+The apply says so, in one line and no more:
+
+```
+shale: 3 links in /home/you point at paths the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names them
+```
+
+It counts the links that apply itself left behind — the paths its own build took out of the tree —
+and stops there. An apply that stow then refuses says it too, as the last line under what stow
+reported, because the build has already taken those paths out of the tree; the apply after your fix
+will not mention them again. Run `shale doctor` for the rest: which links they are, that `current`
+is correct, and which remedy fits. Doctor is also what still reports them afterwards, where a second
+`shale apply` says nothing, having removed nothing. It is what finds them:
 
 ```
 shale: /home/you/.config/foo/a.conf points at /home/you/.dotfiles/current/.config/foo/a.conf, which the built tree no longer provides

--- a/shale
+++ b/shale
@@ -4665,8 +4665,134 @@ cmd_build() {
   fi
 }
 
+# Every path the built tree holds below $CUR/$1, relative to $CUR, appended to
+# PREVIOUS_PATHS.  Apply calls it once on the tree a build is about to replace,
+# which is the only moment the paths that build removes can still be read: a
+# build reaps current.old unless it has a divergence to point at, so after one
+# there is nothing left holding them, and no walk of $HOME afterwards can tell a
+# link this apply orphaned from one an apply last year did.
+#
+# Neither dotglob nor nullglob is set here - cmd_build sets both, and this runs
+# before it - so both patterns are wanted and an unmatched one arrives as
+# itself, exactly as in doctor's walks.  '.' and '..' are dropped by name,
+# whatever the glob options say about them.
+scan_previous_tree() {
+  local rel=$1 here e base srel
+  here=$CUR${rel:+/$rel}
+  # A directory that cannot be listed answers every glob with nothing, exactly
+  # as an empty one does.  Nothing is said about it: what this feeds is a count
+  # of the links one apply left behind, and a subtree shale cannot read is one
+  # it can say nothing about - doctor walks $HOME itself and does.
+  { [ -r "$here" ] && [ -x "$here" ]; } || return 0
+  list_dir "$here" 1
+  for e in ${DIR_ENTRIES[@]+"${DIR_ENTRIES[@]}"}; do
+    base=${e##*/}
+    case "$base" in
+      . | ..) continue ;;
+      '*' | '.*')
+        { [ -e "$e" ] || [ -L "$e" ]; } || continue
+        ;;
+    esac
+    srel=${rel:+$rel/}$base
+    PREVIOUS_PATHS+=("$srel")
+    # A symlink to a directory is a leaf here as it is in the composer, and
+    # descending one would walk out of the built tree.
+    if [ -d "$e" ] && [ ! -L "$e" ]; then
+      scan_previous_tree "$srel"
+    fi
+  done
+}
+
+# How many links in $HOME this apply has just left pointing at nothing, in
+# DANGLING.  Run after stow, and every answer is the filesystem's as it stands
+# rather than a prediction: a path counts only where the built tree has stopped
+# providing it, $HOME still holds a symlink at it, and that link resolves to
+# exactly the path the tree dropped.  So a link stow pruned a moment ago is not
+# counted - the ordinary case of a file leaving its layer, where the directory
+# holding it stays and stow walks in - and neither is a dangling link of the
+# user's own that happens to sit at one of these paths.
+#
+# What this is not is an audit of $HOME, which is doctor's and costs a walk of
+# it.  Measured on the container: chkstow takes 0.10s over a 20k-entry home and
+# 0.44s over a 100k-entry one, and $HOME's size has nothing to do with the size
+# of the tree being applied - so an apply of seven files would pay it in full,
+# on every run, for a report that is almost always empty.  The snapshot this
+# reads instead is a listing walk of the built tree alone: 60ms over 2200 paths
+# on bash 5.2 and 130ms on 3.2, against the 6s the same tree costs to compose.
+#
+# The price of that scope is that this speaks for one apply.  A link a previous
+# apply orphaned is not named again here, so a second apply over the same $HOME
+# is silent while the links are still there; doctor is the standing report, and
+# the line below points at it.
+#
+# Which is a promise about doctor, and it is kept in one case and not the other.
+# Where a name holds a newline the count skips it, below, doctor being unable to
+# name that one; where chkstow is not installed it is not skipped, because doctor
+# still answers for itself - it says chkstow is missing and what that costs, in
+# its own words, and chkstow ships with stow, which an apply needed to run at all.
+count_dangling_links() {
+  local i n rel target link dest
+  DANGLING=0
+  # The substitution below swallows a missing readlink - every link would arrive
+  # with an empty target and be passed over, and the count would be a 0 meaning
+  # 'not checked'.  Doctor is where the missing tool is reported.
+  command -v readlink >/dev/null 2>&1 || return 0
+  i=0
+  n=${#PREVIOUS_PATHS[@]}
+  while [ "$i" -lt "$n" ]; do
+    rel=${PREVIOUS_PATHS[$i]}
+    i=$((i + 1))
+    # A name holding a newline is passed over, and the line this feeds is the
+    # whole reason: it sends the reader to doctor, and doctor cannot name this
+    # one.  Doctor reads chkstow's output, which is one unquoted path per line,
+    # so a link whose name holds a newline arrives as two lines and is dropped -
+    # audit_broken_links says so where it parses them.  Counted here, an apply
+    # would report a link and doctor would then answer 'no problems found'.
+    # Silence is what shale said about this before there was a line at all, and
+    # it is the honest half of the two.
+    #
+    # Nothing else in this walk minds one: the paths come from PREVIOUS_PATHS
+    # rather than from any tool's output, so the count itself would be right.
+    case "$rel" in
+      *"$NL"*) continue ;;
+    esac
+    # Nothing under $DOTFILES, which is the exclusion doctor's own audit makes:
+    # this count is what sends a reader to that report, so a link counted here
+    # and declined there would send them to a clean one.  No apply puts a link
+    # under this path - stow refuses to link into the stow directory it was
+    # given, and says so - so the arm only ever answers for a link something
+    # else made, at a path a layer once composed a '.dotfiles' of its own into.
+    case "$rel" in
+      .dotfiles | .dotfiles/*) continue ;;
+    esac
+    target=$CUR/$rel
+    { [ ! -e "$target" ] && [ ! -L "$target" ]; } || continue
+    link=$HOME_PREFIX/$rel
+    [ -L "$link" ] || continue
+    # A link that still resolves is not pointing at the path above, which is not
+    # there - so this decides nothing on its own and is here to keep the fork
+    # below off every link the user has at a path a layer once provided.
+    [ ! -e "$link" ] || continue
+    dest=$(readlink "$link") || continue
+    [ -n "$dest" ] || continue
+    # A relative target is what stow writes, and it is relative to the directory
+    # holding the link rather than to anywhere shale is.
+    case "$dest" in
+      /*) ;;
+      *) dest=${link%/*}/$dest ;;
+    esac
+    normalise_path "$dest"
+    dest=$NORMALISED
+    # Both sides normalised, so the two spellings compare rather than the
+    # strings as they arrived: $HOME itself may hold a '.' or a '..'.
+    normalise_path "$target"
+    [ "$dest" = "$NORMALISED" ] || continue
+    DANGLING=$((DANGLING + 1))
+  done
+}
+
 cmd_apply() {
-  local status err had_xtrace i n rel bits pre have target failed kept
+  local status err had_xtrace i n rel bits pre have target failed kept lines
 
   parse_config || exit 1
 
@@ -4675,6 +4801,15 @@ cmd_apply() {
       'install it with your system package manager: shale installs nothing'
 
   acquire_lock
+
+  # Under the lock, so nothing else is rebuilding the tree being read, and
+  # before the build, which is what takes paths out of it.  A tree that is not a
+  # directory is left to the build to refuse, and a missing one - the state
+  # before the first build - leaves nothing to have orphaned.
+  PREVIOUS_PATHS=()
+  if [ -d "$CUR" ] && [ ! -L "$CUR" ]; then
+    scan_previous_tree ''
+  fi
 
   cmd_build || exit 1
 
@@ -4764,19 +4899,46 @@ cmd_apply() {
   if [ "$status" -ne 0 ] && [ -n "$err" ]; then
     printf '%s\n' "$err" >&2
   fi
+
+  # Counted before the three refusals below and not only after them, because the
+  # build is what leaves these links, not the stow: the tree lost the paths the
+  # moment it was installed, whether or not stow then ran or ran to the end.  A
+  # run that stopped here used to say nothing about them, and could not say it
+  # later either - the next apply snapshots a tree those paths have already left,
+  # so the reader fixed exactly what shale named, applied again, got silence, and
+  # was back at the state #132 exists to remove.
+  #
+  # Carried as a continuation line of the failure rather than as a line of its
+  # own, and last: what stow refused is the reader's first problem, and this is
+  # one more thing to know once it is fixed.  The wording is not the success
+  # one's either.  With stow refused, the count holds every link the tree stopped
+  # providing, including the ones an apply that had run would have pruned - so
+  # what is said is that the build took the paths out, which is true of all of
+  # them, rather than that stow declined to remove them, which is true of some.
+  count_dangling_links
+  lines=()
+  if [ "$DANGLING" -eq 1 ]; then
+    lines=("1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it")
+  elif [ "$DANGLING" -gt 0 ]; then
+    lines=("$DANGLING links in $HOME point at paths the built tree no longer provides: this build took those paths out of the tree, and 'shale doctor' names them")
+  fi
+
   if [ "$status" -eq 125 ]; then
     die "could not enter $DOTFILES to run stow" \
-      "$CUR is built; nothing in $HOME was relinked"
+      "$CUR is built; nothing in $HOME was relinked" \
+      ${lines[@]+"${lines[@]}"}
   fi
   if [ "$status" -eq 1 ]; then
     die "stow failed; nothing in $HOME was relinked" \
       'stow plans the whole operation and abandons all of it rather than half-applying one' \
-      "$CUR is built and correct: fix what stow reported above, in $HOME or in a layer, then apply again"
+      "$CUR is built and correct: fix what stow reported above, in $HOME or in a layer, then apply again" \
+      ${lines[@]+"${lines[@]}"}
   fi
   [ "$status" -eq 0 ] ||
     die "stow failed part-way: $HOME may be partly relinked" \
       'stow changes nothing until the whole operation is planned, but nothing undoes the part it had carried out' \
-      "$CUR is built and correct: fix what stow reported above, in $HOME or in a layer, then apply again"
+      "$CUR is built and correct: fix what stow reported above, in $HOME or in a layer, then apply again" \
+      ${lines[@]+"${lines[@]}"}
 
   # Exit 0 with something written is the third outcome: stow linked most of the
   # tree and said so.  These lines claim only that stow wrote and what it would
@@ -4792,6 +4954,30 @@ cmd_apply() {
       'shale does not read what stow writes; its output follows unchanged' \
       "if it names a path stow skipped, that path is not linked from $CUR into $HOME"
     printf '%s\n' "$err" >&2
+  fi
+
+  # The links this apply has just left pointing at nothing, which stow neither
+  # removes nor mentions: its unstow phase walks only the directories the
+  # package still holds, so a directory that left every layer keeps every link
+  # inside it and the apply exits 0.  Measured on stow 2.3.1 and on 2.4.1, which
+  # agree about this and write nothing at all about it.  Counted above, in the
+  # one place both this and the failures share; stow having run to the end is
+  # the whole of what lets this wording name it as the cause.
+  #
+  # One line, whatever the count, and the detail is doctor's - the same split as
+  # the directory modes below.  Nothing here reproduces doctor's report: which
+  # links they are, that the built tree is correct and needs no rebuild, and
+  # which of the two remedies applies are what a reader acts on, and all of it
+  # is already there.  What was missing is that the command which created them
+  # said nothing, so the only route to that report was deciding to run doctor
+  # for no visible reason.
+  #
+  # A warning rather than a failure, and the status stays 0: the tree is built,
+  # $HOME is linked, and what is left over is a link stow declined to remove.
+  if [ "$DANGLING" -eq 1 ]; then
+    warn "1 link in $HOME points at a path the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names it"
+  elif [ "$DANGLING" -gt 0 ]; then
+    warn "$DANGLING links in $HOME point at paths the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names them"
   fi
 
   # The directory modes the build composed, put onto the directories in $HOME.

--- a/tests/run
+++ b/tests/run
@@ -6139,7 +6139,10 @@ test_apply_a_file_deleted_from_a_layer_has_its_link_pruned() {
 # the directories the package still holds, and a directory that has left every
 # layer is not among them, so the links inside it are never taken back.  --compat
 # would find them by walking the whole target tree, which info stow warns "can be
-# prohibitive if your target tree is very large"; finding them is doctor's job.
+# prohibitive if your target tree is very large"; naming them is doctor's job.
+#
+# Apply's own line is the singular one here, one directory having left with one
+# file in it, and it is the whole of what apply says about it.
 test_apply_a_directory_removed_from_every_layer_leaves_a_dangling_link() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
@@ -6155,6 +6158,305 @@ test_apply_a_directory_removed_from_every_layer_leaves_a_dangling_link() {
   assert_missing "$HOME/.dotfiles/current/.config" 'the built tree'
   assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
   assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  assert_eq \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names it" \
+    "$shale_err" 'stderr'
+}
+
+# The transcript issue #132 was opened with: a directory leaves every layer, the
+# apply that notices it says one line, and doctor still carries the detail.  The
+# count is what makes the line worth having - three links from two directories,
+# so neither a per-link report nor a per-directory one would print this number.
+#
+# The status stays 0 and the tree is correct: what is left over is a link stow
+# declined to remove, not a failure of the apply.
+test_apply_names_how_many_links_a_departed_directory_left_dangling() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  mklayer local .config/git/config
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that made the links'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_eq \
+    "shale: 3 links in $HOME point at paths the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names them" \
+    "$shale_err" 'stderr'
+  # One line and no more: which links they are, that the built tree is correct,
+  # and which remedy applies are doctor's, and a block of them here would be a
+  # block on the command people run.
+  assert_eq 1 "$(printf '%s\n' "$shale_err" | grep -c '^shale: ')" 'lines shale printed'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  assert_dangling_symlink "$HOME/.config/nvim/spell.add" 'the leftover link'
+  assert_dangling_symlink "$HOME/.config/git/config" 'the leftover link'
+  # The apply did everything else it was asked to do.
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  assert_missing "$HOME/.dotfiles/current/.config" 'the built tree'
+  # And doctor still says what it said before, at length, about the same three.
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/nvim/init.lua points at $HOME/.dotfiles/current/.config/nvim/init.lua, which the built tree no longer provides" \
+    'doctor stdout'
+  assert_contains "$shale_out" \
+    'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
+    'doctor stdout'
+  assert_contains "$shale_out" 'shale: 3 problems found' 'doctor stdout'
+}
+
+# The other half of the claim, and the one that decides whether the line above
+# is read at all: an apply that leaves nothing dangling says nothing.  Three
+# shapes of ordinary run, none of which may print it - a first apply, a repeat,
+# and the file-leaves-its-layer case, where the directory holding the link stays
+# and stow prunes the link itself.
+#
+# assert_empty is the anchor: a substring test for the message would pass on any
+# message that merely differs from the needle, and what is being asserted here
+# is that there is no message at all.
+test_apply_says_nothing_when_it_leaves_no_dangling_link() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .vimrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the first apply'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the second apply'
+  # A file leaving its layer, twice over: one in the tree's root and one in a
+  # directory that stays.  Stow walks both directories and takes both links
+  # back, so nothing is left dangling and nothing is said.
+  sandbox_leaf "$HOME/.dotfiles/personal/base" .vimrc
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  sandbox_leaf "$HOME/.dotfiles/personal/base/.config/nvim" spell.add
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that pruned two links'
+  assert_missing "$HOME/.vimrc" 'the pruned link'
+  assert_missing "$HOME/.config/nvim/spell.add" 'the pruned link'
+}
+
+# A link at one of those paths that is not the link an apply made is not
+# counted, which is what makes the number a fact rather than an inference: the
+# path left the built tree and $HOME holds a dangling symlink at it, and that is
+# still not enough, because what it points at is somewhere else entirely.
+#
+# Without the target check this case reports one link and names doctor, which
+# then reports nothing - doctor counts a link only where it resolves into the
+# built tree.
+test_apply_does_not_count_a_dangling_link_that_points_elsewhere() {
+  local dir
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  # The user's own link, put where the apply's link was.
+  sandbox_mkdir "$HOME/.config/nvim"
+  dir=$sandbox_dir
+  rm -f "$dir/init.lua" || fail 'could not remove the link the apply made'
+  sandbox_leaf "$dir" init.lua new
+  ln -s "$CASE_DIR/nowhere" "$sandbox_path" || fail 'could not plant the link'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the planted link'
+  # And doctor agrees: it is not a link into the built tree either.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor'
+  assert_not_contains "$shale_out" 'which the built tree no longer provides' \
+    'doctor stdout'
+}
+
+# The scope of the line, stated as a case because it is a decision rather than
+# an accident: apply speaks for the apply the user just ran.  The links are read
+# against the paths that build took out of the tree, and a second apply removes
+# nothing, so it says nothing while the links are still there.
+#
+# Buying the other reading costs a walk of the whole of $HOME on every apply -
+# chkstow over a 100k-entry home took 0.44s on the container, against 0.07s for
+# an apply of a seven-file tree - and doctor is where that walk lives.
+test_apply_says_nothing_a_second_time_about_links_it_already_named() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides" \
+    'the apply that left it'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply after it'
+  # Still there, and still doctor's to report.
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/nvim/init.lua points at $HOME/.dotfiles/current/.config/nvim/init.lua, which the built tree no longer provides" \
+    'doctor stdout'
+}
+
+# The failure path, where saying nothing costs the report for good.  The build
+# runs to completion, so the tree loses the directory and the links inside it
+# dangle; stow then refuses the whole operation over something else entirely and
+# apply exits 1.  Nothing said there could be said later either: the next apply
+# snapshots a tree those paths have already left, so the reader fixes exactly
+# what shale named, applies again, gets silence, and is back where #132 started.
+#
+# It is the last of shale's lines and under stow's own output, because what stow
+# refused is what the reader has to fix first, and the wording is the one that
+# names the build rather than stow - with stow refused, the count holds links a
+# working apply would have pruned as well as the ones it would have kept.
+test_apply_names_the_orphans_when_stow_then_refuses_the_apply() {
+  local last
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  # An unmanaged file where a new layer file wants to go: stow plans the whole
+  # operation, finds the conflict and abandons all of it.
+  mklayer personal/base .bashrc
+  sandbox_write "$HOME" .bashrc 'not shale'
+  run_shale apply
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: stow failed; nothing in $HOME was relinked" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it" \
+    'stderr'
+  # Under the failure, not over it.
+  last=$(printf '%s\n' "$shale_err" | grep '^shale:' | tail -1)
+  assert_eq \
+    "shale:   1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it" \
+    "$last" 'the last line shale printed'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  # The reader does what they were told, and the apply after it works - and says
+  # nothing about the link, the path having left the tree in the build before.
+  # That silence is what makes the line above the only chance to say it.
+  sandbox_leaf "$HOME" .bashrc
+  rm -f "$sandbox_path" || fail 'could not remove the unmanaged file'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the fix'
+  assert_empty "$shale_err" 'the apply after the fix'
+  assert_symlink_to "$HOME/.bashrc" "$HOME/.dotfiles/current/.bashrc"
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/nvim/init.lua points at $HOME/.dotfiles/current/.config/nvim/init.lua, which the built tree no longer provides" \
+    'doctor stdout'
+}
+
+# The scope of that failure line, and the claim README makes for the whole
+# feature: apply speaks for the apply you just ran.  It counts the paths its own
+# build took out of the tree, never what happens to be dangling in $HOME - which
+# is doctor's answer and a different number the moment an earlier apply left one.
+#
+# The failure branch is where the two can be told apart.  On the ordinary path
+# they coincide: a run that leaves an orphan has just relinked everything else,
+# so the only dangling links left are its own.  Here stow refuses, the count is
+# taken all the same, and an orphan from an earlier apply is sitting in $HOME
+# while it is: two dangling links, doctor naming both, and apply naming one.
+test_apply_names_only_the_orphans_this_run_made_when_stow_refuses() {
+  local last
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/git/config
+  run_shale apply
+  assert_status 0 "$shale_status"
+  # An earlier apply, leaving one orphan and saying so.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/nvim" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the first orphan'
+  assert_contains "$shale_err" \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names it" \
+    'the apply that made the first orphan'
+  # A second directory leaves, and stow refuses the whole operation over
+  # something else entirely.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/git" || fail 'could not remove the layer directory'
+  mklayer personal/base .bashrc
+  sandbox_write "$HOME" .bashrc 'not shale'
+  run_shale apply
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: stow failed; nothing in $HOME was relinked" 'stderr'
+  # An equality rather than a substring test, because the number is the whole
+  # claim: a line counting both orphans would satisfy any needle this one is a
+  # prefix of.
+  last=$(printf '%s\n' "$shale_err" | grep '^shale:' | tail -1)
+  assert_eq \
+    "shale:   1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it" \
+    "$last" 'the last line shale printed'
+  # Both are dangling, and doctor - which answers for $HOME rather than for a
+  # run - names both.  Counted rather than read off the summary, which also
+  # holds the unmanaged file this case planted to make stow refuse.
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the earlier orphan'
+  assert_dangling_symlink "$HOME/.config/git/config" 'the orphan this run made'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/nvim/init.lua points at $HOME/.dotfiles/current/.config/nvim/init.lua, which the built tree no longer provides" \
+    'doctor stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/git/config points at $HOME/.dotfiles/current/.config/git/config, which the built tree no longer provides" \
+    'doctor stdout'
+  assert_eq 2 \
+    "$(printf '%s\n' "$shale_out" | grep -c 'which the built tree no longer provides')" \
+    'the orphans doctor names'
+}
+
+# The one link apply may not count, because the line it would print promises a
+# doctor run that names it and doctor cannot: it reads chkstow's output, which
+# is one unquoted path per line, so a link whose name holds a newline arrives as
+# two lines and is dropped.  Apply builds these paths itself and has no such
+# trouble, which is exactly how the two came to disagree - one report of a link
+# and one 'no problems found' about the same link.
+#
+# Silence is what shale said about this before there was a line at all, so
+# nothing is lost here that was not already missing.
+test_apply_says_nothing_about_a_link_doctor_cannot_name() {
+  local inside
+  inside=$(printf 'a\nb.lua')
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base ".config/nvim/$inside"
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_symlink_to "$HOME/.config/nvim/$inside" \
+    "$HOME/.dotfiles/current/.config/nvim/$inside" 'the link stow made'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_dangling_symlink "$HOME/.config/nvim/$inside" 'the leftover link'
+  # The other half of the claim, and the reason for the first: doctor is silent
+  # about this link too, and exits 0.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor'
+  assert_contains "$shale_out" 'shale: no problems found' 'doctor stdout'
 }
 
 # The third outcome, between the two apply otherwise reports: stow did the work,


### PR DESCRIPTION
Closes #132.

Deleting a directory from every layer is routine, and stow's unstow phase only visits directories the package still has — so the links inside it are left dangling by an apply that exits 0 and says nothing. `doctor` caught them afterwards, but only if the user independently thought to run it.

`apply` now prints one line naming the count and pointing at `doctor`. It counts what that apply removed, by snapshotting the tree it is about to replace under the lock, before the build. A full `$HOME` walk was measured and rejected — 0.44s at 100k entries, scaled by `$HOME` rather than by the tree, for a report almost always empty. This costs ~3–4%, and forks `readlink` only for a link already dangling.

An apply that stow then refuses reports it too, as the last line under the failure: the build has already taken those paths out of the tree, so the next apply cannot see them. A path whose name holds a newline is skipped, because `doctor` reads chkstow's one-path-per-line output and could not name it — the line's whole content is a promise that doctor can.

Recorded rather than fixed: #137 covers `build` orphaning links silently, which `apply`'s snapshot cannot see by construction.