### PR TITLE
Let a layer declare the mode of a path, and stop inferring one

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,30 @@ pattern does not unlink what an earlier apply already linked — stow skips an i
 unstowing it — so `doctor` names those leftover links too, and removing them is the whole of the fix.
 [docs/layers.md](docs/layers.md#blocking-a-file-without-removing-it) has the detail.
 
+## Declaring the mode of a path
+
+Git records no permission bits for a directory and only the executable bit for a file, so a cloned
+layer has whatever the clone's umask gave it — `755` on most machines, `775` on Debian and Ubuntu,
+and `644` for a `config` you committed at `600`. A mode you want is a mode you declare, in a
+`.shale-modes` beside the `.shale-ignore` at the top of the clone root:
+
+```
+# ~/.dotfiles/personal/.shale-modes
+700  .ssh
+600  .ssh/config
+700  .gnupg
+```
+
+The mode first, in `chmod` order, then one exact path relative to the layer root — no globs, and
+three octal digits, setuid and setgid and sticky being refused rather than set on a path in your
+home directory. `build` puts that mode on the path in `current/`, and `apply` puts it on the
+directory stow makes in `$HOME`, which is the only way one reaches `$HOME` at all: stow creates each
+directory with `mkdir` and the caller's umask. A directory nobody declares is `755` in `current/`
+and stow's business in `$HOME`. A path no layer provides, a path with a symlink anywhere on it, and
+any line shale cannot read all stop the build with the file and the line. Two clone roots declaring
+one path resolve by config order, and `shale which` names the line that wins.
+[docs/layers.md](docs/layers.md) has the whole of it.
+
 Every transcript below was produced from that config, in a home directory at `/home/you` that had
 been applied once already — `doctor` says more before the first build, and more before the first
 apply, than after both. Where a
@@ -167,6 +191,7 @@ PATH is relative to ~/.dotfiles.  URL says how to clone PATH's top-level
 directory; give it once per directory and leave it off the other lines.
 
 A .shale-ignore file at the top of a clone root blocks paths from every apply.
+A .shale-modes file there declares modes, one "700  .ssh" per line.
 ```
 
 `shale help`, `shale -h` and `shale --help` print that same text, as does `shale` with no arguments
@@ -440,12 +465,14 @@ overwrites, and how to carry on from a block that stopped.
 - Rebuilding replaces `~/.dotfiles/current` in place, so there is a brief window in which the
   symlinks in `$HOME` point at nothing. Apply relinks immediately afterwards.
 - No build is incremental: every one composes every layer from scratch, so a one-character edit
-  costs what a first build costs. Roughly two milliseconds a file — 4.1 seconds for a 2000-file
-  tree, 31 milliseconds for a seven-file one, on the container these were measured in. A directory
-  costs more than a file, because its mode is read and set: budget about three milliseconds each —
-  once per directory and not once per layer providing it, since only the layer that wins a path pays
-  — which a directory-heavy tree notices and an ordinary one does not. An `apply` adds one more read
-  for each of those directories that was already in `$HOME`.
+  costs what a first build costs. Roughly two and a half milliseconds a file — 5.0 seconds for a
+  2000-file tree spread over 400 directories, 40 milliseconds for a seven-file one, on the container
+  these were measured in. A directory
+  is one `mkdir` and costs less than a file: no layer's directory mode is read or copied. What costs
+  instead is each line of a `.shale-modes` — one `chmod` in the build, and a read and a `chmod` in
+  the apply — so the price is the length of that file rather than the shape of the tree. Against a
+  400-directory tree, five lines were not measurable, twenty added 13 milliseconds to the build and
+  72 to the apply, and four hundred added 0.9 seconds and 2.4.
 - When a whole directory leaves every layer, stow does not visit it and the links inside it are left
   dangling by an apply that still exits 0. That apply counts them and says so in one line; `shale
   doctor` names them and prints what to do about them, and goes on finding them on every later run,
@@ -461,9 +488,11 @@ overwrites, and how to carry on from a block that stopped.
   appear in `$HOME`.
 - Git records no permission bits for a directory, and only the executable bit for a file, so a
   freshly cloned layer has whatever modes the clone's umask gave it — `755` on most machines, `775`
-  on Debian and Ubuntu, and `644` for a file you committed at `600`. Shale copies the working tree
-  faithfully, and the working tree after a clone is not what was committed. Where a mode matters,
-  `chmod` it in the layer: every build and apply reproduces it from there.
+  on Debian and Ubuntu, and `644` for a file you committed at `600`. Shale carries a file's mode
+  across faithfully, and the working tree after a clone is not what was committed; a directory's
+  mode it does not carry at all. Where a mode matters,
+  declare it in a `.shale-modes` at the top of the clone root: that file is plain text, which is the
+  one thing about a mode git reproduces exactly.
 - The built tree is `700`, so nothing but you can walk it. Nothing shale runs needs to — stow reads
   it as you — but if your `$HOME` is group-readable by design and something else reads a file shale
   linked, it resolves the link into `~/.dotfiles/current` and stops there. There is no option to
@@ -472,10 +501,10 @@ overwrites, and how to carry on from a block that stopped.
   bits are shale's — a setgid bit inherited from `~/.dotfiles` gives you `2700` on every build, and
   `doctor` says nothing about that.
 - Shale sets the mode of a directory it creates in `$HOME`, and never widens one that was already
-  there. So a `~/.ssh` you keep at `700` survives a layer that a clone left at `755`. `apply` says
-  in one line that it left such a directory alone, `doctor` names each one and both ways to settle
-  it, and `doctor` stays green — nothing is broken, and the directory shale kept is the safer of
-  the two.
+  there. So a `~/.ssh` you keep at `700` survives a layer that declares `755`. `apply` says in one
+  line that it left such a directory alone, `doctor` names each one and both ways to settle it —
+  change the declaration, or `chmod` the directory yourself — and `doctor` stays green, since
+  nothing is broken and the directory shale kept is the safer of the two.
 
 ## Licence
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -339,88 +339,193 @@ Git cannot store an empty directory. Ship a `.gitkeep` in it, and expect it in `
 it like any other file and stow links it. `~/.config/zsh/rc.d/.gitkeep` is the price of a fragment
 directory that starts out empty.
 
-## Permissions on a directory
+## Permissions
 
-A file arrives in `$HOME` with the mode it has in the layer, and so does the directory holding it, as
-long as shale is the one that created it. `~/.ssh` at `700` in a layer is `700` in
-`~/.dotfiles/current` and `700` in `$HOME`, on a machine at any umask. Nothing about the machine you
-build on decides it.
+**Git records none of this.** A tree entry has no permission bits at all, and a blob's are one
+executable bit, so a freshly cloned layer has whatever the clone's umask gave it — `755` on most
+machines, `775` on Debian and Ubuntu, and `644` for a `config` you committed at `600`. Nothing you
+`chmod` in a working tree survives the trip to the next machine.
 
-One bit is shale's rather than the layer's: the owner's `rwx` is always on. A layer directory at
-`550` composes as `750`. Shale has to be able to write into a directory it has just created — the
-next layer composes into it, and an interrupted build has to be able to delete the tree it left
-behind — and a directory in `$HOME` you cannot enter is not an arrangement any dotfile wants. The
-group and world bits, which are the ones that decide whether `~/.ssh` is safe, are copied exactly.
+So a mode you want is a mode you declare. `.shale-modes`, at the top of the clone root and committed
+with the layers, is plain text — which is the one thing git carries perfectly:
 
-Where two layers provide the same directory, the mode is the last one's, exactly as its files are.
-That includes a layer that provides only one file inside it: a `local` layer adding
-`~/.ssh/known_hosts` hands the mode of `~/.ssh` to `local`, whatever the base layer says. Put the
-mode you want on the directory in every layer that has it.
+```
+~/.dotfiles/
+  shale.conf          this machine's
+  personal/           the clone root, the git repository
+    .shale-ignore     committed
+    .shale-modes      committed
+    base/  wsl/
+```
 
-Directories in `$HOME` are set by `apply` after stow has run, because stow does not carry a mode:
-under `--no-folding` it creates each directory with the umask of whoever ran it and never with the
-mode of the built tree.
+```
+# ~/.dotfiles/personal/.shale-modes
+# Blank lines and lines starting with '#' are ignored.
+700  .ssh
+600  .ssh/config
+700  .gnupg
+600  .netrc
+```
+
+The mode first, in `chmod`'s own order, then the path — relative to the **layer root**, which is the
+top of the tree a layer mirrors, so `.ssh/config` is the same spelling you would use with `shale
+which`. One or more spaces or tabs between them; only the first run separates the two, so a path with
+a space in it needs no quoting.
+
+A declaration covers a file as readily as a directory. A `600` on a config is as lost to a clone as a
+`700` on a directory, and shale does not have to guess which of your files are secret if you tell it.
+
+### What a declaration does
+
+`build` sets the declared mode on the path in `~/.dotfiles/current`. `apply` sets it again on the
+directory stow makes in `$HOME` — stow carries no mode of its own, creating each directory with
+`mkdir` and the umask of whoever ran it. A declared *file* needs nothing in `$HOME`: what is there is
+a symlink into `current/`, and reading through it reads the file the build already set the mode on.
+
+The result is the same on every machine at every umask, which is the whole point:
+
+```
+committed:                     .ssh=700  .ssh/config=600
+clone at umask 022, apply:     ~/.ssh=700  ~/.ssh/config=600
+clone at umask 002, apply:     ~/.ssh=700  ~/.ssh/config=600
+```
+
+One digit is shale's rather than yours: **the owner's triad is always `7` for a directory.** Only
+that digit, and the other two are taken exactly as written:
+
+```
+declared:  050  500  000  070  007
+composed:  750  700  700  770  707
+```
+
+Shale has to write into a directory it has just created — the next layer composes into it, and an
+interrupted build has to be able to delete the tree it left behind — and a directory in `$HOME` you
+cannot enter is not an arrangement any dotfile wants, nor one stow can descend to link what is
+inside. The group and world bits, which are the ones that decide whether `~/.ssh` is safe, are
+untouched by it. A declared *file* gets all three digits unchanged.
+
+**A directory nobody declares is `755`** in `current/`, at any umask, and shale sets nothing at all
+for it in `$HOME` — there it is stow's `mkdir` against your umask, as it was before any of this.
+Shale acts on the paths it was told about and no others.
+
+### What stops a build
+
+- **A path no layer provides.** A declaration for a file you have since renamed is otherwise a silent
+  no-op, and the mode goes missing on the next machine with every command exiting 0. Shale names the
+  file and the line: `.shale-modes:2: no layer provides '.ssh/id_rsa'`. Correct the path or remove
+  the line.
+- **A path that is a symlink.** `chmod` follows one, so honouring the line would set the mode of
+  whatever it points at, somewhere else entirely, and there is no portable way to do the other thing.
+- **Four octal digits.** Setuid, setgid and the sticky bit are refused rather than set on a path in
+  your home directory: everything created inside a `setgid` directory afterwards takes its group,
+  including files no layer ever named. `0700` is refused by the same rule, and the message names the
+  three digits to write instead.
+- **A glob.** `600 .ssh/*` is refused: one exact path per line. Exact paths are also what makes
+  precedence between two clone roots something you can read.
+- **`..`, a leading `/`, a trailing `/`, an empty component.** Each refused by name.
+
+`shale doctor` finds every one of these before a build, and each is a problem rather than a note: no
+build runs until it is fixed.
+
+### Two roots declaring one path
+
+Config order, like everything else — the last one read wins. `shale which` names the line that
+decides a path, and the lines it shadows:
+
+```
+$ shale which .ssh
+merged    work  /home/you/.dotfiles/work/base/.ssh/
+merged    base  /home/you/.dotfiles/personal/base/.ssh/
+shale: note: '.ssh' is declared mode 755 at /home/you/.dotfiles/work/.shale-modes:1
+shale:   shadowed: /home/you/.dotfiles/personal/.shale-modes:1 declares 700
+shale:   shale sets that mode on /home/you/.dotfiles/current/.ssh
+shale:   and on /home/you/.ssh, where it never widens a directory that was already there
+```
+
+`merged` rather than `winner` because both providers are directories and directories merge; the
+trailing slash is how `which` writes one. For a declared file the last line is different, because
+what is in `$HOME` is a link and the mode lives on the copy the link points at:
+
+```
+$ shale which .netrc
+winner    base  /home/you/.dotfiles/personal/base/.netrc
+shale: note: '.netrc' is declared mode 600 at /home/you/.dotfiles/personal/.shale-modes:2
+shale:   shale sets that mode on /home/you/.dotfiles/current/.netrc
+shale:   /home/you/.netrc is a link into that tree, so that is the mode read through it
+```
+
+Neither last line is printed for a path an ignore list covers: no apply links one, so no apply sets a
+mode on one, and the note below the table says so.
+
+### Never-widen, in `$HOME`
 
 **A directory that was already in `$HOME` before the apply is only ever narrowed.** Keep `~/.ssh` at
-`700` and add a layer whose `.ssh` is `755` — the mode a clone gives it — and the apply leaves your
-`700` alone. The same layer against a `~/.ssh` that does not exist yet, or one at `755`, gives you the
-layer's mode exactly. The rule is the asymmetry: a mode fix that quietly opens `~/.ssh` is worse than
-the mode being wrong.
+`700` and add a layer declaring `755`, and the apply leaves your `700` alone. The same declaration
+against a `~/.ssh` that does not exist yet, or one at `775`, gives you `755` exactly.
 
-`apply` says so in one line, with the count and no more, because after a clone this is the ordinary
-state rather than a rare one and it lasts until you change something:
+The asymmetry is the rule: a declaration is what a layer's author asked for, the mode on the machine
+is yours, and a mode fix that quietly opens `~/.ssh` is worse than the mode being wrong.
+
+`apply` says so in one line, with the count and no more, because this is a standing disagreement
+rather than an event and it lasts until you change one side:
 
 ```
 shale: 1 directory in /home/you was left as it is: shale never widens one that was already there; 'shale doctor' names it
 ```
 
-`shale doctor` is where the detail is. It names each path, the mode it has and the mode the layer
-gives, as a note rather than a problem — the directory that survives is the *safer* of the two, so
-nothing here is broken and `doctor` still exits 0:
+`shale doctor` is where the detail is, as a note rather than a problem — the directory that survives
+is the *safer* of the two, so nothing is broken and `doctor` still exits 0:
 
 ```
 shale: an apply left 1 directory in /home/you as it is
-shale:   /home/you/.ssh is 0700, and the layer that provides it gives 0755
+shale:   /home/you/.ssh is 700, and shale is asked for 755
 shale:   shale sets the mode of a directory it creates in /home/you, and never widens one that was already there
-shale:   to take the mode the layer gives, chmod that directory yourself
-shale:   to keep the mode it has, set that mode on the directory in the layer: 'shale which' names the layer for a path
-shale: no problems found, but read the note above
+shale:   to take the mode the declaration asks for, chmod that directory yourself
+shale:   to keep the mode it has, change the declaration: 'shale which' names the line that decides a path
 ```
 
 `apply` exits 0 either way — nothing it was asked to do was left undone. A mode it cannot set at all
 is a different thing: that is named on stderr and `apply` exits 1 with the links in place.
 
-Nothing is set on a path an ignore list blocks, in `$HOME` or below it. No apply links anything
-there, so the `~/.cache` a layer names in `.shale-ignore` is yours and shale does not touch its mode
-— the same paths `shale which` reports as ignored.
+### A declaration that never reached `$HOME`
 
-`setgid`, `setuid` and the sticky bit are copied with the rest. A layer directory that is `2775` makes
-`$HOME`'s `2775`, and everything created inside it afterwards takes that directory's group. That is
-rarely what anyone intends and is easy to acquire by accident, since a directory created inside a
-`setgid` parent inherits the bit: check with `ls -ld` if a layer of yours lives on a shared volume.
+The other way a line can go unhonoured is the path not being linked at all — stow declined it, or
+something removed the link. The mode is on the copy in `current/` and on nothing anybody uses, and
+`doctor` says so as a note:
 
-**Git records none of this.** A tree entry has no permission bits at all, and a blob's are one
-executable bit, so a freshly cloned layer has whatever the clone's umask gave it — `755` on most
-machines, `775` on Debian and Ubuntu, and `644` for a `config` you committed at `600`. Shale copies
-what is in the working tree, faithfully, and what is in the working tree after a clone is not what
-you committed. Where a mode matters, set it after cloning:
-
-```sh
-chmod 700 ~/.dotfiles/personal/base/.ssh ~/.dotfiles/personal/base/.gnupg
-chmod 600 ~/.dotfiles/personal/base/.ssh/config
 ```
+shale: 1 declared mode is not on anything in /home/you
+shale:   /home/you/.dotfiles/personal/.shale-modes:4 declares 600, and nothing in /home/you is at /home/you/.netrc
+shale:   the built tree holds each of these paths with the declared mode on it, and an apply is what puts one in /home/you
+shale:   'shale which PATH' says why a path in the tree is not linked
+```
+
+Nothing is set on a path an ignore list blocks, in `$HOME` or below it, declaration or no
+declaration. No apply links anything there, so the `~/.cache` a layer names in `.shale-ignore` is
+yours and shale does not touch its mode — the same paths `shale which` reports as ignored. `doctor`
+says nothing about one either.
+
+### Where the file is read
+
+One `.shale-modes` per clone root — the top of the first component of each layer path — and every one
+of them concatenated into a single list, exactly as `.shale-ignore` is. Shale reads these files and
+composes none of them, at any depth, the way it never composes a `.git`, so one never reaches `$HOME`
+even when a clone root is named as a layer itself. A `.shale-modes` beside the config, or anywhere
+inside a layer, is read by nothing; `shale doctor` names those, because silence there is a file of
+declarations doing nothing.
 
 ## Permissions on the built tree itself
 
 `~/.dotfiles/current` is `700`, and so are `current.new`, any `current.old` and the lock at
-`~/.dotfiles/.lock`. No layer provides those, so there is no mode to copy: shale picks one, and picks
-the narrowest, on every machine at every umask.
+`~/.dotfiles/.lock`. No layer provides those and no line declares them: shale picks one mode, and
+picks the narrowest, on every machine at every umask.
 
 It matters more than it looks. Every symlink shale makes in `$HOME` resolves *through* that
 directory, so its mode is what decides who may read the file at the end of the link and who may
-replace it — and what is inside it is a copy of every file of every layer, at whatever mode the layer
-has. Read the paragraph above again: a clone gives you `644` on a `config` you committed at `600`.
-`700` on the tree is what contains that mistake.
+replace it — and what is inside it is a copy of every file of every layer, at whatever mode a clone
+left it. Read the first paragraph of the section above again: a clone gives you `644` on a `config`
+you committed at `600`, and it stays `644` until a line says otherwise. `700` on the tree is what
+contains that mistake in the meantime.
 
 The cost is that nothing but you can walk the built tree. Nothing shale runs needs to — stow reads it
 as you, and so does every other command here — but if your `$HOME` is group-readable by design and
@@ -442,8 +547,8 @@ across. So a `~/.dotfiles` on a shared volume gives you `2700` here rather than 
 build, and `doctor` says nothing about it — that bit is yours. It is the mode of a genuinely wide
 tree, `2755` say, that `doctor` reports, and it reports the whole of it so you can see both halves.
 
-The modes *inside* the tree are the layers' and are untouched by this: `current/.ssh` is whatever the
-section above says it is.
+The modes *inside* the tree are untouched by this: `current/.ssh` is whatever the section above says
+it is — the declared mode, or `755` for a directory nobody declared.
 
 ## What a layer must not ship
 

--- a/shale
+++ b/shale
@@ -221,6 +221,21 @@ OWN_DIR_MODE=0700
 # and only those: the mask discards anything above them, which is right because a
 # umask cannot carry a set-id or sticky bit anyway.
 printf -v OWN_DIR_UMASK '%04o' "$((0777 & ~8#$OWN_DIR_MODE))"
+
+# The mode of every directory a build composes that no .shale-modes line names.
+# Not the layer's: git records no permission bits for a directory at all, so on
+# any cloned layer the mode in the working tree is the clone umask's rather than
+# anything anybody committed, and reproducing it reproduces the umask.  Fixed
+# rather than taken from this machine's umask for the same reason the tree's own
+# mode is - the same layers must compose the same tree on every machine - and
+# 0755 rather than 0700 because these are the user's directories once stow has
+# made them in $HOME, where a home directory's own furniture is ordinarily
+# world-readable and a tighter default would be shale deciding otherwise for
+# every path nobody asked about.  A path that wants another mode says so in a
+# line.
+COMPOSED_DIR_MODE=0755
+printf -v COMPOSED_DIR_UMASK '%04o' "$((0777 & ~8#$COMPOSED_DIR_MODE))"
+
 # make_own_dir's cache of the umask it has to put back.  Empty until one is read.
 UMASK_SAVED=
 
@@ -297,7 +312,8 @@ usage() {
     "PATH is relative to ~/.dotfiles.  URL says how to clone PATH's top-level" \
     'directory; give it once per directory and leave it off the other lines.' \
     '' \
-    'A .shale-ignore file at the top of a clone root blocks paths from every apply.'
+    'A .shale-ignore file at the top of a clone root blocks paths from every apply.' \
+    'A .shale-modes file there declares modes, one "700  .ssh" per line.'
 }
 
 usage_error() {
@@ -1436,6 +1452,404 @@ path_is_stow_ignored() {
   [ "${#STOW_IGNORED_BY[@]}" -gt 0 ]
 }
 
+# ---------------------------------------------------------------- the mode list
+
+# The file shale reads at the top of each clone root, and never composes, on the
+# terms $IGNORE_NAME is read on.
+#
+# It exists because git carries no mode worth having.  A tree entry has no
+# permission bits at all and a blob has one executable bit, so a layer cloned
+# onto a second machine has whatever that clone's umask gave it - 0755 on most,
+# 0775 on Debian and Ubuntu, 0644 for a config committed at 0600 - and a mode
+# read off the working tree is that umask rather than anybody's intent.  A line
+# of plain text is the one thing about a mode git reproduces exactly, which is
+# why the declaration is the mechanism and the working tree is not.
+MODES_NAME=.shale-modes
+
+# Every declaration read, in the order the files were read: the three octal
+# digits, the path, and where it came from.  The path is relative to the layer
+# root, and a layer root mirrors $HOME - so one spelling names the path in the
+# layer, in the built tree and in $HOME alike, and nothing here translates
+# between them.
+#
+# Set here as well as in parse_mode_files, because doctor and which consult them
+# and a parse that failed before reaching them must leave something to consult.
+MODE_BITS=()
+MODE_PATHS=()
+MODE_FILES=()
+MODE_LINES=()
+MODE_ERRORS=0
+
+# Collected like config_error and ignore_error, and for the same reason: doctor
+# calls the reader bare and counts these into its own findings.
+mode_error() {
+  MODE_ERRORS=$((MODE_ERRORS + 1))
+  emit "$@"
+}
+
+# Records the declaration $1, read from line $3 of file $2.  Non-zero when it is
+# one shale refuses, having said so.
+#
+# 'MODE  PATH', in chmod's order, and that is the whole syntax.
+#
+# Three octal digits and never four.  A layer that could declare setgid on a
+# directory in someone's $HOME is a different proposition from one declaring
+# 700 - everything created inside such a directory afterwards takes its group,
+# including files no layer ever named - so the three bits above the permission
+# bits are refused rather than quietly dropped, because a mode somebody wrote
+# and shale ignored is the one outcome that teaches nothing.
+#
+# The path is exact and holds no glob.  '600 .ssh/*' invites the translation
+# problem #96 records the cost of, and an exact path is also the whole of what
+# makes two roots declaring one path a thing a reader can see: 'shale which'
+# names the line that wins because there is a line to name.
+add_mode_declaration() {
+  local raw=$1 file=$2 lineno=$3 bits rest c seg part meta
+  # The digits are everything up to the first blank, so a path with a space in
+  # it needs no quoting: only the first run of whitespace separates the two.
+  bits=
+  rest=$raw
+  while [ -n "$rest" ]; do
+    c=${rest:0:1}
+    case "$c" in
+      ' ' | "$TAB") break ;;
+    esac
+    bits=$bits$c
+    rest=${rest#?}
+  done
+  while :; do
+    case "$rest" in
+      ' '* | "$TAB"*) rest=${rest#?} ;;
+      *) break ;;
+    esac
+  done
+  # The reader has already trimmed both ends, so a line with anything after the
+  # digits has a path here and a line with nothing after them has none.
+  if [ -z "$rest" ]; then
+    mode_error "$file:$lineno: '$raw' is a mode with no path after it" \
+      "a declaration is a mode, whitespace and one path: '700  .ssh'"
+    return 1
+  fi
+  # Enumerated rather than ranged: '[0-7]' is a range, and what a range holds is
+  # the collation's business in a way an eight-character set is not.  Nothing
+  # here has to enter the byte locale as a result.
+  case "$bits" in
+    [01234567][01234567][01234567]) ;;
+    [01234567][01234567][01234567][01234567])
+      mode_error "$file:$lineno: '$bits' is four octal digits, and shale takes three" \
+        'setuid, setgid and the sticky bit are refused rather than set on a path in your home directory' \
+        "write the permission bits alone: '${bits#?}'"
+      return 1
+      ;;
+    *)
+      mode_error "$file:$lineno: '$bits' is not a mode" \
+        "a mode is three octal digits, in chmod's own order: '700', '755', '600'"
+      return 1
+      ;;
+  esac
+  meta=
+  case "$rest" in
+    *'*'*) meta='*' ;;
+    *'?'*) meta='?' ;;
+    *'['*) meta='[' ;;
+    *']'*) meta=']' ;;
+  esac
+  if [ -n "$meta" ]; then
+    mode_error "$file:$lineno: '$rest' contains '$meta'" \
+      'a declaration names one exact path, and there is no glob syntax here' \
+      'write one line for each path that needs a mode'
+    return 1
+  fi
+  case "$rest" in
+    /*)
+      mode_error "$file:$lineno: '$rest' begins with '/'" \
+        'a path is relative to the layer root, which is the top of the tree a layer mirrors'
+      return 1
+      ;;
+    */)
+      mode_error "$file:$lineno: '$rest' ends in '/'" \
+        'a path names one file or one directory, and a mode on a directory says nothing about what is inside it'
+      return 1
+      ;;
+  esac
+  part=$rest
+  while :; do
+    seg=${part%%/*}
+    case "$seg" in
+      '')
+        mode_error "$file:$lineno: '$rest' has an empty path component" \
+          "a '//' names nothing, and a path is one or more names joined by '/'"
+        return 1
+        ;;
+      . | ..)
+        mode_error "$file:$lineno: '$rest' has a '$seg' component" \
+          'a path is spelled out from the layer root, with nothing relative in it'
+        return 1
+        ;;
+    esac
+    case "$part" in
+      */*) part=${part#*/} ;;
+      *) break ;;
+    esac
+  done
+  MODE_BITS+=("$bits")
+  MODE_PATHS+=("$rest")
+  MODE_FILES+=("$file")
+  MODE_LINES+=("$lineno")
+  return 0
+}
+
+# Reads the mode file at the top of every clone root the config names, in config
+# order, into the MODE_* arrays.  Returns non-zero when any of them holds
+# something shale refuses; like parse_config and parse_ignore_files it never
+# exits, because doctor calls it bare and goes on reporting.
+#
+# One list, from every root together, as the ignore list is - and for a
+# different reason.  A mode names one path in one tree, and two roots naming the
+# same path is a precedence question rather than a scoping one: the last
+# declaration read wins, which is config order, which is the order everything
+# else in shale resolves in.
+#
+# A blank line and a line whose first character is '#' are skipped, and
+# whitespace comes off both ends, which is also what makes a file with CRLF line
+# endings read the same as any other.
+parse_mode_files() {
+  local i root seen file line lineno raw
+  MODE_BITS=()
+  MODE_PATHS=()
+  MODE_FILES=()
+  MODE_LINES=()
+  MODE_ERRORS=0
+  seen=' '
+  i=0
+  while [ "$i" -lt "${#LAYER_PATHS[@]}" ]; do
+    root=${LAYER_PATHS[$i]%%/*}
+    i=$((i + 1))
+    # A layer path component holds no whitespace, so this is a word list.
+    case "$seen" in
+      *" $root "*) continue ;;
+    esac
+    seen=$seen$root' '
+    file=$DOTFILES/$root/$MODES_NAME
+    { [ -e "$file" ] || [ -L "$file" ]; } || continue
+    if [ ! -f "$file" ]; then
+      mode_error "$file is not a regular file" \
+        'shale reads one mode file per clone root, and reads that one as lines of declarations'
+      continue
+    fi
+    if [ ! -r "$file" ]; then
+      mode_error "cannot read $file: permission denied" \
+        'shale reads it on every build, and will not compose a tree whose modes it cannot set' \
+        'check the permissions on that file'
+      continue
+    fi
+    lineno=0
+    # shellcheck disable=SC2094  # $file is passed below to be named in a message, never written
+    while IFS= read -r line || [ -n "$line" ]; do
+      lineno=$((lineno + 1))
+      raw=$line
+      while :; do
+        case "$raw" in
+          ' '* | "$TAB"* | "$CR"*) raw=${raw#?} ;;
+          *) break ;;
+        esac
+      done
+      while :; do
+        case "$raw" in
+          *' ' | *"$TAB" | *"$CR") raw=${raw%?} ;;
+          *) break ;;
+        esac
+      done
+      case "$raw" in
+        '' | '#'*) continue ;;
+      esac
+      add_mode_declaration "$raw" "$file" "$lineno" || continue
+    done <"$file"
+  done
+  [ "$MODE_ERRORS" -eq 0 ] || return 1
+  return 0
+}
+
+# Non-zero unless declaration $1 is the one that decides its path.  The last one
+# read wins - config order between two roots, line order inside one file - and
+# every earlier declaration for the same path is shadowed exactly as a lower
+# layer's copy of a file is.
+#
+# Every declaration is still checked against the tree whether or not it wins: a
+# line naming a path nothing provides is stale in whichever file holds it, and a
+# shadowed one that went unchecked would be a line nobody is ever told about.
+mode_wins() {
+  local i=$1 rel=${MODE_PATHS[$1]} j
+  j=$((i + 1))
+  while [ "$j" -lt "${#MODE_PATHS[@]}" ]; do
+    [ "${MODE_PATHS[$j]}" != "$rel" ] || return 1
+    j=$((j + 1))
+  done
+  return 0
+}
+
+# $1 with the owner's rwx forced on, in DECLARED_BITS.  What a declaration gives
+# a directory; a file gets its three digits as written.
+#
+# Shale has to write into a directory it has just created - the next layer
+# composes into it, and cleanup's rm -rf has to be able to delete a tree an
+# interrupted build left behind, which it cannot do through a directory it may
+# not read.  A directory in $HOME its owner cannot enter is also not an
+# arrangement any dotfile wants, and stow could not descend one to link what is
+# inside it.  So '500 .private' composes as 0700, and the group and world bits -
+# which are the whole of what makes a .ssh directory unsafe - are exactly as
+# declared.
+declared_dir_bits() {
+  DECLARED_BITS=7${1#?}
+}
+
+# Non-zero unless some component of $2, below the directory $1, is a symlink,
+# leaving the first one found in CROSSED_LINK as a path relative to $1.  The
+# leaf counts: it is one component like any other.
+#
+# chmod resolves the whole path, not just its last component, so a link
+# *anywhere* above a declared path takes the mode somewhere else.  A layer
+# holding '.ssh' as a link outside $HOME and a line reading '666 .ssh/secret'
+# set that file to 0666 with the build exiting 0 and saying nothing - measured,
+# with the target spelled both ways, on a file outside $HOME entirely.  The leaf
+# was tested and nothing above it was, which is the same reasoning applied to
+# one component out of however many the path has.
+#
+# Each prefix is tested from the top down, so the shallowest link is the one
+# named: that is the component to change, and the ones below it are only where
+# the path happened to end up.  There is no portable lchmod to do the other
+# thing with, and resolving the path first and checking where it landed would be
+# shale deciding which directories outside its trees are acceptable to write to.
+CROSSED_LINK=
+path_crosses_a_symlink() {
+  local root=$1 rel=$2 part prefix
+  CROSSED_LINK=
+  prefix=
+  part=$rel
+  while :; do
+    prefix=${prefix:+$prefix/}${part%%/*}
+    if [ -L "$root/$prefix" ]; then
+      CROSSED_LINK=$prefix
+      return 0
+    fi
+    case "$part" in
+      */*) part=${part#*/} ;;
+      *) break ;;
+    esac
+  done
+  return 1
+}
+
+# The two lines that go under either refusal above, so that build and doctor
+# refuse a declaration in the same words.  $1 is the whole declared path and $2
+# the component that is a link, which is $1 itself where the leaf is the link.
+declared_link_lines() {
+  MODE_LINK_HEAD="'$2' is a symlink"
+  [ "$1" = "$2" ] || MODE_LINK_HEAD="'$2' is a symlink, and '$1' is below it"
+  MODE_LINK_WHY='shale sets a mode with chmod, which resolves every symlink on the way down and would set the mode of whatever the path ends at, outside both trees'
+  MODE_LINK_FIX='declare a path with no symlink on it: a symlink carries no mode of its own that shale can set'
+}
+
+# What the layers make of the declared path $1, in MODE_PATH_STATE, with the
+# component at fault in CROSSED_LINK where there is one:
+#
+#   ok       every component is provided and none of them is a symlink
+#   link     CROSSED_LINK is the shallowest component that is a symlink
+#   missing  no layer provides some component, so no build composes the path
+#   unknown  a layer directory could not be searched on the way to it
+#
+# Read from the layers rather than from a composed tree, so doctor and which
+# both answer on a machine that has never run a build, and one whose tree is
+# older than the file gets the answer the next build will give rather than the
+# last one's.  One reader for both, because the two commands answering the same
+# question differently is the defect this shape exists to prevent.
+#
+# Component by component, from the top down.  The composer takes each directory
+# from the highest layer providing it, so a link two levels up is composed as a
+# link and a chmod below it resolves through - and the walk is also what makes
+# the shallowest link the one named, that being the component to change.  A
+# prefix nothing provides means nothing provides the path either, and the walk
+# stops there.
+#
+# The three names the composer skips at every depth answer 'missing', because
+# that is what they are: no build composes a path at or below a '.git' or either
+# of shale's own two files, so the tree holds nothing there however many layers
+# hold one - and build, which tests the tree, refuses such a line in exactly
+# those words.
+declared_path_state() {
+  local rel=$1 part prefix j path winner obscured
+  CROSSED_LINK=
+  MODE_PATH_STATE='missing'
+  case "/$rel/" in
+    */.git/* | */"$IGNORE_NAME"/* | */"$MODES_NAME"/*) return 0 ;;
+  esac
+  prefix=
+  part=$rel
+  while :; do
+    prefix=${prefix:+$prefix/}${part%%/*}
+    winner=
+    obscured=0
+    j=${#LAYER_PATHS[@]}
+    while [ "$j" -gt 0 ]; do
+      j=$((j - 1))
+      path=$DOTFILES/${LAYER_PATHS[$j]}/$prefix
+      if [ -e "$path" ] || [ -L "$path" ]; then
+        winner=$path
+        break
+      fi
+      ! obscured_ancestor "$DOTFILES" "${LAYER_PATHS[$j]}/$prefix" || obscured=1
+    done
+    if [ -z "$winner" ]; then
+      MODE_PATH_STATE='missing'
+      [ "$obscured" -eq 0 ] || MODE_PATH_STATE='unknown'
+      return 0
+    fi
+    if [ -L "$winner" ]; then
+      CROSSED_LINK=$prefix
+      MODE_PATH_STATE='link'
+      return 0
+    fi
+    case "$part" in
+      */*) part=${part#*/} ;;
+      *) break ;;
+    esac
+  done
+  MODE_PATH_STATE='ok'
+  return 0
+}
+
+# Non-zero unless the path $1 or some directory above it is on either ignore
+# list.  Nothing is set on such a path in $HOME: it is composed into the built
+# tree and stow is told to skip it, so no apply links anything into the $HOME
+# directory of that name - it is the user's, holding their files and nothing of
+# shale's, and a chmod there would be shale acting on the one class of path
+# 'which' reports as never touched.
+#
+# The ancestors are tested here because a declaration arrives as a whole path
+# with no walk behind it, where compose_dir and the doctor's walks carry the
+# answer down from the directory that matched.  A pattern matching a directory
+# covers everything under it, and a per-path test alone would call a descendant
+# of a matched directory unignored.
+declared_path_is_ignored() {
+  local rel=$1 prefix part
+  prefix=
+  part=$rel
+  while :; do
+    prefix=${prefix:+$prefix/}${part%%/*}
+    if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$prefix"; then
+      return 0
+    fi
+    if path_is_stow_ignored "$prefix"; then
+      return 0
+    fi
+    case "$part" in
+      */*) part=${part#*/} ;;
+      *) break ;;
+    esac
+  done
+  return 1
+}
+
 # ------------------------------------------------------------- listing a tree
 
 # The entries of one directory, as full paths.  Written by list_dir and read by
@@ -1615,9 +2029,16 @@ arm_traps
 # each call: this runs once per directory of the composed tree per layer, and
 # '$(umask)' is a fork where the two builtins around it are not.
 make_own_dir() {
-  local path=$1 status
+  make_dir_at "$OWN_DIR_UMASK" "$1"
+}
+
+# The same, at the umask $1, for the directories a build composes - which are
+# not shale's own and take COMPOSED_DIR_UMASK.  Two callers and one mkdir, so
+# that neither can acquire a mode the other did not mean to give it.
+make_dir_at() {
+  local mask=$1 path=$2 status
   [ -n "$UMASK_SAVED" ] || UMASK_SAVED=$(umask)
-  umask "$OWN_DIR_UMASK"
+  umask "$mask"
   mkdir "$path"
   status=$?
   umask "$UMASK_SAVED"
@@ -1928,10 +2349,17 @@ mode_triad() {
   return 0
 }
 
-# The permission bits of the directory $1, as the four octal digits chmod takes:
-# DIR_MODE_RAW is what is there, DIR_MODE is that with the owner's rwx forced on.
-# Non-zero when they could not be read, which the caller reports: a mode nobody
-# can name is not one to guess at.
+# The mode of the directory $1, as the four octal digits chmod takes, in
+# DIR_MODE_RAW.  Non-zero when it could not be read, which the caller reports: a
+# mode nobody can name is not one to guess at.
+#
+# A reader and nothing more.  Nothing infers a mode from a layer's working tree:
+# git records none for a directory, so what is there after a clone is the
+# clone's umask, and a .shale-modes line is what says what a path should be.
+# What is left for this is the two questions about a mode that is already on
+# disk - whether the directory in $HOME is narrower than a declaration asks for,
+# which is what never-widen turns on, and whether the built tree's own mode is
+# still the one shale builds at.
 #
 # ls, because there is no other portable reader.  No shell builtin gives a mode;
 # 'test' answers for this process's access and says nothing about the group's or
@@ -1946,16 +2374,6 @@ mode_triad() {
 # neither a strange one nor an eleventh column - the '+' or '@' a system with
 # ACLs or extended attributes adds - moves them.  The path is absolute at every
 # call site, so no operand here can be read as an option.
-#
-# The owner's rwx is forced on rather than copied, and that is the one bit of
-# this that is not the layer's mode.  Shale has to write into the directory it
-# has just created - the next layer composes into it, and cleanup has to be able
-# to delete a tree an interrupted build left behind, which 'rm -rf' cannot do
-# through a directory it may not read.  A directory in $HOME that its owner
-# cannot enter is also not an arrangement any dotfile wants, and stow could not
-# descend one to link what is inside it.  So 0500 in a layer arrives as 0700,
-# and the group and world bits - which are the whole of what makes a .ssh
-# directory unsafe - arrive exactly as the layer has them.
 #
 # ls keeps its own stderr, as chmod does at the two call sites that run one: on
 # the paths that reach either, which errno it is - the tool missing, the path
@@ -1983,19 +2401,13 @@ dir_mode() {
   mode_triad "${perm:6:3}" || return 1
   other=$TRIAD
   DIR_MODE_RAW=$hi$owner$group$other
-  DIR_MODE=$hi'7'$group$other
   return 0
 }
 
 # Copies one layer directory over the composed tree, entry by entry, last write
 # winning per path.  No bulk cp: it would name neither layer in a collision.
-#
-# $4 is 1 where a directory above this one is on an ignore list, which is
-# scan_ignored_links's carry and is here for the same reason: a pattern matches
-# a directory and covers everything under it, so a per-path test at each entry
-# would call a descendant of a matched directory unignored.
 compose_dir() {
-  local src=$1 dst=$2 rel=$3 inherited=$4 e base srel dpath here mode ignored
+  local src=$1 dst=$2 rel=$3 e base srel dpath here
   here=$src${rel:+/$rel}
   # nullglob makes a directory that cannot be listed indistinguishable from an
   # empty one, so without this its whole subtree is dropped from the build and
@@ -2023,6 +2435,8 @@ compose_dir() {
     # may be named as a layer itself, which would otherwise put that file in
     # $HOME.  One deeper is read by nobody, and doctor says so.
     [ "$base" = "$IGNORE_NAME" ] && continue
+    # The other file shale reads and composes nowhere, on the same terms.
+    [ "$base" = "$MODES_NAME" ] && continue
     srel=${rel:+$rel/}$base
     dpath=$dst/$srel
     # A symlink to a directory is a leaf.  Recursing into one would put a
@@ -2034,56 +2448,26 @@ compose_dir() {
           continue
         fi
       else
-        make_own_dir "$dpath" || die "could not create $dpath"
+        # $COMPOSED_DIR_MODE, and no layer has a say in it.  A directory's mode
+        # was copied from whichever layer won the path, which reproduced the
+        # umask of whoever cloned that layer - git records no mode for a
+        # directory - and made adding one file inside a directory reassign that
+        # directory's permissions, the winner of ~/.ssh being any layer that
+        # contributes a known_hosts to it.  A .shale-modes line is what says a
+        # path should be something other than this, and it names the path it is
+        # about.
+        #
+        # The umask rather than a chmod after the mkdir, for make_own_dir's
+        # reason: there is no instant at which the directory exists at a wider
+        # mode.  It also keeps the cost of a composed directory at one mkdir,
+        # where the copied mode cost an ls and a chmod on top of it.
+        #
+        # Created once and left alone by every later layer, so the mode does not
+        # move with which layer happens to provide the directory last.
+        make_dir_at "$COMPOSED_DIR_UMASK" "$dpath" ||
+          die "could not create $dpath"
       fi
-      # The ignore lists, in scan_ignored_links's order and with its carry.
-      # Guarded on the pattern count for the reason that one is: the ordinary
-      # config has no ignore line at all, and the call would still pay for two
-      # locale switches at every directory of every layer.
-      ignored=$inherited
-      if [ "$ignored" -eq 0 ]; then
-        if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$srel"; then
-          ignored=1
-        elif path_is_stow_ignored "$srel"; then
-          ignored=1
-        fi
-      fi
-      # A directory's mode is copied from the layer, where a file's comes with
-      # it in cp -RPp.  Only the layer that wins the path does either half of
-      # it, and that is what makes the cost one read and one chmod per composed
-      # directory rather than one of each per directory per layer: the mode a
-      # losing layer would set is overwritten by the winner a moment later, and
-      # a build's whole answer for the path is the winner's.
-      #
-      # Which leaves a directory a losing layer created holding make_own_dir's
-      # mode until the winner reaches it, and that is writable by construction
-      # rather than by luck: $OWN_DIR_MODE carries the owner's rwx whatever the
-      # caller's umask, so the next layer can compose into it and cleanup's
-      # rm -rf can delete it.  It was mkdir's own 0777-against-the-umask until
-      # every directory shale creates became a fixed mode, and a 'umask 0700'
-      # run stopped at current.new there.
-      #
-      # Written before the recursion rather than after it, which is safe only
-      # because dir_mode forces the owner's rwx on: the entries below are
-      # composed into this directory a moment later.
-      #
-      # Recorded for apply at the same point, and this is the whole of what
-      # apply acts on in $HOME.  An ignored path is kept out of it, because no
-      # apply links anything into one: the directory is composed and stow is
-      # told to skip it, so a $HOME directory of that name is the user's,
-      # holding their files and nothing of shale's, and setting a mode on it
-      # would be shale acting on a path 'which' reports as never touched.
-      if wins_this_path "$srel"; then
-        dir_mode "$e" || die "could not read the mode of $e" \
-          'shale copies a layer directory mode onto the one it composes'
-        mode=$DIR_MODE
-        chmod "$mode" "$dpath" || die "could not set the mode $mode on $dpath"
-        if [ "$ignored" -eq 0 ]; then
-          DIR_MODE_PATHS+=("$srel")
-          DIR_MODE_BITS+=("$mode")
-        fi
-      fi
-      compose_dir "$src" "$dst" "$srel" "$ignored"
+      compose_dir "$src" "$dst" "$srel"
     else
       if [ -d "$dpath" ] && [ ! -L "$dpath" ]; then
         conflict "$srel" file "$e"
@@ -2435,12 +2819,14 @@ layer_denied() {
     'check the permissions on that file'
 }
 
-# The ignore files that walk finds inside a layer and nothing reads, capped like
+# The files of shale's own that walk finds inside a layer and nothing reads -
+# an ignore file or a mode file below the top of a clone root - capped like
 # every other list doctor keeps: the cap changes what is printed and never what
-# is counted.
-STRAY_IGNORE_CAP=10
-STRAY_IGNORE_COUNT=0
-STRAY_IGNORE_PATHS=()
+# is counted.  One list for the two names, because the report is per file and
+# the name in it is read back off the path.
+STRAY_CAP=10
+STRAY_COUNT=0
+STRAY_PATHS=()
 
 # The paths in $HOME that stow will refuse to write over, collected by the layer
 # walk below.  Capped like every other list doctor keeps: the cap changes what is
@@ -2690,12 +3076,12 @@ scan_layer_trees() {
       # At every depth, as in the composer: a build composes no .git, so nothing
       # inside one is ever a collision.
       [ "$base" = .git ] && continue
-      # Composed by no build either, so it collides with nothing and stands at
-      # no path in $HOME - and read by nothing unless it is the one at the top
-      # of a clone root, which this walk meets only where the layer *is* that
-      # root.  Every other one is a file of patterns doing nothing, which is
-      # silence a reader cannot tell from a working setup.
-      if [ "$base" = "$IGNORE_NAME" ]; then
+      # Composed by no build either, so either name collides with nothing and
+      # stands at no path in $HOME - and read by nothing unless it is the one at
+      # the top of a clone root, which this walk meets only where the layer *is*
+      # that root.  Every other one is a file doing nothing, which is silence a
+      # reader cannot tell from a working setup.
+      if [ "$base" = "$IGNORE_NAME" ] || [ "$base" = "$MODES_NAME" ]; then
         if [ -n "$rel" ] ||
           [ "${LAYER_PATHS[$i]}" != "${LAYER_PATHS[$i]%%/*}" ]; then
           # Deduplicated, because one file is reached once per layer whose tree
@@ -2706,14 +3092,14 @@ scan_layer_trees() {
           # the line that replaces the names says only 'and more' - the same
           # bargain unreachable makes.
           k=0
-          while [ "$k" -lt "${#STRAY_IGNORE_PATHS[@]}" ]; do
-            [ "${STRAY_IGNORE_PATHS[$k]}" != "$e" ] || break
+          while [ "$k" -lt "${#STRAY_PATHS[@]}" ]; do
+            [ "${STRAY_PATHS[$k]}" != "$e" ] || break
             k=$((k + 1))
           done
-          if [ "$k" -eq "${#STRAY_IGNORE_PATHS[@]}" ]; then
-            STRAY_IGNORE_COUNT=$((STRAY_IGNORE_COUNT + 1))
-            [ "$STRAY_IGNORE_COUNT" -gt "$STRAY_IGNORE_CAP" ] ||
-              STRAY_IGNORE_PATHS+=("$e")
+          if [ "$k" -eq "${#STRAY_PATHS[@]}" ]; then
+            STRAY_COUNT=$((STRAY_COUNT + 1))
+            [ "$STRAY_COUNT" -gt "$STRAY_CAP" ] ||
+              STRAY_PATHS+=("$e")
           fi
         fi
         continue
@@ -3447,122 +3833,209 @@ ignored_link_finding() {
   fi
 }
 
-# The directories an apply is leaving as they are, in WIDE_DIR_*, walking the
-# built tree with scan_ignored_links's carry: an ignored path is not one any
-# apply sets a mode on, so it is not one to report a mode for either.
+# build's two refusals of a mode declaration, in build's own words and against
+# the layers rather than against a composed tree - so doctor answers them on a
+# machine that has never run a build, and a machine whose tree is older than the
+# file gets the answer the next build will give rather than the last one's.
 #
-# The test is apply's own, made from the two trees rather than from anything an
-# apply recorded, so doctor answers this without a build: a bit the built tree
-# has and the $HOME directory has not is a widening, and a widening is what an
-# apply declines.  The other direction needs no report - the next apply narrows
-# the directory and says nothing, which is what it is for.
+# What the layers say is what the tree will hold: the highest layer providing a
+# path is the copy that lands, and the composer reaches neither a '.git' nor
+# either of shale's own two file names at any depth, so a declaration at or
+# below one of those names has no path in any tree however many layers hold it.
 #
-# Two reads for each directory that is in both trees, which is what this check
-# costs and where doctor's time goes on a wide tree.  Paid here rather than in
-# apply, which is the everyday command and now prints only a count.
-#
-# Either read may fail and neither failure is doctor's to report: a directory
-# that goes while a walk is in flight is the one shape that reaches it, and this
-# check has nothing to say about a path that is no longer there.  The two other
-# walks answer the same way, by returning where they cannot read.
-scan_home_dir_modes() {
-  local rel=$1 inherited=$2 cap=$3 here e base srel ignored target want have
-  here=$CUR${rel:+/$rel}
-  { [ -r "$here" ] && [ -x "$here" ]; } || return 0
-  list_dir "$here" 1
-  for e in ${DIR_ENTRIES[@]+"${DIR_ENTRIES[@]}"}; do
-    base=${e##*/}
-    case "$base" in
-      . | ..) continue ;;
-      '*' | '.*')
-        { [ -e "$e" ] || [ -L "$e" ]; } || continue
+# Silent on 'unknown', where a layer cannot be searched.  The existence test is
+# then false about a path that may well be there, and the directory that cannot
+# be read is a blocking finding of its own a few lines above; a second finding
+# derived from it would be one shale cannot stand behind.
+audit_mode_declarations() {
+  local i n rel file lineno
+  n=${#MODE_PATHS[@]}
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    rel=${MODE_PATHS[$i]}
+    file=${MODE_FILES[$i]}
+    lineno=${MODE_LINES[$i]}
+    i=$((i + 1))
+    declared_path_state "$rel"
+    case "$MODE_PATH_STATE" in
+      link)
+        declared_link_lines "$rel" "$CROSSED_LINK"
+        blocking_finding "$file:$lineno: $MODE_LINK_HEAD" \
+          "$MODE_LINK_WHY" "$MODE_LINK_FIX"
+        ;;
+      missing)
+        blocking_finding "$file:$lineno: no layer provides '$rel'" \
+          'a mode declaration names a path in the tree a build composes, and nothing composes one at that path' \
+          'correct the path, or remove the line'
         ;;
     esac
-    # Directories only: a file in $HOME is a link into this tree and has no mode
-    # of its own to compare.
-    { [ -d "$e" ] && [ ! -L "$e" ]; } || continue
-    srel=${rel:+$rel/}$base
-    ignored=$inherited
-    if [ "$ignored" -eq 0 ]; then
-      if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$srel"; then
-        ignored=1
-      elif path_is_stow_ignored "$srel"; then
-        ignored=1
-      fi
-    fi
-    if [ "$ignored" -eq 0 ]; then
-      target=$HOME_PREFIX/$srel
-      if [ -d "$target" ] && [ ! -L "$target" ] && dir_mode "$e" 2>/dev/null; then
-        want=$DIR_MODE_RAW
-        if dir_mode "$target" 2>/dev/null; then
-          have=$DIR_MODE_RAW
-          if [ "$want" != "$have" ] && [ $(((8#$want) & ~(8#$have))) -ne 0 ]; then
-            WIDE_DIR_COUNT=$((WIDE_DIR_COUNT + 1))
-            if [ "$WIDE_DIR_COUNT" -le "$cap" ]; then
-              WIDE_DIR_PATHS+=("$target")
-              WIDE_DIR_HAVE+=("$have")
-              WIDE_DIR_WANT+=("$want")
-            fi
-          fi
-        fi
-      fi
-    fi
-    scan_home_dir_modes "$srel" "$ignored" "$cap"
   done
 }
 
-# What apply's one line points at.  Each of these is a directory whose mode the
-# built tree and $HOME disagree about in the one direction an apply will not
-# resolve, and it stays that way until somebody changes one of them - which is
-# the ordinary state after a clone rather than a rare one, git recording no mode
-# for a directory and a cloned .ssh layer therefore arriving at the umask's.
+# What apply's one line points at, and the other half of it: a declaration the
+# machine does not have.  Two shapes, both reported as notes and neither of them
+# a problem to fix in a hurry.
 #
-# A note, and this is the one thing about it worth arguing over.  The direction
-# decides it: where the layer is the tighter of the two, an apply narrows the
-# directory and no difference is left, so the only state that can persist is the
-# layer being looser - which is to say the directory in $HOME is safer than the
-# layer asks for, and shale declining to open it is shale working.  Nothing is
-# broken, nothing is blocked, and the apply exits 0.  A finding here would make
-# doctor red by default for everyone who has cloned a layer with a .ssh in it,
-# and #92's guarantee runs the other way: a green doctor means a green apply,
-# which spends the signal on a machine that is fine.
+# The first is never-widen.  A declaration is a layer author's intent and the
+# mode on the machine is the user's, and where they disagree in the one
+# direction an apply will not resolve - the declaration being the looser of the
+# two - the directory in $HOME stays as it is and stays that way until somebody
+# changes one side.  The direction is the whole argument for it being a note:
+# where the declaration is the tighter, an apply narrows the directory and no
+# difference is left, so the only state that can persist is the one in which the
+# directory in $HOME is *safer* than the layer asks for, and shale declining to
+# open it is shale working.  A finding here would make doctor red on a machine
+# that is fine, and #92's guarantee runs the other way - a green doctor means a
+# green apply.
 #
-# One note rather than one per path, in the shape the .stowrc and built-tree
-# notes use, so the summary counts this class once however many directories are
-# in it.
-audit_home_dir_modes() {
-  local cap n i rest lines
+# The second is a declaration whose path never reached $HOME at all: the build
+# composed it and stow did not link it.  Also a note, for a plainer reason -
+# every cause of it is something else's finding or something else's note, and
+# the reader is owed the fact that the mode they wrote is not on the machine
+# rather than a second copy of why.
+#
+# The test in both halves is made from what is on disk rather than from anything
+# an apply recorded, so doctor answers without a build.  Two reads per declared
+# directory that is in both trees is the whole cost, where the mode of every
+# directory of the tree used to be compared with the mode of every directory of
+# $HOME.
+#
+# Either read may fail and neither failure is doctor's to report: a directory
+# that goes while doctor is running is the one shape that reaches it, and this
+# has nothing to say about a path that is no longer there.
+#
+# Nothing at all is said about a path on either ignore list.  No apply links into
+# one and no apply sets a mode on one, so a $HOME directory of that name is the
+# user's and its mode is not shale's business to have an opinion about.
+#
+# One note per shape rather than one per path, in the form the .stowrc and
+# built-tree notes take, so the summary counts each class once however many
+# paths are in it.
+audit_declared_modes() {
+  local cap n i idx rel bits target have rest lines linked
+  local wide_count wide_paths wide_have wide_want
+  local miss_count miss_paths miss_bits miss_where
   [ -d "$CUR" ] || return 0
   [ ! -L "$CUR" ] || return 0
   [ -n "${HOME-}" ] || return 0
 
-  WIDE_DIR_COUNT=0
-  WIDE_DIR_PATHS=()
-  WIDE_DIR_HAVE=()
-  WIDE_DIR_WANT=()
   # audit_ignored_links' cap, for its reasons.
   cap=10
-  scan_home_dir_modes '' 0 "$cap"
-  n=$WIDE_DIR_COUNT
-  [ "$n" -gt 0 ] || return 0
+  wide_count=0
+  wide_paths=()
+  wide_have=()
+  wide_want=()
+  miss_count=0
+  miss_paths=()
+  miss_bits=()
+  miss_where=()
 
-  if [ "$n" -eq 1 ]; then
-    lines=("an apply left 1 directory in $HOME as it is")
+  n=${#MODE_PATHS[@]}
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    idx=$i
+    rel=${MODE_PATHS[$i]}
+    bits=${MODE_BITS[$i]}
+    target=$HOME_PREFIX/$rel
+    i=$((i + 1))
+    mode_wins "$idx" || continue
+    ! declared_path_is_ignored "$rel" || continue
+    # apply's guard, and silent here for the reason it is silent there: a $HOME
+    # path a layer provides that is not shale's link is home_conflict's finding,
+    # which this must not report a second time in weaker words.  It also keeps
+    # the mode read below off a directory somewhere else entirely.
+    ! path_crosses_a_symlink "$HOME_PREFIX" "$rel" || continue
+    # Nothing is claimed about a declaration the built tree does not answer for.
+    # A tree older than the .shale-modes file is the ordinary way in, and the
+    # next build is what settles it - by composing the path, or by refusing.
+    { [ -e "$CUR/$rel" ] || [ -L "$CUR/$rel" ]; } || continue
+    if [ -d "$CUR/$rel" ] && [ ! -L "$CUR/$rel" ]; then
+      # A declared directory is honoured by a real directory in $HOME, stow
+      # making one at every level under --no-folding.
+      if [ -d "$target" ] && [ ! -L "$target" ]; then
+        declared_dir_bits "$bits"
+        dir_mode "$target" 2>/dev/null || continue
+        have=$DIR_MODE_RAW
+        [ $(((8#$have) & 0777)) -ne $((8#$DECLARED_BITS)) ] || continue
+        # apply's own test: a bit the declaration has and the directory has not
+        # is a widening, and a widening is what an apply declines.
+        [ $(((8#$DECLARED_BITS) & ~(8#$have))) -ne 0 ] || continue
+        wide_count=$((wide_count + 1))
+        if [ "$wide_count" -le "$cap" ]; then
+          wide_paths+=("$target")
+          # The permission bits of what is there, three digits, because that is
+          # the width of the thing it is printed beside and of the file the
+          # reader edits.  Under #119 both sides were a mode read off a
+          # directory and both were four digits; a declaration cannot carry a
+          # set-id or sticky bit at all - four digits are refused - so showing
+          # one here would invite the reader to think shale compares it, and
+          # the test two lines above masks it off.  dir_mode's digits are fixed
+          # in number, so the leading one comes off by name.
+          wide_have+=("${have#?}")
+          wide_want+=("$DECLARED_BITS")
+        fi
+        continue
+      fi
+    else
+      # A declared file is honoured by a link in $HOME resolving to the copy in
+      # the built tree, which is where the mode the build set actually lives.
+      [ ! "$target" -ef "$CUR/$rel" ] || continue
+    fi
+    miss_count=$((miss_count + 1))
+    if [ "$miss_count" -le "$cap" ]; then
+      miss_paths+=("$target")
+      miss_bits+=("$bits")
+      miss_where+=("${MODE_FILES[$idx]}:${MODE_LINES[$idx]}")
+    fi
+  done
+
+  if [ "$wide_count" -gt 0 ]; then
+    if [ "$wide_count" -eq 1 ]; then
+      lines=("an apply left 1 directory in $HOME as it is")
+    else
+      lines=("an apply left $wide_count directories in $HOME as they are")
+    fi
+    i=0
+    while [ "$i" -lt "${#wide_paths[@]}" ]; do
+      lines+=("${wide_paths[$i]} is ${wide_have[$i]}, and shale is asked for ${wide_want[$i]}")
+      i=$((i + 1))
+    done
+    if [ "$wide_count" -gt "$cap" ]; then
+      rest=$((wide_count - cap))
+      lines+=("and $rest more, not named here")
+    fi
+    lines+=("shale sets the mode of a directory it creates in $HOME, and never widens one that was already there")
+    lines+=('to take the mode the declaration asks for, chmod that directory yourself')
+    lines+=("to keep the mode it has, change the declaration: 'shale which' names the line that decides a path")
+    note ${lines[@]+"${lines[@]}"}
+  fi
+
+  [ "$miss_count" -gt 0 ] || return 0
+  # Said only where something of the tree is linked at all.  On a machine that
+  # has built and never applied every declaration is in this state, and
+  # audit_unapplied_tree has already said the one thing there is to say about
+  # that tree - a list of paths under it would be the same fact per declaration.
+  BUILT_TREE_UNREAD=0
+  linked=0
+  ! built_tree_is_linked '' || linked=1
+  [ "$linked" -eq 1 ] || return 0
+
+  if [ "$miss_count" -eq 1 ]; then
+    lines=("1 declared mode is not on anything in $HOME")
   else
-    lines=("an apply left $n directories in $HOME as they are")
+    lines=("$miss_count declared modes are not on anything in $HOME")
   fi
   i=0
-  while [ "$i" -lt "${#WIDE_DIR_PATHS[@]}" ]; do
-    lines+=("${WIDE_DIR_PATHS[$i]} is ${WIDE_DIR_HAVE[$i]}, and the layer that provides it gives ${WIDE_DIR_WANT[$i]}")
+  while [ "$i" -lt "${#miss_paths[@]}" ]; do
+    lines+=("${miss_where[$i]} declares ${miss_bits[$i]}, and nothing in $HOME is at ${miss_paths[$i]}")
     i=$((i + 1))
   done
-  if [ "$n" -gt "$cap" ]; then
-    rest=$((n - cap))
+  if [ "$miss_count" -gt "$cap" ]; then
+    rest=$((miss_count - cap))
     lines+=("and $rest more, not named here")
   fi
-  lines+=("shale sets the mode of a directory it creates in $HOME, and never widens one that was already there")
-  lines+=('to take the mode the layer gives, chmod that directory yourself')
-  lines+=("to keep the mode it has, set that mode on the directory in the layer: 'shale which' names the layer for a path")
+  lines+=("the built tree holds each of these paths with the declared mode on it, and an apply is what puts one in $HOME")
+  lines+=("'shale which PATH' says why a path in the tree is not linked")
   note ${lines[@]+"${lines[@]}"}
 }
 
@@ -4139,6 +4612,72 @@ report_ignored() {
   emit ${lines[@]+"${lines[@]}"}
 }
 
+# The declaration that decides the mode of $1, with the file and the line it is
+# on, and every earlier one it shadows.  $2 is the kind the winning layer
+# provides it as, and $3 is 1 where an apply would set a mode at this path in
+# $HOME.  Nothing is printed where no line names the path, which is every
+# ordinary one.
+#
+# Two clone roots declaring one path resolve by config order, as everything else
+# in shale does, and this is the whole of what makes that visible: two lines a
+# reader can be sent to, rather than an emergent consequence of which layer
+# happened to provide a file inside a directory.
+#
+# What it may not do is claim a chmod that does not happen.  Every line below
+# about a tree is conditional on shale acting on that tree: the build refuses
+# the whole declaration in two of the states, no apply sets a mode at a path
+# either ignore list covers - which the note under this one says in as many
+# words, so an unconditional claim here contradicted it two lines later - and a
+# declared file has no mode of its own in $HOME at all, what is there being a
+# link into the built tree.
+report_declared_mode() {
+  local rel=$1 kind=${2-} in_home=${3-0} i winner lines
+  winner=-1
+  i=0
+  while [ "$i" -lt "${#MODE_PATHS[@]}" ]; do
+    [ "${MODE_PATHS[$i]}" != "$rel" ] || winner=$i
+    i=$((i + 1))
+  done
+  [ "$winner" -ge 0 ] || return 0
+  lines=("note: '$rel' is declared mode ${MODE_BITS[$winner]} at ${MODE_FILES[$winner]}:${MODE_LINES[$winner]}")
+  i=0
+  while [ "$i" -lt "$winner" ]; do
+    [ "${MODE_PATHS[$i]}" != "$rel" ] ||
+      lines[${#lines[@]}]="shadowed: ${MODE_FILES[$i]}:${MODE_LINES[$i]} declares ${MODE_BITS[$i]}"
+    i=$((i + 1))
+  done
+  declared_path_state "$rel"
+  case "$MODE_PATH_STATE" in
+    # The two states build refuses, said as refusals rather than as a mode: a
+    # line shale will not act on is a line to correct or remove, and every build
+    # says so until one of those happens.
+    missing)
+      lines[${#lines[@]}]="no layer provides that path, so no build composes one at it and 'shale build' refuses the line"
+      ;;
+    link)
+      declared_link_lines "$rel" "$CROSSED_LINK"
+      lines[${#lines[@]}]="$MODE_LINK_HEAD, so 'shale build' refuses the line"
+      lines[${#lines[@]}]=$MODE_LINK_WHY
+      ;;
+    # 'unknown' says nothing more: cmd_which has already refused an answer where
+    # a layer could not be searched.
+    ok)
+      lines[${#lines[@]}]="shale sets that mode on $CUR/$rel"
+      if [ "$in_home" -eq 1 ] && [ -n "${HOME-}" ]; then
+        if [ "$kind" = directory ]; then
+          lines[${#lines[@]}]="and on $HOME_PREFIX/$rel, where it never widens a directory that was already there"
+        elif [ -L "$HOME_PREFIX/$rel" ] && [ "$HOME_PREFIX/$rel" -ef "$CUR/$rel" ]; then
+          # Only where the link is actually there.  Where it is not, the
+          # residual note at the end of the answer is the one that speaks, and
+          # doctor carries the same fact as a note of its own.
+          lines[${#lines[@]}]="$HOME_PREFIX/$rel is a link into that tree, so that is the mode read through it"
+        fi
+      fi
+      ;;
+  esac
+  emit ${lines[@]+"${lines[@]}"}
+}
+
 # The one path no apply links that neither list can be made to account for:
 # '.stow-local-ignore' with a trailing newline.  Stow adds
 # '^/\.stow-local-ignore$' to whatever a package's list holds rather than
@@ -4372,7 +4911,7 @@ check_layers() {
 }
 
 cmd_build() {
-  local i dir n had_current qcur qold
+  local i dir n had_current qcur qold rel file lineno bits errors
 
   parse_config || exit 1
 
@@ -4398,6 +4937,10 @@ cmd_build() {
   # composed, because a pattern shale refuses stops the build and composing a
   # tree first would only be work to throw away.
   parse_ignore_files || exit 1
+  # The mode declarations, on the same terms and in the same window: committed
+  # inside a clone root, and a line shale refuses stops the build before a tree
+  # is composed for it to be refused against.
+  parse_mode_files || exit 1
 
   if [ -L "$CUR" ]; then
     die "$CUR is a symlink" \
@@ -4421,10 +4964,6 @@ cmd_build() {
 
   DIVERGED_PATHS=()
   DIVERGED_LAYERS=()
-  # Blanked here rather than at the top of the file, so that the list apply
-  # replays is this build's and never a previous one's.
-  DIR_MODE_PATHS=()
-  DIR_MODE_BITS=()
   OLDER_COUNT=0
   CONFLICT_PATHS=()
   CONFLICT_MINE=()
@@ -4434,7 +4973,7 @@ cmd_build() {
     SRC_INDEX=$i
     SRC_NAME=${LAYER_NAMES[$i]}
     dir=$DOTFILES/${LAYER_PATHS[$i]}
-    compose_dir "$dir" "$NEW" '' 0
+    compose_dir "$dir" "$NEW" ''
     report "composed layer '$SRC_NAME' from $dir"
     i=$((i + 1))
   done
@@ -4469,6 +5008,66 @@ cmd_build() {
     done
     die "$CUR not rebuilt"
   fi
+
+  # The mode declarations, against the tree they name.  Every one is checked
+  # before any of them is set, and a line shale cannot act on stops the build.
+  #
+  # A declared path that nothing composes is the case that decides this, and the
+  # precedent is an ignore pattern shale cannot translate: that stops a build
+  # rather than being dropped, because a line somebody wrote and shale silently
+  # did nothing with is worse than either acting on it or refusing it.  A path
+  # renamed in a layer leaves its declaration behind, and the mode then goes
+  # missing on the next machine that clones the layer, with every command
+  # exiting 0.  Named with its file and its line, which is what makes it one
+  # edit.
+  #
+  # A symlink on the path is the other shape, and the same argument: chmod
+  # resolves every component, so honouring the line would set the mode of
+  # whatever the path ends at, somewhere else entirely.  Tested before the
+  # existence check, because a link to nothing answers that one with the wrong
+  # cause, and every component is tested rather than the leaf alone - see
+  # path_crosses_a_symlink for what testing the leaf alone let through.
+  errors=0
+  n=${#MODE_PATHS[@]}
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    rel=${MODE_PATHS[$i]}
+    file=${MODE_FILES[$i]}
+    lineno=${MODE_LINES[$i]}
+    i=$((i + 1))
+    if path_crosses_a_symlink "$NEW" "$rel"; then
+      declared_link_lines "$rel" "$CROSSED_LINK"
+      emit "$file:$lineno: $MODE_LINK_HEAD" "$MODE_LINK_WHY" "$MODE_LINK_FIX"
+      errors=$((errors + 1))
+    elif [ ! -e "$NEW/$rel" ]; then
+      emit "$file:$lineno: no layer provides '$rel'" \
+        'a mode declaration names a path in the tree a build composes, and nothing composes one at that path' \
+        'correct the path, or remove the line'
+      errors=$((errors + 1))
+    fi
+  done
+  if [ "$errors" -eq 1 ]; then
+    die "1 mode declaration shale cannot act on; $CUR not rebuilt"
+  elif [ "$errors" -gt 0 ]; then
+    die "$errors mode declarations shale cannot act on; $CUR not rebuilt"
+  fi
+  # Only the winner is set, so two roots declaring one path leave one chmod
+  # rather than two in an order nobody chose.  A file gets the three digits as
+  # written; a directory gets declared_dir_bits' clamp, for the reason there.
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    rel=${MODE_PATHS[$i]}
+    bits=${MODE_BITS[$i]}
+    if mode_wins "$i"; then
+      if [ -d "$NEW/$rel" ]; then
+        declared_dir_bits "$bits"
+        bits=$DECLARED_BITS
+      fi
+      chmod "$bits" "$NEW/$rel" ||
+        die "could not set the mode $bits on $NEW/$rel"
+    fi
+    i=$((i + 1))
+  done
 
   # A package-local ignore list replaces stow's built-in one wholesale rather
   # than adding to it, so whatever is missing here is linked into $HOME with
@@ -4792,7 +5391,7 @@ count_dangling_links() {
 }
 
 cmd_apply() {
-  local status err had_xtrace i n rel bits pre have target failed kept lines
+  local status err had_xtrace i n idx rel bits pre have target failed kept lines
 
   parse_config || exit 1
 
@@ -4861,19 +5460,19 @@ cmd_apply() {
   #
   # No restore is owed on the paths that do not reach it: every trap that can
   # fire in this window exits.
-  # Which of the directories the build recorded are already in $HOME, taken
-  # before stow runs because afterwards there is no telling one stow has just
-  # made from one that was there all along - and that is the whole of what
-  # decides whether the mode below may widen it.  Tests only, no fork.
-  DIR_MODE_PRE=()
+  # Which of the declared paths are already directories in $HOME, taken before
+  # stow runs because afterwards there is no telling one stow has just made from
+  # one that was there all along - and that is the whole of what decides whether
+  # the mode below may widen it.  Tests only, no fork.
+  MODE_PRE=()
   i=0
-  n=${#DIR_MODE_PATHS[@]}
+  n=${#MODE_PATHS[@]}
   while [ "$i" -lt "$n" ]; do
-    target=$HOME_PREFIX/${DIR_MODE_PATHS[$i]}
+    target=$HOME_PREFIX/${MODE_PATHS[$i]}
     if [ -d "$target" ] && [ ! -L "$target" ]; then
-      DIR_MODE_PRE+=(1)
+      MODE_PRE+=(1)
     else
-      DIR_MODE_PRE+=(0)
+      MODE_PRE+=(0)
     fi
     i=$((i + 1))
   done
@@ -4980,45 +5579,66 @@ cmd_apply() {
     warn "$DANGLING links in $HOME point at paths the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names them"
   fi
 
-  # The directory modes the build composed, put onto the directories in $HOME.
-  # Stow does not carry them: it creates each directory with mkdir and no mode,
-  # so what lands is 0777 against the caller's umask whatever $CUR holds -
-  # measured on 2.3.1 and on 2.4.1, which agree.  So without this the mode a
-  # layer puts on .ssh reaches the built tree and stops there, and $HOME gets
-  # 0755 on a machine at the common umask and 0775 - group writable, which
-  # OpenSSH's StrictModes refuses - on a Debian or Ubuntu one.
+  # The declared modes, put onto the directories in $HOME.  Stow does not carry
+  # one: it creates each directory with mkdir and no mode, so what lands is 0777
+  # against the caller's umask whatever $CUR holds - measured on 2.3.1 and on
+  # 2.4.1, which agree.  So without this a '700 .ssh' reaches the built tree and
+  # stops there, and $HOME gets 0755 on a machine at the common umask and 0775 -
+  # group writable, which OpenSSH's StrictModes refuses - on a Debian or Ubuntu
+  # one.
   #
-  # In the order the build recorded them, which is the order the layers were
-  # composed in.  Parents come before their children, and every mode has the
-  # owner's rwx in it, so nothing here can shut the walk out of a directory
-  # below it.
+  # A declaration reaches both trees because they are two trees.  The built one
+  # is shale's own and gets the mode as declared; $HOME is the user's, and there
+  # the declaration is what a layer author asked for while the mode on disk is
+  # what the person at the machine has.
   #
-  # A directory that was already in $HOME before this apply is only ever
+  # So a directory that was already in $HOME before this apply is only ever
   # narrowed, never widened, and that asymmetry is the point of the whole pass.
-  # Git records no mode for a directory, so a freshly cloned layer has whatever
-  # the clone's umask gave it - 0755, or 0775 on Debian and Ubuntu - and a
-  # ~/.ssh the user keeps at 0700 with a private key in it would be opened up by
-  # an apply, silently, on the ordinary clone-and-apply path.  A mode fix that
-  # exposes ~/.ssh is worse than the bug it fixes.  A directory stow made in
-  # this apply has no such history and gets the layer's mode exactly, which is
-  # what keeps the built tree and $HOME agreeing on every path shale created.
+  # A '755 .ssh' against a ~/.ssh the user keeps at 0700, with a private key in
+  # it, would be opened up by an apply on the ordinary clone-and-apply path,
+  # silently; a mode fix that exposes ~/.ssh is worse than the bug it fixes.  A
+  # directory stow made in this apply has no such history and gets the declared
+  # mode exactly, which is what keeps the built tree and $HOME agreeing on every
+  # path shale created.
   #
-  # Two shapes are passed over, and neither is silence about a mode that was
-  # meant to land: a path that is not a directory now was never linked into -
-  # stow skipped it, or nothing of the tree reached it - and a symlink at the
-  # path is not shale's directory, chmod would follow it and change the mode of
-  # whatever it points at, somewhere else entirely.
+  # In the order the declarations were read, which is config order, so a path
+  # two roots declare is settled the way everything else in shale is.  Only the
+  # winner is acted on, and every mode carries the owner's rwx, so nothing here
+  # can shut the pass out of a path below it.
+  #
+  # Three shapes are passed over, and none of them is silence about a mode that
+  # was meant to land.  A path on either ignore list is not one any apply links
+  # into, so the $HOME directory of that name is the user's entirely.  A symlink
+  # at the path is a declared file, arriving in $HOME as a link into the built
+  # tree, where the mode the build set on the copy is the mode a reader gets
+  # through the link - and chmod would follow the link to that same file.  And a
+  # path with nothing at it was not linked at all: stow skipped it, or nothing
+  # of the tree reached it, which doctor reports.
   failed=0
   kept=0
   i=0
-  n=${#DIR_MODE_PATHS[@]}
+  n=${#MODE_PATHS[@]}
   while [ "$i" -lt "$n" ]; do
-    rel=${DIR_MODE_PATHS[$i]}
-    bits=${DIR_MODE_BITS[$i]}
-    pre=${DIR_MODE_PRE[$i]}
+    idx=$i
+    rel=${MODE_PATHS[$i]}
+    bits=${MODE_BITS[$i]}
+    pre=${MODE_PRE[$i]}
     target=$HOME_PREFIX/$rel
     i=$((i + 1))
+    mode_wins "$idx" || continue
+    ! declared_path_is_ignored "$rel" || continue
+    # Every component, not the leaf alone, for build's reason: chmod resolves
+    # the whole path.  Nothing shale created is below a link in $HOME - stow
+    # refuses to stow into one and this apply would have died before reaching
+    # here - so this guards a path shale has no business writing to rather than
+    # one it made, and it says nothing: a $HOME path a layer provides that is
+    # not shale's link is a finding of doctor's own, in home_conflict's words.
+    ! path_crosses_a_symlink "$HOME_PREFIX" "$rel" || continue
     { [ -d "$target" ] && [ ! -L "$target" ]; } || continue
+    # A directory, so the clamp, and the same bits the build put on the copy in
+    # the tree.
+    declared_dir_bits "$bits"
+    bits=$DECLARED_BITS
     if [ "$pre" -eq 1 ]; then
       if ! dir_mode "$target"; then
         emit "could not read the mode of $target"
@@ -5028,12 +5648,14 @@ cmd_apply() {
       have=$DIR_MODE_RAW
       # Nothing to do, and the commonest case by far: every directory of the
       # last apply arrives here already holding the mode this one would set.
-      [ "$have" != "$bits" ] || continue
-      # A bit the layer has and the directory has not is a widening, and every
-      # one of them is refused together: a mode is one answer rather than nine,
-      # and half of one is a directory neither side asked for.  8# because a
-      # leading 1 through 7 in the set-id digit is not a leading zero, and bash
-      # would read the whole thing as decimal.
+      # The permission bits alone, because the declaration has nothing to say
+      # about a set-id or sticky bit and 'chmod 700' would not clear one anyway.
+      # 8# because a leading 1 through 7 in the set-id digit is not a leading
+      # zero, and bash would read the whole thing as decimal.
+      [ $(((8#$have) & 0777)) -ne $((8#$bits)) ] || continue
+      # A bit the declaration has and the directory has not is a widening, and
+      # every one of them is refused together: a mode is one answer rather than
+      # nine, and half of one is a directory neither side asked for.
       if [ $(((8#$bits) & ~(8#$have))) -ne 0 ]; then
         kept=$((kept + 1))
         continue
@@ -5047,13 +5669,12 @@ cmd_apply() {
   done
 
   # One line, whatever the count, and the detail is doctor's.  This is a
-  # standing condition rather than an event: after a clone the layer's .ssh is
-  # 0755 - git having recorded no mode for it - and a ~/.ssh the user keeps at
-  # 0700 diverges from it on every apply until one side is changed, which is the
-  # default state for anyone with a .ssh layer rather than a rare one.  A block
-  # of lines there would be a block on every apply, which is #75's rule; saying
-  # nothing at all would be an apply quietly declining what a layer asked for,
-  # which is #92's.  So: the count here, the paths and the modes in doctor.
+  # standing condition rather than an event: a layer declaring '755 .ssh' and a
+  # ~/.ssh the user keeps at 0700 disagree on every apply until one side is
+  # changed, and neither side has any reason to change.  A block of lines there
+  # would be a block on every apply, which is #75's rule; saying nothing at all
+  # would be an apply quietly declining what a layer asked for, which is #92's.
+  # So: the count here, the paths and the modes in doctor.
   #
   # A warning rather than a failure, and the status stays 0: what shale declined
   # to do leaves the safer of the two modes in place and nothing about the apply
@@ -5240,6 +5861,13 @@ cmd_doctor() {
   FINDINGS=$((FINDINGS + IGNORE_ERRORS))
   BUILD_BLOCKED=$((BUILD_BLOCKED + IGNORE_ERRORS))
 
+  # The mode declarations, on the same terms: build calls this as
+  # 'parse_mode_files || exit 1' too, so each refusal is blocking.  The paths
+  # they name are checked below, once the layers have been looked at.
+  parse_mode_files 2>&1
+  FINDINGS=$((FINDINGS + MODE_ERRORS))
+  BUILD_BLOCKED=$((BUILD_BLOCKED + MODE_ERRORS))
+
   # The layers as build composes them, once the loop above has said which of
   # them there is anything to walk.  A root that is missing, unreadable or not a
   # directory is that loop's finding and is left out here rather than reported
@@ -5257,8 +5885,8 @@ cmd_doctor() {
   APPLY_CONFLICTS=0
   APPLY_CONFLICT_PATHS=()
   HOME_CONFLICT_SKIP=
-  STRAY_IGNORE_COUNT=0
-  STRAY_IGNORE_PATHS=()
+  STRAY_COUNT=0
+  STRAY_PATHS=()
   [ -z "$layers" ] || scan_layer_trees '' "${layers# }"
   # Under the cap every one of them is printed above and this says nothing.
   if [ "$LAYER_DENIED" -gt "$LAYER_DENIED_CAP" ]; then
@@ -5283,6 +5911,10 @@ cmd_doctor() {
     fi
     i=$((i + 1))
   done
+
+  # build's other refusal of a line, after the layers above have said which of
+  # them there is anything to read.
+  audit_mode_declarations
 
   # Everything in ~/.dotfiles that shale does not account for, a file as much as
   # a directory: an editor left a 'shale.conf.bak' beside the config and nothing
@@ -5400,25 +6032,34 @@ cmd_doctor() {
     note ${lines[@]+"${lines[@]}"}
   fi
 
-  # An ignore file shale does not read: beside the config, where the config is,
-  # or anywhere inside a layer, which the walk above found at any depth.
-  # Neither is read by anything and neither is composed, so without this the
-  # patterns in it are silence a reader cannot tell from a working setup.
-  if [ -e "$DOTFILES/$IGNORE_NAME" ] || [ -L "$DOTFILES/$IGNORE_NAME" ]; then
-    note "$DOTFILES/$IGNORE_NAME is read by nothing" \
-      "shale reads one $IGNORE_NAME per clone root, at $DOTFILES/<root>/$IGNORE_NAME" \
+  # One of shale's own two files where shale does not read it: beside the
+  # config, where the config is, or anywhere inside a layer, which the walk
+  # above found at any depth.  Neither is read by anything and neither is
+  # composed, so without this what is in it is silence a reader cannot tell from
+  # a working setup.
+  for entry in "$IGNORE_NAME" "$MODES_NAME"; do
+    { [ -e "$DOTFILES/$entry" ] || [ -L "$DOTFILES/$entry" ]; } || continue
+    note "$DOTFILES/$entry is read by nothing" \
+      "shale reads one $entry per clone root, at $DOTFILES/<root>/$entry" \
       'move it into the clone root whose layers it is about'
-  fi
-  i=0
-  while [ "$i" -lt "${#STRAY_IGNORE_PATHS[@]}" ]; do
-    note "${STRAY_IGNORE_PATHS[$i]} is read by nothing" \
-      "shale reads one $IGNORE_NAME per clone root, at $DOTFILES/<root>/$IGNORE_NAME" \
-      'one list covers the whole built tree, so a layer cannot have patterns of its own'
-    i=$((i + 1))
   done
-  if [ "$STRAY_IGNORE_COUNT" -gt "$STRAY_IGNORE_CAP" ]; then
-    i=$((STRAY_IGNORE_COUNT - STRAY_IGNORE_CAP))
-    note "and $i more $IGNORE_NAME files read by nothing, not named here"
+  i=0
+  while [ "$i" -lt "${#STRAY_PATHS[@]}" ]; do
+    entry=${STRAY_PATHS[$i]##*/}
+    i=$((i + 1))
+    if [ "$entry" = "$MODES_NAME" ]; then
+      note "${STRAY_PATHS[$((i - 1))]} is read by nothing" \
+        "shale reads one $entry per clone root, at $DOTFILES/<root>/$entry" \
+        'one list covers the whole built tree, so a layer cannot have declarations of its own'
+    else
+      note "${STRAY_PATHS[$((i - 1))]} is read by nothing" \
+        "shale reads one $entry per clone root, at $DOTFILES/<root>/$entry" \
+        'one list covers the whole built tree, so a layer cannot have patterns of its own'
+    fi
+  done
+  if [ "$STRAY_COUNT" -gt "$STRAY_CAP" ]; then
+    i=$((STRAY_COUNT - STRAY_CAP))
+    note "and $i more files of shale's own read by nothing, not named here"
   fi
 
   # The two files stow reads: '~/.stowrc', and './.stowrc' from the directory it
@@ -5464,10 +6105,10 @@ cmd_doctor() {
   # list covers, against what $HOME still links.
   audit_ignored_links
 
-  # The built tree once more, against the modes of the same directories in
-  # $HOME: the detail behind the one line an apply prints when it leaves one as
-  # it is.
-  audit_home_dir_modes
+  # The declarations against $HOME: the detail behind the one line an apply
+  # prints when it leaves a directory as it is, and the declarations that never
+  # reached $HOME at all.
+  audit_declared_modes
 
   # Last, because it is the only check that walks the whole of $HOME and the only
   # one that means anything only once everything above it is sound.
@@ -5557,14 +6198,17 @@ cmd_doctor() {
 # Reads no build output but the one note at the end: the answer is what the
 # layers say, so it is the same before the first build as after it.
 cmd_which() {
-  local arg=${1-} rel path i n lower upper keyword column width obscured ignored
-  local explained refused dot_git own_ignore unreached
+  local arg=${1-} rel path i n lower upper keyword column width obscured ignored home_modes
+  local explained refused dot_git own_ignore own_modes unreached
 
   parse_config || exit 1
   # Refused rather than answered around: a pattern shale will not read is one it
   # cannot say whether this path matches, and an answer that left it out would
   # be the silent half of the same mistake.  Every build refuses it too.
   parse_ignore_files || exit 1
+  # The same, for the same reason: a line shale will not read is one it cannot
+  # say what mode this path gets from, and every build refuses it too.
+  parse_mode_files || exit 1
   which_normalise "$arg" || exit 1
   rel=$WHICH_REL
 
@@ -5573,6 +6217,16 @@ cmd_which() {
   # provides it, and the reader arrives asking about a file that is missing
   # rather than about which layer wins.
   #
+  # Whether an apply would set a mode at this path in $HOME at all, which is
+  # apply's own test and takes the ancestors with it - nothing is set below a
+  # directory an ignore list covers either.
+  #
+  # Before the pair below and never after, because it runs those same two
+  # matchers on each prefix and leaves their answers holding the last prefix it
+  # tested; what report_ignored prints is what the pair below leaves.
+  home_modes=1
+  ! declared_path_is_ignored "$rel" || home_modes=0
+
   # Both lists, and both answers kept: stow reads them out of one file and a
   # path can be on either or on both, while what to do about it differs.
   ignored=0
@@ -5618,6 +6272,9 @@ cmd_which() {
     # has just moved the file out of a layer to stop it being linked is owed the
     # pattern that was already doing it.
     [ "$ignored" -eq 0 ] || report_ignored "$rel"
+    # And here above all: a declaration outliving the path it names is what the
+    # reader has, and the next build refuses it.
+    report_declared_mode "$rel" '' "$home_modes"
     # Said here for the same reason, and beside the stale note rather than
     # instead of it: the tree holding this path and no layer providing it is
     # where a reader lands the moment after renaming the file, and 'run build'
@@ -5687,6 +6344,13 @@ cmd_which() {
     i=$((i + 1))
   done
 
+  # Directly under the table and ahead of every note about $HOME, because it is
+  # about the same question the table answers - what this path gets, and which
+  # line decides it - rather than about why the path is or is not linked.  It
+  # accounts for nothing: a path with a declared mode is otherwise an ordinary
+  # path, and the notes below run exactly as they would without one.
+  report_declared_mode "$rel" "${WHICH_KINDS[0]}" "$home_modes"
+
   # First among the notes: the table above says which layer's copy lands in the
   # built tree, which is true and is not the answer to why the file is not in
   # $HOME.
@@ -5704,25 +6368,28 @@ cmd_which() {
   # can account for, and two notes making the one point read as two problems.
   explained=0
 
-  # The two names the composer skips, read once and before anything is printed:
-  # the notes below are decided from them as well as reported by them, and a
-  # second copy of either test is a place for the two answers to drift apart.
+  # The three names the composer skips, read once and before anything is
+  # printed: the notes below are decided from them as well as reported by them,
+  # and a second copy of any of the tests is a place for the answers to drift
+  # apart.
   dot_git=0
   case "/$rel/" in
     */.git/*) dot_git=1 ;;
   esac
   own_ignore=0
   [ "${rel##*/}" != "$IGNORE_NAME" ] || own_ignore=1
+  own_modes=0
+  [ "${rel##*/}" != "$MODES_NAME" ] || own_modes=1
 
   # Whether the composer reaches this path at all, which is a component test
-  # where the note about the second name is a leaf test - deliberately, and the
-  # two must not be confused.  compose_dir drops both names by basename at every
-  # depth and does not descend, so nothing below a directory of either is
-  # composed either, while the note below says which layer's copy of *this*
-  # file is not composed and reads the leaf to say it.
+  # where the notes about the other two names are leaf tests - deliberately, and
+  # they must not be confused.  compose_dir drops all three names by basename at
+  # every depth and does not descend, so nothing below a directory of any of
+  # them is composed either, while the notes below say which layer's copy of
+  # *this* file is not composed and read the leaf to say it.
   unreached=0
   case "/$rel/" in
-    */.git/* | */"$IGNORE_NAME"/*) unreached=1 ;;
+    */.git/* | */"$IGNORE_NAME"/* | */"$MODES_NAME"/*) unreached=1 ;;
   esac
 
   # Whether the next build exits 1 at this path, decided before a line is
@@ -5828,6 +6495,11 @@ cmd_which() {
     emit "note: no build composes a $IGNORE_NAME — shale reads the one at the top of a clone root and copies none of them"
     # Accounted for, like the three above: only a hand puts one of these in the
     # built tree, and the line above says why no build did.
+    explained=1
+  fi
+  # The other file of shale's own, on the same terms and for the same reason.
+  if [ "$own_modes" -ne 0 ]; then
+    emit "note: no build composes a $MODES_NAME — shale reads the one at the top of a clone root and copies none of them"
     explained=1
   fi
 

--- a/tests/run
+++ b/tests/run
@@ -912,6 +912,19 @@ mkignore() {
   sandbox_write "$HOME/.dotfiles/$root" .shale-ignore ${1+"$@"}
 }
 
+# mkmodes ROOT LINE... - the mode file shale reads for the clone root ROOT,
+# which is $HOME/.dotfiles/ROOT/.shale-modes.  ROOT is the first component of a
+# layer path, exactly as mkignore takes it.
+mkmodes() {
+  local root=${1-}
+  [ -n "$root" ] || fail 'mkmodes: no clone root given'
+  shift
+  # .dotfiles on its own first, so a symlink there is refused before the path
+  # below it is looked at, exactly as mklayer does it.
+  sandbox_mkdir "$HOME/.dotfiles"
+  sandbox_write "$HOME/.dotfiles/$root" .shale-modes ${1+"$@"}
+}
+
 # inherit_shell_line LINE... - makes the shell that runs shale execute LINE
 # before shale's own first line.  In force for the rest of the case, each case
 # being its own subshell.
@@ -2292,25 +2305,22 @@ test_build_the_exec_bit_follows_the_winning_layer() {
   [ ! -x "$HOME/.dotfiles/current/.zshrc" ] || fail '.zshrc is executable'
 }
 
-# A layer's file modes are cp -RPp's to carry; its directory modes are shale's,
-# and before this they were nobody's - a directory was created by mkdir and took
-# whatever the caller's umask left, so the same layer produced a different tree
-# on every machine.  The four umasks are the ones people actually have: 0022 is
-# the common default and 0002 ships on Debian and Ubuntu with user-private
-# groups, which is the one that turns a 0700 .ssh into a group-writable
-# directory that OpenSSH's StrictModes then refuses.
+# A declared mode is the same on every machine, which is the whole point of
+# declaring one: the four umasks are the ones people actually have, 0022 being
+# the common default and 0002 the one Debian and Ubuntu ship with user-private
+# groups - the one that turns a 0700 .ssh into a group-writable directory
+# OpenSSH's StrictModes then refuses.
 #
-# The file beside it is asserted in the same loop: cp -RPp already carried its
-# mode, and a directory pass that reached a file would be a regression nothing
-# else here would see.
-test_build_a_directory_mode_comes_from_the_layer_and_not_the_umask() {
+# The file beside it is asserted in the same loop, and it is a declared file: a
+# mode on a file is as lost to a clone as a mode on a directory, and #123 was
+# closed on the grounds that shale must not guess which files are secret.  It
+# does not have to guess if it is told.
+test_build_a_declared_mode_is_the_same_at_every_umask() {
   local um saved
   conf 'base personal/base'
   mklayer personal/base .ssh/config
   mklayer personal/base .zshrc
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  chmod 0600 "$sandbox_dir/config" || fail 'could not set the layer file mode'
+  mkmodes personal '700  .ssh' '600  .ssh/config'
   saved=$(umask)
   for um in 0022 0002 0077 0000; do
     umask "$um"
@@ -2322,22 +2332,44 @@ test_build_a_directory_mode_comes_from_the_layer_and_not_the_umask() {
   done
 }
 
-# The file modes inside the directory whose mode is being set, pinned whole
-# rather than by the exec bit alone: the directory pass runs a chmod for every
-# directory it composes, and one written a level out - or a chmod -R - would
-# leave every file in the tree executable, or every private one readable, with
-# the build still exiting 0.  cp -RPp is what carries these, and nothing in the
-# directory pass may touch them.
-test_build_a_file_mode_is_untouched_by_the_directory_pass() {
+# The mode a declaration does not name.  Every composed directory is 0755 and no
+# layer has a say in it, at any umask - where before it was the mode of whatever
+# layer won the path, which on a cloned layer is the mode that clone's umask
+# gave it and nothing anybody committed.
+test_build_an_undeclared_directory_is_one_mode_whatever_the_layer_has() {
+  local um saved
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .private/f
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.private"
+  chmod 0777 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  saved=$(umask)
+  for um in 0022 0002 0077 0000; do
+    umask "$um"
+    run_shale build
+    umask "$saved"
+    assert_status 0 "$shale_status" "umask $um exit status"
+    assert_mode "$HOME/.dotfiles/current/.config" 'drwxr-xr-x' "umask $um"
+    assert_mode "$HOME/.dotfiles/current/.private" 'drwxr-xr-x' "umask $um"
+  done
+}
+
+# The file modes inside a directory a declaration names, pinned whole rather
+# than by the exec bit alone: a chmod written a level out - or a chmod -R -
+# would leave every file in the tree executable, or every private one readable,
+# with the build still exiting 0.  cp -RPp is what carries these, and nothing in
+# the declaration pass may touch a file it was not pointed at.
+test_build_a_file_mode_is_untouched_by_the_declaration_pass() {
   local um saved
   conf 'base personal/base'
   mklayer personal/base .ssh/config
   mklayer personal/base .local/bin/up
+  mkmodes personal '700  .ssh' '700  .local/bin'
   sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
   chmod 0600 "$sandbox_dir/config" || fail 'could not set the layer file mode'
   sandbox_mkdir "$HOME/.dotfiles/personal/base/.local/bin"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
   chmod 0755 "$sandbox_dir/up" || fail 'could not set the layer file mode'
   saved=$(umask)
   for um in 0000 0077; do
@@ -2350,45 +2382,84 @@ test_build_a_file_mode_is_untouched_by_the_directory_pass() {
   done
 }
 
-# The rule where two layers provide one directory, which is the rule their files
-# already have: the layer that wins is the last one listed that provides it.
-# Both directions, because a rule that only ever tightens and a rule that only
-# ever loosens would each pass half of this.
+# The footgun, gone.  A directory's mode was taken whole from the highest layer
+# *providing* it, and providing included contributing one file inside it - so a
+# local layer adding ~/.ssh/known_hosts took the mode of ~/.ssh from the base
+# layer that meant to set it, and the thing that changed the permission was not
+# the directory anybody edited.
 #
-# The trap it pins is the one worth having a case for: a base layer with .ssh at
-# 0700 and a local layer that adds one file to the same directory hands the mode
-# to the local layer, whatever the base layer says.
-test_build_a_directory_mode_follows_the_winning_layer() {
-  conf 'base personal/base' 'local local'
-  mklayer personal/base .config/git/config
-  mklayer local .config/nvim/init.lua
+# Both orders, because the old behaviour gave two different answers to them and
+# this must give one.  The layer directories are deliberately at odds with the
+# declaration and with each other: nothing in a working tree decides this now.
+test_build_a_declared_mode_does_not_move_when_a_layer_adds_a_file() {
+  conf 'base personal/base'
   mklayer personal/base .ssh/config
-  mklayer local .ssh/known_hosts
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/local/.config"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh'
   sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
   chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/local/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
   run_shale build
-  assert_status 0 "$shale_status"
-  assert_mode "$HOME/.dotfiles/current/.config" 'drwxr-xr-x' 'loosened by local'
-  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'tightened by local'
+  assert_status 0 "$shale_status" 'before the second layer'
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'one layer'
+  # The one edit: another layer contributes a file inside the declared
+  # directory, and its own copy of that directory is 0777.
+  conf 'base personal/base' 'local local'
+  mklayer local .ssh/known_hosts
+  sandbox_mkdir "$HOME/.dotfiles/local/.ssh"
+  chmod 0777 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  run_shale build
+  assert_status 0 "$shale_status" 'after the second layer'
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'the layer that added a file'
+  assert_eq 'local/.ssh/known_hosts' \
+    "$(cat "$HOME/.dotfiles/current/.ssh/known_hosts")" 'the added file'
+  # And with the config order reversed, which used to give the other answer.
+  conf 'local local' 'base personal/base'
+  run_shale build
+  assert_status 0 "$shale_status" 'config order reversed'
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'config order reversed'
 }
 
-# The owner's rwx is the one part of a directory mode shale does not copy, and
-# this is what it buys: a layer directory shale cannot write into cannot be
-# composed into either, and the next layer, the next build and cleanup's rm -rf
-# all have to get inside the one this build made.  The group and world bits are
-# copied whole, which is the half that decides whether a directory is safe.
-test_build_a_layer_directory_the_owner_cannot_write_gets_the_write_bit() {
+# Two clone roots declaring one path, which is the case config order settles -
+# like everything else in shale.  Both directions, because a rule that only ever
+# tightens and one that only ever loosens would each pass half of this.
+test_build_two_roots_declaring_one_path_resolve_by_config_order() {
+  conf 'base personal/base' 'work work/base'
+  mklayer personal/base .ssh/config
+  mklayer work/base .netrc
+  mkmodes personal '700  .ssh' '600  .netrc'
+  mkmodes work '755  .ssh' '644  .netrc'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwxr-xr-x' 'the later root loosens'
+  assert_mode "$HOME/.dotfiles/current/.netrc" '-rw-r--r--' 'the later root loosens'
+  conf 'work work/base' 'base personal/base'
+  run_shale build
+  assert_status 0 "$shale_status" 'config order reversed'
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'the later root tightens'
+  assert_mode "$HOME/.dotfiles/current/.netrc" '-rw-------' 'the later root tightens'
+}
+
+# Two lines in one file naming one path, which is the same rule one level down:
+# the last one read wins, and line order is what 'last' means inside a file.
+test_build_two_lines_declaring_one_path_resolve_by_line_order() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mkmodes personal '755  .ssh' '700  .ssh'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'the later line'
+}
+
+# The owner's rwx is the one part of a declared mode shale does not take
+# literally, and this is what it buys: a directory the owner cannot write cannot
+# be composed into either, and the next layer, the next build and cleanup's
+# rm -rf all have to get inside the one this build made.  The group and world
+# bits are taken exactly, which is the half that decides whether a directory is
+# safe.
+test_build_a_declared_directory_keeps_the_owners_rwx() {
   conf 'base personal/base'
   mklayer personal/base .private/inner/f
   mklayer personal/base .zshrc
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.private"
-  chmod 0550 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '050  .private'
   run_shale build
   assert_status 0 "$shale_status"
   assert_empty "$shale_err" 'stderr'
@@ -2401,10 +2472,6 @@ test_build_a_layer_directory_the_owner_cannot_write_gets_the_write_bit() {
   assert_eq 'personal/base/.private/inner/f' \
     "$(cat "$HOME/.dotfiles/current/.private/inner/f")" 'the composed file'
   assert_missing "$HOME/.dotfiles/current.old"
-  # The layer's own directory, put back: the runner's own rm -rf cannot descend
-  # one the owner may not write, and says so on an otherwise green run.
-  chmod 0755 "$HOME/.dotfiles/personal/base/.private" ||
-    fail 'could not restore the layer directory mode'
 }
 
 # The same clamp from the other side, and the reason it is not a preference: a
@@ -2416,10 +2483,10 @@ test_build_an_interrupt_leaves_no_scratch_tree_it_cannot_remove() {
   conf 'base personal/base'
   mklayer personal/base .private/inner/f
   mklayer personal/base .zshrc
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.private"
-  chmod 0500 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '000  .private'
   # The copy of the file inside it: by then the directory above has been created
-  # and given its mode, which is the state this is about.
+  # and the declaration pass has not run yet, so this is the tree at its widest
+  # spread of half-finished states.
   # shellcheck disable=SC2016  # the body runs in the stub, not here
   stub_interrupt cp '*.private/inner/f' '"$real" "$@" || exit $?'
   saved=$PATH
@@ -2432,23 +2499,50 @@ test_build_an_interrupt_leaves_no_scratch_tree_it_cannot_remove() {
   run_shale build
   assert_status 0 "$shale_status" 'the build after the interrupt'
   assert_empty "$shale_err" 'the build after the interrupt stderr'
-  chmod 0755 "$HOME/.dotfiles/personal/base/.private" ||
-    fail 'could not restore the layer directory mode'
+  # The declaration landed on the finished tree, with the owner's rwx forced on.
+  assert_mode "$HOME/.dotfiles/current/.private" 'drwx------' 'the composed directory'
 }
 
-# The two ways the mode of a composed directory can fail to be what the layer
-# says, both of which stop the build rather than leaving a tree whose modes
-# nobody can account for.  Neither tool is stubbed for the whole run: it is the
+# The same claim for the other window, which the case above cannot reach: the
+# declaration pass runs after everything is composed and before the two renames
+# that install the tree, so a build killed in between leaves a scratch tree with
+# every declared mode already on it.  A stub mv is what stops one with it still
+# standing, and the build after it has to reap the whole thing.
+#
+# 000 on the declaration, because that is the mode that would wedge every later
+# build on 'could not remove current.new' were the owner's rwx not forced on.
+# shellcheck disable=SC2123  # PATH is prefixed on purpose and restored below
+test_build_a_scratch_tree_left_after_the_declarations_is_still_removable() {
+  local saved_path
+  conf 'base personal/base'
+  mklayer personal/base .private/inner/f
+  mklayer personal/base .zshrc
+  mkmodes personal '000  .private' '000  .private/inner'
+  stub_mv '*/current.new' 1
+  saved_path=$PATH
+  PATH=$stub_path:$PATH
+  run_shale build
+  PATH=$saved_path
+  assert_status 1 "$shale_status"
+  assert_exists "$HOME/.dotfiles/current.new" 'the scratch tree the stub left'
+  assert_mode "$HOME/.dotfiles/current.new/.private" 'drwx------' 'the declared directory'
+  assert_mode "$HOME/.dotfiles/current.new/.private/inner" 'drwx------' 'one below it'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps the scratch tree'
+  assert_empty "$shale_err" 'the build that reaps the scratch tree stderr'
+  assert_missing "$HOME/.dotfiles/current.new"
+  assert_mode "$HOME/.dotfiles/current/.private" 'drwx------' 'the installed tree'
+}
+
+# A mode the build cannot set stops it, rather than leaving a tree whose modes
+# nobody can account for.  chmod is not stubbed for the whole run: it is the
 # first call matching the built tree that fails, so the failure lands where the
 # message says it does.
-test_build_a_directory_mode_it_cannot_set_stops_the_build() {
+test_build_a_declared_mode_it_cannot_set_stops_the_build() {
   local saved
   conf 'base personal/base'
   mklayer personal/base .ssh/config
-  # Set rather than inherited: the mode is in the message this asserts on, and
-  # the umask of whoever runs the suite must not decide what it says.
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh'
   stub_fail_once chmod '*current.new/.ssh'
   saved=$PATH
   PATH=$stub_path:$PATH
@@ -2456,25 +2550,389 @@ test_build_a_directory_mode_it_cannot_set_stops_the_build() {
   PATH=$saved
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" \
-    "shale: could not set the mode 0755 on $HOME/.dotfiles/current.new/.ssh" 'stderr'
+    "shale: could not set the mode 700 on $HOME/.dotfiles/current.new/.ssh" 'stderr'
   assert_missing "$HOME/.dotfiles/current"
 }
 
-test_build_a_directory_mode_it_cannot_read_stops_the_build() {
-  local saved
+# A declaration for a path since renamed is otherwise a silent no-op, and the
+# mode then goes missing on the next machine that clones the layer with every
+# command exiting 0.  The precedent is an ignore pattern shale cannot translate,
+# which stops the build; this stops it too, and names the file and the line so
+# that fixing it is one edit.
+test_build_a_declared_path_no_layer_provides_stops_the_build() {
   conf 'base personal/base'
   mklayer personal/base .ssh/config
-  stub_fail_once ls '*'
-  saved=$PATH
-  PATH=$stub_path:$PATH
+  mkmodes personal '700  .ssh' '600  .ssh/id_rsa'
   run_shale build
-  PATH=$saved
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" \
-    "shale: could not read the mode of $HOME/.dotfiles/personal/base/.ssh" 'stderr'
+    "shale: $HOME/.dotfiles/personal/.shale-modes:2: no layer provides '.ssh/id_rsa'" 'stderr'
   assert_contains "$shale_err" \
-    'shale:   shale copies a layer directory mode onto the one it composes' 'stderr'
+    'shale:   a mode declaration names a path in the tree a build composes, and nothing composes one at that path' 'stderr'
+  assert_contains "$shale_err" \
+    "shale: 1 mode declaration shale cannot act on; $HOME/.dotfiles/current not rebuilt" 'stderr'
   assert_missing "$HOME/.dotfiles/current"
+  # The line that is fine is not named, and the anchor is the whole prefix: a
+  # bare '.ssh' would be a substring of the '.ssh/id_rsa' line above.
+  assert_not_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1:" 'stderr'
+}
+
+# Every declaration is checked, not only the ones that win: a shadowed line
+# naming a path nothing provides is as stale as any other, and one nobody is
+# ever told about is the silence this whole check exists to remove.
+test_build_checks_a_shadowed_declaration_too() {
+  conf 'base personal/base' 'work work/base'
+  mklayer personal/base .ssh/config
+  mklayer work/base .zshrc
+  mkmodes personal '700  .gone'
+  mkmodes work '755  .gone'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: no layer provides '.gone'" 'stderr'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/work/.shale-modes:1: no layer provides '.gone'" 'stderr'
+  assert_contains "$shale_err" \
+    "shale: 2 mode declarations shale cannot act on; $HOME/.dotfiles/current not rebuilt" 'stderr'
+}
+
+# chmod follows a symlink, so honouring a declaration on one would set the mode
+# of whatever it points at, somewhere else entirely - and there is no portable
+# lchmod to do the other thing with.  Refused, with the file and the line.
+test_build_a_declared_path_that_is_a_symlink_stops_the_build() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base elsewhere/target
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  ln -s elsewhere/target "$sandbox_dir/.netrc" || fail 'could not make the layer link'
+  mkmodes personal '600  .netrc'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.netrc' is a symlink" 'stderr'
+  assert_contains "$shale_err" \
+    'shale:   shale sets a mode with chmod, which resolves every symlink on the way down and would set the mode of whatever the path ends at, outside both trees' 'stderr'
+  assert_missing "$HOME/.dotfiles/current"
+}
+
+# The same claim for a link *above* the declared path, which is the shape that
+# escaped both trees: chmod resolves every component, not the last one, so a
+# layer holding '.ssh' as a link and a line reading '666 .ssh/secret' set a file
+# outside $HOME to 0666 with build exiting 0 and saying nothing.  Nothing else
+# would have caught it either - build's chmod has no never-widen, and apply's
+# never-widen guards the path in $HOME rather than wherever it resolves to.
+#
+# Both spellings of the target, because a real layer holds the relative one and
+# only the absolute one is obvious.  The victim is outside $HOME entirely, and
+# the assertion that matters is its mode afterwards rather than the message.
+test_build_a_symlink_above_a_declared_path_stops_the_build() {
+  local spelling target victim
+  for spelling in absolute relative; do
+    conf 'base personal/base'
+    mklayer personal/base .zshrc
+    # Outside $HOME, which is the point: under $CASE_DIR rather than under it.
+    sandbox_write "$CASE_DIR/outside-$spelling" secret 'a file of somebody else'
+    victim=$sandbox_path
+    chmod 0600 "$victim" || fail 'could not set the victim mode'
+    sandbox_mkdir "$HOME/.dotfiles/personal/base"
+    rm -f "$sandbox_dir/.ssh" || fail 'could not clear the layer link'
+    if [ "$spelling" = absolute ]; then
+      target=$CASE_DIR/outside-$spelling
+    else
+      # The link sits in the layer directory, so the walk up is base, personal,
+      # .dotfiles, home - four - and then across into the case directory.
+      target=../../../../outside-$spelling
+    fi
+    ln -s "$target" "$sandbox_dir/.ssh" || fail 'could not make the layer link'
+    # The link has to resolve, or the case proves only that a dangling one is
+    # refused - which is a different bug.
+    assert_exists "$HOME/.dotfiles/personal/base/.ssh/secret" "$spelling: the link resolves"
+    mkmodes personal '666  .ssh/secret'
+    run_shale build
+    assert_status 1 "$shale_status" "$spelling"
+    assert_contains "$shale_err" \
+      "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.ssh' is a symlink, and '.ssh/secret' is below it" \
+      "$spelling"
+    assert_contains "$shale_err" \
+      'shale:   declare a path with no symlink on it: a symlink carries no mode of its own that shale can set' \
+      "$spelling"
+    assert_mode "$victim" '-rw-------' "$spelling: the file outside the trees"
+    assert_missing "$HOME/.dotfiles/current" "$spelling"
+  done
+}
+
+# The shallowest link is the one named, because that is the component to change;
+# the ones below it are only where the path happened to end up.
+test_build_names_the_shallowest_symlink_on_a_declared_path() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base real/inner/f
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  ln -s real "$sandbox_dir/.a" || fail 'could not make the layer link'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/real"
+  ln -s inner "$sandbox_dir/.b" || fail 'could not make the second layer link'
+  mkmodes personal '600  .a/.b/f'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.a' is a symlink, and '.a/.b/f' is below it" 'stderr'
+  assert_not_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.a/.b' is a symlink" 'stderr'
+}
+
+# doctor answers it against the layers, before any build and in build's words.
+test_doctor_names_a_symlink_above_a_declared_path() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base elsewhere/secret
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  ln -s elsewhere "$sandbox_dir/.ssh" || fail 'could not make the layer link'
+  mkmodes personal '666  .ssh/secret'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.ssh' is a symlink, and '.ssh/secret' is below it" \
+    'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # Blocking, and build agrees - which is the whole of what makes doctor's
+  # answer worth having before a build has run.
+  run_shale build
+  assert_status 1 "$shale_status" 'build'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.ssh' is a symlink, and '.ssh/secret' is below it" \
+    'build'
+}
+
+# and which says the build refuses it rather than naming a mode shale sets.
+test_which_names_a_symlink_above_a_declared_path() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base elsewhere/secret
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  ln -s elsewhere "$sandbox_dir/.ssh" || fail 'could not make the layer link'
+  mkmodes personal '666  .ssh/secret'
+  run_shale which .ssh/secret
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: note: '.ssh/secret' is declared mode 666 at $HOME/.dotfiles/personal/.shale-modes:1" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   '.ssh' is a symlink, and '.ssh/secret' is below it, so 'shale build' refuses the line" 'stderr'
+  # And it may not claim the chmod that build refuses to make.
+  assert_not_contains "$shale_err" \
+    "shale:   shale sets that mode on $HOME/.dotfiles/current/.ssh/secret" 'stderr'
+}
+
+# Setuid, setgid and the sticky bit are refused rather than ignored.  A layer
+# able to declare setgid on a directory in someone else's $HOME is a different
+# proposition from one declaring 700 - everything created inside such a
+# directory afterwards takes its group, including files no layer ever named -
+# and a mode somebody wrote that shale silently dropped is the one outcome that
+# teaches nothing.
+#
+# '0700' is refused by the same rule and is the spelling people have in their
+# fingers, so the message names the three digits to write instead.
+test_build_refuses_a_four_digit_mode() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mkmodes personal '2755  .ssh'
+  run_shale build
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '2755' is four octal digits, and shale takes three" 'stderr'
+  assert_contains "$shale_err" \
+    'shale:   setuid, setgid and the sticky bit are refused rather than set on a path in your home directory' 'stderr'
+  assert_contains "$shale_err" "shale:   write the permission bits alone: '755'" 'stderr'
+  assert_missing "$HOME/.dotfiles/current"
+  mkmodes personal '0700  .ssh'
+  run_shale build
+  assert_status 1 "$shale_status" 'a leading zero'
+  assert_contains "$shale_err" \
+    "shale:   write the permission bits alone: '700'" 'a leading zero'
+}
+
+# Exact paths only.  '600 .ssh/*' invites the whole translation problem
+# .shale-ignore needed and #96 records the cost of, and an exact path is also
+# what makes two roots declaring one path a thing a reader can see.
+test_build_refuses_a_glob_in_a_declared_path() {
+  local meta
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  for meta in '*' '?' '[' ']'; do
+    mkmodes personal "600  .ssh/x${meta}y"
+    run_shale build
+    assert_status 1 "$shale_status" "the metacharacter $meta"
+    assert_contains "$shale_err" \
+      "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.ssh/x${meta}y' contains '$meta'" \
+      "the metacharacter $meta"
+    assert_contains "$shale_err" \
+      'shale:   a declaration names one exact path, and there is no glob syntax here' \
+      "the metacharacter $meta"
+    assert_missing "$HOME/.dotfiles/current" "the metacharacter $meta"
+  done
+}
+
+# The rest of the syntax, each refusal naming what is wrong with the line rather
+# than the file.  A build stops at none of them silently, and every one of them
+# is a line somebody could plausibly write.
+test_build_refuses_a_declaration_it_cannot_read() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+
+  mkmodes personal '700'
+  run_shale build
+  assert_status 1 "$shale_status" 'a mode with no path'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '700' is a mode with no path after it" \
+    'a mode with no path'
+  assert_contains "$shale_err" \
+    "shale:   a declaration is a mode, whitespace and one path: '700  .ssh'" \
+    'a mode with no path'
+
+  mkmodes personal 'rwx  .ssh'
+  run_shale build
+  assert_status 1 "$shale_status" 'a symbolic mode'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: 'rwx' is not a mode" 'a symbolic mode'
+  assert_contains "$shale_err" \
+    "shale:   a mode is three octal digits, in chmod's own order: '700', '755', '600'" \
+    'a symbolic mode'
+
+  mkmodes personal '780  .ssh'
+  run_shale build
+  assert_status 1 "$shale_status" 'a digit above seven'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '780' is not a mode" 'a digit above seven'
+
+  mkmodes personal '700  /.ssh'
+  run_shale build
+  assert_status 1 "$shale_status" 'an absolute path'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '/.ssh' begins with '/'" 'an absolute path'
+  assert_contains "$shale_err" \
+    'shale:   a path is relative to the layer root, which is the top of the tree a layer mirrors' \
+    'an absolute path'
+
+  mkmodes personal '700  .ssh/'
+  run_shale build
+  assert_status 1 "$shale_status" 'a trailing slash'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.ssh/' ends in '/'" 'a trailing slash'
+
+  mkmodes personal '700  .ssh//config'
+  run_shale build
+  assert_status 1 "$shale_status" 'an empty component'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.ssh//config' has an empty path component" \
+    'an empty component'
+
+  mkmodes personal '700  .ssh/../.gnupg'
+  run_shale build
+  assert_status 1 "$shale_status" 'a relative component'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.ssh/../.gnupg' has a '..' component" \
+    'a relative component'
+  assert_contains "$shale_err" \
+    'shale:   a path is spelled out from the layer root, with nothing relative in it' \
+    'a relative component'
+
+  assert_missing "$HOME/.dotfiles/current" 'no build ran'
+}
+
+# Comments, blank lines and whitespace at both ends, which is also what makes a
+# file with CRLF line endings read the same as any other - and a path with a
+# space in it, which needs no quoting because only the first run of whitespace
+# separates the two fields.
+test_build_reads_the_mode_file_like_the_ignore_file() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mklayer personal/base 'my notes/f'
+  mkmodes personal \
+    '# a comment' \
+    '' \
+    '   700	.ssh   ' \
+    '	# an indented comment' \
+    '700  my notes'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'after the trims'
+  assert_mode "$HOME/.dotfiles/current/my notes" 'drwx------' 'a path with a space'
+}
+
+# Read by shale and composed by nothing, at every depth, exactly as
+# .shale-ignore is: a clone root may be named as a layer itself, which would
+# otherwise put the file in $HOME, and one deeper is read by nobody.
+test_build_composes_no_shale_modes_at_any_depth() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .config/f
+  mkmodes personal '700  .config'
+  # Inside a layer at three depths, none of them a clone root's own top.
+  sandbox_write "$HOME/.dotfiles/personal/base" .shale-modes '777  .zshrc'
+  sandbox_write "$HOME/.dotfiles/personal/base/.config" .shale-modes '777  .zshrc'
+  sandbox_write "$HOME/.dotfiles/local/.config" .shale-modes '777  .zshrc'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_missing "$HOME/.dotfiles/current/.shale-modes"
+  assert_missing "$HOME/.dotfiles/current/.config/.shale-modes"
+  # None of them was read either: the one at the top of the clone root is, and
+  # it is the only reason .config has a mode at all.
+  assert_mode "$HOME/.dotfiles/current/.config" 'drwx------' 'the file that is read'
+  assert_mode "$HOME/.dotfiles/current/.zshrc" '-rw-r--r--' 'the files that are not'
+}
+
+# A clone root named as a layer itself reads its own file and composes none of
+# it, which is the shape that would otherwise put the name in $HOME.
+test_build_reads_the_mode_file_of_a_root_that_is_a_layer() {
+  conf 'local local'
+  mklayer local .ssh/config
+  mkmodes local '700  .ssh'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_mode "$HOME/.dotfiles/current/.ssh" 'drwx------' 'the declared directory'
+  assert_missing "$HOME/.dotfiles/current/.shale-modes"
+}
+
+# The file itself, in the shapes that are not a file of declarations.  Both are
+# parse_ignore_files' arms, in its words, because both readers stop the same way.
+test_build_refuses_a_mode_file_it_cannot_read() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/.shale-modes"
+  run_shale build
+  assert_status 1 "$shale_status" 'a directory at the path'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes is not a regular file" 'a directory at the path'
+  assert_contains "$shale_err" \
+    'shale:   shale reads one mode file per clone root, and reads that one as lines of declarations' \
+    'a directory at the path'
+  rmdir "$HOME/.dotfiles/personal/.shale-modes" || fail 'could not remove the directory'
+  mkmodes personal '700  .ssh'
+  chmod 0000 "$HOME/.dotfiles/personal/.shale-modes" ||
+    fail 'could not make the mode file unreadable'
+  run_shale build
+  assert_status 1 "$shale_status" 'an unreadable file'
+  assert_contains "$shale_err" \
+    "shale: cannot read $HOME/.dotfiles/personal/.shale-modes: permission denied" \
+    'an unreadable file'
+  chmod 0644 "$HOME/.dotfiles/personal/.shale-modes" ||
+    fail 'could not restore the mode file'
+}
+
+# A path either ignore list covers still gets its declared mode in the built
+# tree - that tree is shale's own and holds the path whatever stow does with it
+# - and nothing is set in $HOME, which is the apply case below.
+test_build_sets_a_declared_mode_on_an_ignored_path() {
+  conf 'base personal/base'
+  mklayer personal/base .cache/junk
+  mklayer personal/base .zshrc
+  mkignore personal /.cache
+  mkmodes personal '700  .cache'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.dotfiles/current/.cache" 'drwx------' 'the built tree'
 }
 
 # The other half of the mode question, and the half no layer has a say in: the
@@ -5456,25 +5914,20 @@ test_apply_makes_real_directories_with_per_file_links() {
 # The other half of --no-folding: stow makes a real directory at every level,
 # and it makes it with mkdir and no mode, so what lands is 0777 against the
 # caller's umask and never the mode of the directory in the built tree.  That
-# was measured against GNU Stow 2.3.1 and 2.4.1, which agree on it, so the mode
-# in $HOME is shale's to set after stow has run and nobody else's.
+# was measured against GNU Stow 2.3.1 and 2.4.1, which agree on it, so a
+# declared mode in $HOME is shale's to set after stow has run and nobody else's.
 #
-# .ssh and .gnupg because they are where a reader meets this: 0700 in the layer
-# and 0775 in $HOME on an ordinary Ubuntu machine is a directory OpenSSH refuses
-# to use.  .config beside them at 0755 under a 0077 umask is the same claim
-# pointed the other way - the mode is the layer's, not the tightest thing going.
-test_apply_a_directory_mode_reaches_home_whatever_the_umask() {
+# .ssh and .gnupg because they are where a reader meets this: 700 declared and
+# 0775 in $HOME on an ordinary Ubuntu machine is a directory OpenSSH refuses to
+# use.  .config beside them at 755 under a 0077 umask is the same claim pointed
+# the other way - the mode is the one declared, not the tightest thing going.
+test_apply_a_declared_mode_reaches_home_whatever_the_umask() {
   local um saved
   conf 'base personal/base'
   mklayer personal/base .ssh/config
   mklayer personal/base .gnupg/gpg.conf
   mklayer personal/base .config/nvim/init.lua
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.gnupg"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh' '700  .gnupg' '755  .config'
   saved=$(umask)
   for um in 0022 0002 0077 0000; do
     umask "$um"
@@ -5490,6 +5943,60 @@ test_apply_a_directory_mode_reaches_home_whatever_the_umask() {
   done
 }
 
+# A declared file, which a clone loses exactly as it loses a directory - git
+# records one executable bit and nothing else.  The mode lands on the copy in
+# the built tree, and the link stow makes is what carries it into $HOME: reading
+# ~/.netrc reads that file through the link, at that mode, whatever the umask
+# of the machine that built it.
+test_apply_a_declared_file_mode_reaches_home_through_the_link() {
+  local um saved
+  conf 'base personal/base'
+  mklayer personal/base .netrc
+  mklayer personal/base .zshrc
+  mkmodes personal '600  .netrc'
+  saved=$(umask)
+  for um in 0022 0002 0077 0000; do
+    umask "$um"
+    run_shale apply
+    umask "$saved"
+    assert_status 0 "$shale_status" "umask $um exit status"
+    assert_empty "$shale_err" "umask $um stderr"
+    assert_symlink_to "$HOME/.netrc" "$HOME/.dotfiles/current/.netrc"
+    assert_mode "$HOME/.dotfiles/current/.netrc" '-rw-------' "umask $um"
+    assert_eq 'personal/base/.netrc' "$(cat "$HOME/.netrc")" 'through the link'
+  done
+}
+
+# The directory nobody declared, in the tree that is not shale's.  Its mode in
+# $HOME is stow's mkdir against the caller's umask, as it was before any of this
+# existed, and shale neither sets it nor has anything to say about it - which is
+# what stops one line in a layer's .shale-modes deciding the permissions of a
+# path nobody wrote a line about.
+#
+# The ~/.config here is deliberately tighter than the layer's copy: under the
+# old rule that was a widening shale declined and reported.  Now there is
+# nothing to report, because there is nothing shale was asked to do.
+test_apply_sets_no_mode_on_a_directory_no_line_declares() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  sandbox_mkdir "$HOME/.config"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'stderr'
+  assert_mode "$HOME/.config" 'drwx------' 'the directory that was already there'
+  assert_mode "$HOME/.dotfiles/current/.config" 'drwxr-xr-x' 'the built tree'
+  assert_symlink_to "$HOME/.config/nvim/init.lua" \
+    "$HOME/.dotfiles/current/.config/nvim/init.lua"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor'
+  assert_not_contains "$shale_out" \
+    "shale: an apply left 1 directory in $HOME as it is" 'doctor'
+}
+
 # Twice, because an apply reads the built tree and the second one reads it again
 # through a $HOME full of links into it: stow runs as the owner and so does
 # everything else here, which is the whole of what makes a built tree nobody but
@@ -5497,19 +6004,17 @@ test_apply_a_directory_mode_reaches_home_whatever_the_umask() {
 # could not descend current/ is the shape a mode that only looked tight enough
 # would leave.
 #
-# The modes in $HOME are asserted beside it, and they are the layer's rather than
-# the built tree's: the two trees are owned by different people, and shale's own
-# mode may not leak into the one it does not own.  .config at 0755 is what says
-# so - 0700 in $HOME would be this fix reaching a directory it has no business in.
+# The modes in $HOME are asserted beside it, and they are the declared ones
+# rather than the built tree's: the two trees are owned by different people, and
+# shale's own mode may not leak into the one it does not own.  .config at 755 is
+# what says so - 0700 in $HOME would be this reaching a directory it has no
+# business in.
 test_apply_works_twice_over_a_built_tree_only_its_owner_can_enter() {
   conf 'base personal/base'
   mklayer personal/base .ssh/config
   mklayer personal/base .config/nvim/init.lua
   mklayer personal/base .zshrc
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh' '755  .config'
   run_shale apply
   assert_status 0 "$shale_status" 'the first apply'
   assert_empty "$shale_err" 'the first apply stderr'
@@ -5518,42 +6023,40 @@ test_apply_works_twice_over_a_built_tree_only_its_owner_can_enter() {
   assert_status 0 "$shale_status" 'the second apply'
   assert_empty "$shale_err" 'the second apply stderr'
   assert_mode "$HOME/.dotfiles/current" 'drwx------' 'the built tree'
-  assert_mode "$HOME/.ssh" 'drwx------' 'the layer mode in the home directory'
-  assert_mode "$HOME/.config" 'drwxr-xr-x' 'the layer mode in the home directory'
+  assert_mode "$HOME/.ssh" 'drwx------' 'the declared mode in the home directory'
+  assert_mode "$HOME/.config" 'drwxr-xr-x' 'the declared mode in the home directory'
   # Read through the links rather than only listed: the mode of the directory
   # they resolve through is what decides whether any of this is reachable.
   assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.zshrc")" 'through the link'
   assert_eq 'personal/base/.ssh/config' "$(cat "$HOME/.ssh/config")" 'through the link'
 }
 
-# The two-layer rule as it lands in $HOME, which is the tree the rule is about.
-test_apply_a_directory_mode_follows_the_winning_layer() {
-  conf 'base personal/base' 'local local'
+# Two clone roots declaring one path, as it lands in $HOME - which is the tree
+# the question is about.
+test_apply_two_roots_declaring_one_path_resolve_by_config_order() {
+  conf 'base personal/base' 'work work/base'
   mklayer personal/base .ssh/config
-  mklayer local .ssh/known_hosts
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/local/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mklayer work/base .ssh/known_hosts
+  mkmodes personal '755  .ssh'
+  mkmodes work '700  .ssh'
   run_shale apply
   assert_status 0 "$shale_status"
-  assert_mode "$HOME/.ssh" 'drwx------' 'the last layer that provides it'
+  assert_mode "$HOME/.ssh" 'drwx------' 'the last root that declares it'
   assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
   assert_symlink_to "$HOME/.ssh/known_hosts" \
     "$HOME/.dotfiles/current/.ssh/known_hosts"
 }
 
-# A mode that could not be set is the failure this whole change exists to stop
-# being silent, so it is named and it costs the exit status - after every other
-# one has been attempted, so one directory shale does not own cannot hide the
-# rest.  The links are already in place at that point, and the message says so
-# rather than sending the reader to apply again.
+# A mode that could not be set is the failure this whole mechanism exists to
+# stop being silent, so it is named and it costs the exit status - after every
+# other one has been attempted, so one directory shale does not own cannot hide
+# the rest.  The links are already in place at that point, and the message says
+# so rather than sending the reader to apply again.
 test_apply_a_mode_it_cannot_set_is_named_and_the_links_are_still_made() {
   local saved
   conf 'base personal/base'
   mklayer personal/base .ssh/config
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh'
   # The apply's chmod and not the build's: the sandbox home is the one path
   # ending in '/home/.ssh', and the built tree's ends in 'current.new/.ssh'.
   # One word, because the stub writes the pattern into a case arm.
@@ -5563,26 +6066,25 @@ test_apply_a_mode_it_cannot_set_is_named_and_the_links_are_still_made() {
   run_shale apply
   PATH=$saved
   assert_status 1 "$shale_status"
-  assert_contains "$shale_err" "shale: could not set the mode 0700 on $HOME/.ssh" 'stderr'
+  assert_contains "$shale_err" "shale: could not set the mode 700 on $HOME/.ssh" 'stderr'
   assert_contains "$shale_err" \
     "shale: could not set the mode on 1 directory; $HOME is linked" 'stderr'
   assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
 }
 
-# The clone case, which is the ordinary one rather than a corner: git records no
-# mode for a directory, so a freshly cloned .ssh layer is whatever the clone's
-# umask gave it - 0755 on most machines - while the ~/.ssh the user already has,
-# holding a private key, is 0700.  Copying the layer's mode there would open it
-# up, silently, on the path everybody takes.  So a directory that was in $HOME
-# before the apply is only ever narrowed, and shale says which ones it left.
+# Never-widen, which is the piece of #119 that survives the declaration: a
+# declaration is a layer author's intent and the mode on the machine is the
+# user's, and a '755 .ssh' against a ~/.ssh the user keeps at 0700 with a
+# private key in it would open it up, silently, on the ordinary
+# clone-then-apply path.  So a directory that was in $HOME before the apply is
+# only ever narrowed, and shale says which ones it left.
 #
 # The status stays 0: nothing the apply was asked to do was left undone, and the
 # mode that survives is the safer of the two.
 test_apply_never_widens_a_directory_that_was_already_there() {
   conf 'base personal/base'
   mklayer personal/base .ssh/config
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '755  .ssh'
   sandbox_mkdir "$HOME/.ssh"
   chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
   run_shale apply
@@ -5591,21 +6093,22 @@ test_apply_never_widens_a_directory_that_was_already_there() {
   # The links are made all the same: this is about the directory's mode and
   # nothing else.
   assert_symlink_to "$HOME/.ssh/config" "$HOME/.dotfiles/current/.ssh/config"
-  # The built tree keeps the layer's mode, because it is shale's own tree.
+  # The built tree keeps the declared mode, because it is shale's own tree.
   assert_mode "$HOME/.dotfiles/current/.ssh" 'drwxr-xr-x' 'the built tree'
-  # One line and no more.  What is left is the ordinary state of anyone who has
-  # cloned a layer with a .ssh in it, so it is printed on every apply for as
-  # long as it lasts, and a block of lines there would be a block on every
-  # apply.  The paths and the modes are doctor's, which is where a standing
-  # condition goes; this line is the pointer to it.
+  # One line and no more.  What is left is a standing disagreement between a
+  # layer and a machine, so it is printed on every apply for as long as it
+  # lasts, and a block of lines there would be a block on every apply.  The
+  # paths and the modes are doctor's, which is where a standing condition goes;
+  # this line is the pointer to it.
   assert_contains "$shale_err" \
     "shale: 1 directory in $HOME was left as it is: shale never widens one that was already there; 'shale doctor' names it" \
     'stderr'
-  assert_not_contains "$shale_err" '0755' 'the mode detail belongs to doctor'
+  assert_not_contains "$shale_err" \
+    "shale: an apply left 1 directory in $HOME as it is" 'the detail belongs to doctor'
   assert_eq 1 "$(printf '%s\n' "$shale_err" | grep -c '^shale: ')" 'lines shale printed'
   # Twice, because a mode shale is deliberately not setting is a standing
-  # difference between the layer and $HOME rather than a one-run event, and the
-  # second apply is the one people run.
+  # difference between the declaration and $HOME rather than a one-run event,
+  # and the second apply is the one people run.
   run_shale apply
   assert_status 0 "$shale_status" 'the second apply'
   assert_mode "$HOME/.ssh" 'drwx------' 'the second apply'
@@ -5614,15 +6117,13 @@ test_apply_never_widens_a_directory_that_was_already_there() {
     'the second apply stderr'
 }
 
-# The other direction, which is #119's own case and is not a widening: a ~/.ssh
-# that is already there at 0755 and a layer that says 0700 is narrowed, without
-# a word, because that is the mode the layer asked for and nothing is lost by
-# it.
+# The other direction, which is not a widening: a ~/.ssh that is already there
+# at 0755 and a declaration of 700 is narrowed, without a word, because that is
+# the mode the line asked for and nothing is lost by it.
 test_apply_narrows_a_directory_that_was_already_there() {
   conf 'base personal/base'
   mklayer personal/base .ssh/config
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh'
   sandbox_mkdir "$HOME/.ssh"
   chmod 0755 "$sandbox_dir" || fail 'could not set the home directory mode'
   run_shale apply
@@ -5635,21 +6136,18 @@ test_apply_narrows_a_directory_that_was_already_there() {
 # stow, so nothing of shale's is ever linked into the $HOME directory of that
 # name: it is the user's, holding the user's files, and 'shale which' says so in
 # as many words.  Setting a mode on it would be shale acting on the one class of
-# path it promises not to touch.
+# path it promises not to touch, declaration or no declaration.
 #
 # The pattern is anchored, so it matches '.cache' and not the 'inner' below it -
-# which is what makes this a case about the carry rather than about the matcher.
-# Without it, a descendant of a matched directory reads as unignored, and the
-# apply chmods a directory two levels inside one it was told to skip.
+# which is what makes this a case about the ancestors rather than about the
+# matcher.  Without that walk a declaration two levels inside an ignored
+# directory would be chmodded in a $HOME shale was told to leave alone.
 test_apply_says_nothing_at_a_path_an_ignore_file_blocks() {
   conf 'base personal/base'
   mklayer personal/base .cache/inner/junk
   mklayer personal/base .zshrc
   mkignore personal /.cache
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache/inner"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '755  .cache' '755  .cache/inner'
   sandbox_mkdir "$HOME/.cache/inner"
   chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
   sandbox_mkdir "$HOME/.cache"
@@ -5665,15 +6163,12 @@ test_apply_says_nothing_at_a_path_an_ignore_file_blocks() {
 
 # The same claim for the list stow ships, which no ignore file has to mention
 # and which every apply uses: .hg is on it, so nothing is linked into ~/.hg and
-# its mode is not shale's to set.
+# its mode is not shale's to set however many lines declare one.
 test_apply_says_nothing_at_a_path_stows_own_list_blocks() {
   conf 'base personal/base'
   mklayer personal/base .hg/store/f
   mklayer personal/base .zshrc
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.hg"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.hg/store"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '755  .hg' '755  .hg/store'
   sandbox_mkdir "$HOME/.hg/store"
   chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
   sandbox_mkdir "$HOME/.hg"
@@ -5700,6 +6195,7 @@ test_apply_a_mode_it_cannot_set_keeps_what_stow_wrote() {
   mklayer personal/base .zshrc
   mklayer personal/base .dotfiles/notes
   mklayer personal/base .config/nvim/init.lua
+  mkmodes personal '755  .config'
   stub_fail_once chmod '*/home/.config'
   saved=$PATH
   PATH=$stub_path:$PATH
@@ -8659,27 +9155,26 @@ test_doctor_a_missing_chkstow_warns_without_failing() {
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
 }
 
-# ------------------------------------------ doctor's directory-mode cases
+# ------------------------------------------ doctor's declared-mode cases
 #
 # The other half of the one line an apply prints when it leaves a directory as
-# it is.  doctor makes the same judgement from the two trees rather than from
-# anything the apply recorded, so these cases are what say the two agree.
+# it is, and the declarations that never reached $HOME at all.  doctor makes the
+# same judgement from what is on disk rather than from anything an apply
+# recorded, so these cases are what say the two agree.
 
-# The detail, and the standing condition it describes: a cloned .ssh layer is
-# 0755 because git records no mode for a directory, the ~/.ssh holding the key
-# is 0700, and no apply resolves that on its own.
+# The detail, and the standing condition it describes: a layer declaring 755 on
+# .ssh, a ~/.ssh at 0700 holding the key, and no apply that resolves it.
 #
 # A note, and the exit status is the claim: the only difference that can persist
-# is the layer being looser than $HOME - the other direction is narrowed by the
-# next apply and gone - so what is left is a directory safer than the layer asks
-# for, which is shale working rather than a problem.  A finding would make
-# doctor red by default for everyone who has cloned a layer with a .ssh in it,
-# and a red doctor on a machine that is fine is a signal nobody reads twice.
+# is the declaration being looser than $HOME - the other direction is narrowed
+# by the next apply and gone - so what is left is a directory safer than the
+# layer asks for, which is shale working rather than a problem.  A finding would
+# make doctor red on a machine that is fine, and that is a signal nobody reads
+# twice.
 test_doctor_names_a_directory_an_apply_left_as_it_is() {
   conf 'base personal/base'
   mklayer personal/base .ssh/config
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '755  .ssh'
   sandbox_mkdir "$HOME/.ssh"
   chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
   run_shale apply
@@ -8689,14 +9184,14 @@ test_doctor_names_a_directory_an_apply_left_as_it_is() {
   assert_contains "$shale_out" \
     "shale: an apply left 1 directory in $HOME as it is" 'stdout'
   assert_contains "$shale_out" \
-    "shale:   $HOME/.ssh is 0700, and the layer that provides it gives 0755" 'stdout'
+    "shale:   $HOME/.ssh is 700, and shale is asked for 755" 'stdout'
   assert_contains "$shale_out" \
     "shale:   shale sets the mode of a directory it creates in $HOME, and never widens one that was already there" \
     'stdout'
   assert_contains "$shale_out" \
-    'shale:   to take the mode the layer gives, chmod that directory yourself' 'stdout'
+    'shale:   to take the mode the declaration asks for, chmod that directory yourself' 'stdout'
   assert_contains "$shale_out" \
-    "shale:   to keep the mode it has, set that mode on the directory in the layer: 'shale which' names the layer for a path" \
+    "shale:   to keep the mode it has, change the declaration: 'shale which' names the line that decides a path" \
     'stdout'
   # One note for the class however many directories are in it, so the summary
   # counts it once.
@@ -8708,18 +9203,18 @@ test_doctor_names_a_directory_an_apply_left_as_it_is() {
   run_shale doctor
   assert_status 0 "$shale_status" 'doctor after the second apply'
   assert_contains "$shale_out" \
-    "shale:   $HOME/.ssh is 0700, and the layer that provides it gives 0755" 'the second report'
+    "shale:   $HOME/.ssh is 700, and shale is asked for 755" 'the second report'
   # And it ends when either side is changed, which is what makes it worth
   # printing rather than nagging.
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh'
   run_shale apply
-  assert_status 0 "$shale_status" 'the apply after the layer was fixed'
-  assert_empty "$shale_err" 'the apply after the layer was fixed'
+  assert_status 0 "$shale_status" 'the apply after the declaration was fixed'
+  assert_empty "$shale_err" 'the apply after the declaration was fixed'
   run_shale doctor
-  assert_status 0 "$shale_status" 'doctor after the layer was fixed'
+  assert_status 0 "$shale_status" 'doctor after the declaration was fixed'
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
-  assert_not_contains "$shale_out" 'left 1 directory' 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: an apply left 1 directory in $HOME as it is" 'stdout'
 }
 
 # The note may not swallow a real problem, and a real problem may not swallow
@@ -8733,8 +9228,7 @@ test_doctor_a_left_directory_note_sits_beside_a_real_finding() {
   conf 'base personal/base'
   mklayer personal/base .ssh/config
   mklayer personal/base .config/nvim/init.lua
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '755  .ssh'
   sandbox_mkdir "$HOME/.ssh"
   chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
   run_shale apply
@@ -8752,42 +9246,38 @@ test_doctor_a_left_directory_note_sits_beside_a_real_finding() {
   assert_contains "$shale_out" \
     "shale: an apply left 1 directory in $HOME as it is" 'stdout'
   assert_contains "$shale_out" \
-    "shale:   $HOME/.ssh is 0700, and the layer that provides it gives 0755" 'stdout'
+    "shale:   $HOME/.ssh is 700, and shale is asked for 755" 'stdout'
   assert_contains "$shale_out" \
-    'shale:   to take the mode the layer gives, chmod that directory yourself' 'stdout'
+    'shale:   to take the mode the declaration asks for, chmod that directory yourself' 'stdout'
 }
 
-# The other direction is not a finding: the built tree is tighter than $HOME, so
-# the next apply narrows the directory and says nothing.  Reporting it would be
-# doctor naming a difference that fixes itself.
+# The other direction is not a finding: the declaration is tighter than $HOME,
+# so the next apply narrows the directory and says nothing.  Reporting it would
+# be doctor naming a difference that fixes itself.
 test_doctor_says_nothing_where_the_next_apply_narrows_the_directory() {
   conf 'base personal/base'
   mklayer personal/base .ssh/config
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.ssh"
-  chmod 0700 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '700  .ssh'
   sandbox_mkdir "$HOME/.ssh"
   chmod 0755 "$sandbox_dir" || fail 'could not set the home directory mode'
   run_shale build
   assert_status 0 "$shale_status"
   run_shale doctor
   assert_status 0 "$shale_status" 'doctor exit status'
-  assert_not_contains "$shale_out" 'left as it is' 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: an apply left 1 directory in $HOME as it is" 'stdout'
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
 }
 
-# doctor's walk has its own copy of the ignore carry, so it gets its own case: a
-# mode difference at a path no apply touches is not a difference doctor may
-# report, or the report sends a reader to fix something shale would never act
-# on.
+# A declaration at a path either ignore list covers is one no apply acts on, so
+# it is not one doctor may report either - in $HOME or below it.  A report there
+# sends a reader to fix something shale would never touch.
 test_doctor_says_nothing_about_the_mode_of_an_ignored_directory() {
   conf 'base personal/base'
   mklayer personal/base .cache/inner/junk
   mklayer personal/base .zshrc
   mkignore personal /.cache
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
-  sandbox_mkdir "$HOME/.dotfiles/personal/base/.cache/inner"
-  chmod 0755 "$sandbox_dir" || fail 'could not set the layer directory mode'
+  mkmodes personal '755  .cache' '755  .cache/inner'
   sandbox_mkdir "$HOME/.cache/inner"
   chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
   sandbox_mkdir "$HOME/.cache"
@@ -8797,9 +9287,176 @@ test_doctor_says_nothing_about_the_mode_of_an_ignored_directory() {
   assert_empty "$shale_err" 'stderr'
   run_shale doctor
   assert_status 0 "$shale_status" 'doctor exit status'
-  assert_not_contains "$shale_out" 'left as it is' 'stdout'
-  assert_not_contains "$shale_out" "$HOME/.cache is" 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: an apply left 1 directory in $HOME as it is" 'stdout'
+  assert_not_contains "$shale_out" "shale:   $HOME/.cache is" 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: 1 declared mode is not on anything in $HOME" 'stdout'
 }
+
+# The other shape a declaration can fail in: the build composed the path with
+# the mode on it, and stow did not link it - so the mode is in the built tree
+# and on nothing anybody uses.  A note, because every cause of it is something
+# else's finding or something else's note, and what is missing is the plain fact
+# that the mode the reader wrote is not on the machine.
+#
+# The rig removes the link an apply made, which is the state itself and not a
+# way of reaching it: the tree holds the path with the mode on it and $HOME has
+# nothing at it.  A stow that declined the path - an --ignore in a resource
+# file, an option shale does not model - leaves the same state by another route,
+# and doctor cannot tell the two apart or claim to.  Not a conflicting file in
+# $HOME, because stow abandons the whole operation on one - measured on 2.3.1
+# and 2.4.1, which agree - so that rig links nothing at all and proves the note
+# fires on a machine that has never applied instead.
+test_doctor_names_a_declared_mode_that_is_not_in_home() {
+  conf 'base personal/base'
+  mklayer personal/base .netrc
+  mklayer personal/base .zshrc
+  mkmodes personal '600  .netrc'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_symlink_to "$HOME/.netrc" "$HOME/.dotfiles/current/.netrc"
+  rm -f "$HOME/.netrc" || fail 'could not remove the link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: 1 declared mode is not on anything in $HOME" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.dotfiles/personal/.shale-modes:1 declares 600, and nothing in $HOME is at $HOME/.netrc" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   the built tree holds each of these paths with the declared mode on it, and an apply is what puts one in $HOME" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   'shale which PATH' says why a path in the tree is not linked" 'stdout'
+  # The mode is on the copy in the tree all the same, which is what the note
+  # says and what makes it a note rather than a finding.
+  assert_mode "$HOME/.dotfiles/current/.netrc" '-rw-------' 'the built tree'
+}
+
+# And nothing of the sort on a machine that has built and never applied: every
+# declaration is in that state at once, and the note would be the same fact
+# repeated per line beside audit_unapplied_tree's one line about the whole tree.
+test_doctor_says_nothing_about_declared_modes_before_the_first_apply() {
+  conf 'base personal/base'
+  mklayer personal/base .netrc
+  mklayer personal/base .ssh/config
+  mkmodes personal '600  .netrc' '700  .ssh'
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: nothing in the built tree at $HOME/.dotfiles/current is linked in $HOME" 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: 1 declared mode is not on anything in $HOME" 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: 2 declared modes are not on anything in $HOME" 'stdout'
+}
+
+# build's refusals, in build's own words and without a build: doctor reads the
+# layers, so a declaration naming a path no layer provides is named before the
+# tree it would have stopped exists.  Blocking, because build calls the same
+# parse and stops at the same line, so nothing below may offer a build.
+test_doctor_names_a_declared_path_no_layer_provides() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mkmodes personal '700  .ssh'
+  # A tree first, so that the line about applying one is a line doctor would
+  # otherwise print: without it the 'blocking' assertion below is about a
+  # sentence nothing in this rig could ever say.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build before the declaration went stale'
+  mkmodes personal '700  .ssh' '600  .ssh/id_rsa'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:2: no layer provides '.ssh/id_rsa'" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   a mode declaration names a path in the tree a build composes, and nothing composes one at that path' \
+    'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # Blocking: nothing offers a build that would die on the same line.
+  assert_contains "$shale_out" \
+    'shale:   no apply will finish until the problems above are fixed' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   apply it with: shale apply' 'stdout'
+  # And build agrees, which is the whole of what makes doctor's answer worth
+  # having before a build has ever run.
+  run_shale build
+  assert_status 1 "$shale_status" 'build'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:2: no layer provides '.ssh/id_rsa'" 'build'
+}
+
+# The same for a declaration on a symlink, which chmod would follow.
+test_doctor_names_a_declared_path_that_is_a_symlink() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base elsewhere/target
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  ln -s elsewhere/target "$sandbox_dir/.netrc" || fail 'could not make the layer link'
+  mkmodes personal '600  .netrc'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '.netrc' is a symlink" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   declare a path with no symlink on it: a symlink carries no mode of its own that shale can set' 'stdout'
+  run_shale build
+  assert_status 1 "$shale_status" 'build'
+}
+
+# A line shale will not read is a finding of doctor's and stops a build, exactly
+# as an untranslatable ignore pattern does.
+test_doctor_counts_a_refused_declaration_as_a_finding() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  # A tree first, for the reason above: the line the refusal has to suppress is
+  # one doctor prints about a tree nothing has applied.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build before the line was written'
+  mkmodes personal '4700  .ssh'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/personal/.shale-modes:1: '4700' is four octal digits, and shale takes three" \
+    'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   no apply will finish until the problems above are fixed' 'stdout'
+  assert_not_contains "$shale_out" 'shale:   apply it with: shale apply' 'stdout'
+}
+
+# A .shale-modes shale does not read: beside the config, or anywhere inside a
+# layer, which is where somebody puts one having read that it lives at the top
+# of a clone root.  Neither is read and neither is composed, so without this the
+# declarations in it are silence a reader cannot tell from a working setup.
+test_doctor_names_a_mode_file_that_is_read_by_nothing() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_write "$HOME/.dotfiles" .shale-modes '700  .ssh'
+  sandbox_write "$HOME/.dotfiles/personal/base" .shale-modes '700  .ssh'
+  sandbox_write "$HOME/.dotfiles/personal/base/.config" .shale-modes '700  .ssh'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/.shale-modes is read by nothing" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   shale reads one .shale-modes per clone root, at $HOME/.dotfiles/<root>/.shale-modes" \
+    'stdout'
+  assert_contains "$shale_out" \
+    'shale:   move it into the clone root whose layers it is about' 'stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/personal/base/.shale-modes is read by nothing" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/personal/base/.config/.shale-modes is read by nothing" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   one list covers the whole built tree, so a layer cannot have declarations of its own' \
+    'stdout'
+  # Notes, not problems: nothing is broken by a file nobody reads.
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
 
 # The built tree's own mode, which is shale's rather than any layer's and is the
 # one directory every symlink in $HOME resolves through.  A note and never a
@@ -13661,6 +14318,170 @@ test_which_a_layer_shipping_an_ignore_file_says_no_build_composes_one() {
   run_shale build
   assert_status 0 "$shale_status" 'the build'
   assert_missing "$HOME/.dotfiles/current/.config/.shale-ignore"
+}
+
+# The other file of shale's own, on the same terms: composed by nothing at any
+# depth, and which says so where the table above names the layer holding it.
+test_which_a_layer_shipping_a_mode_file_says_no_build_composes_one() {
+  conf 'base common/base'
+  mklayer common/base .config/.shale-modes 'read by nothing'
+  run_shale which .config/.shale-modes
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "winner    base  $HOME/.dotfiles/common/base/.config/.shale-modes" 'stdout'
+  assert_eq 'shale: note: no build composes a .shale-modes — shale reads the one at the top of a clone root and copies none of them' \
+    "$shale_err" 'stderr'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_missing "$HOME/.dotfiles/current/.config/.shale-modes"
+}
+
+# The line that decides a path, named with its file and its line - which is the
+# whole of what makes precedence between two clone roots visible.  Config order
+# settles it, as it settles everything else, and the shadowed line is named
+# beside the winner so that the reader can see both.
+test_which_names_the_declaration_that_decides_a_path() {
+  conf 'base personal/base' 'work work/base'
+  mklayer personal/base .ssh/config
+  mklayer work/base .ssh/known_hosts
+  mkmodes personal '700  .ssh'
+  mkmodes work '755  .ssh'
+  run_shale which .ssh
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale: note: '.ssh' is declared mode 755 at $HOME/.dotfiles/work/.shale-modes:1" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   shadowed: $HOME/.dotfiles/personal/.shale-modes:1 declares 700" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   shale sets that mode on $HOME/.dotfiles/current/.ssh" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   and on $HOME/.ssh, where it never widens a directory that was already there" 'stderr'
+  # And the answer follows the config, which is the claim.
+  conf 'work work/base' 'base personal/base'
+  run_shale which .ssh
+  assert_status 0 "$shale_status" 'config order reversed'
+  assert_contains "$shale_err" \
+    "shale: note: '.ssh' is declared mode 700 at $HOME/.dotfiles/personal/.shale-modes:1" \
+    'config order reversed'
+  assert_contains "$shale_err" \
+    "shale:   shadowed: $HOME/.dotfiles/work/.shale-modes:1 declares 755" 'config order reversed'
+}
+
+# A declared file, whose mode reaches $HOME through the link rather than by a
+# chmod there: shale sets nothing on the path in $HOME, and the note may not say
+# it does.  What is at the path is a link into the built tree, and the mode the
+# build put on that copy is what a reader gets through it.
+test_which_a_declared_file_says_the_mode_travels_through_the_link() {
+  conf 'base personal/base'
+  mklayer personal/base .netrc
+  mklayer personal/base .zshrc
+  mkmodes personal '600  .netrc'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  run_shale which .netrc
+  assert_status 0 "$shale_status" 'which'
+  assert_contains "$shale_err" \
+    "shale:   shale sets that mode on $HOME/.dotfiles/current/.netrc" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   $HOME/.netrc is a link into that tree, so that is the mode read through it" 'stderr'
+  assert_not_contains "$shale_err" \
+    "shale:   and on $HOME/.netrc, where it never widens a directory that was already there" 'stderr'
+}
+
+# And nothing at all about $HOME for a declared file the tree holds and nothing
+# links: the residual note at the end of the answer is what speaks there, and
+# doctor carries the same fact as a note of its own.
+test_which_a_declared_file_that_is_not_linked_claims_nothing_about_home() {
+  conf 'base personal/base'
+  mklayer personal/base .netrc
+  mklayer personal/base .zshrc
+  mkmodes personal '600  .netrc'
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale which .netrc
+  assert_status 0 "$shale_status" 'which'
+  assert_contains "$shale_err" \
+    "shale:   shale sets that mode on $HOME/.dotfiles/current/.netrc" 'stderr'
+  assert_not_contains "$shale_err" \
+    "shale:   $HOME/.netrc is a link into that tree, so that is the mode read through it" 'stderr'
+  assert_not_contains "$shale_err" \
+    "shale:   and on $HOME/.netrc, where it never widens a directory that was already there" 'stderr'
+  # The residual note is the one that speaks about $HOME here.
+  assert_contains "$shale_err" \
+    "shale: note: '.netrc' is in the built tree at $HOME/.dotfiles/current/.netrc, and nothing is at $HOME/.netrc" \
+    'stderr'
+}
+
+# A path an ignore list covers: no apply links one, so no apply sets a mode on
+# one, and the note two lines below this one says so in as many words.  An
+# unconditional claim here contradicted it in the same answer.
+test_which_an_ignored_declared_path_claims_no_mode_in_home() {
+  conf 'base personal/base'
+  mklayer personal/base .cache/inner/junk
+  mklayer personal/base .zshrc
+  mkignore personal /.cache
+  mkmodes personal '700  .cache' '700  .cache/inner'
+  run_shale which .cache
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_err" \
+    "shale:   shale sets that mode on $HOME/.dotfiles/current/.cache" 'stderr'
+  assert_not_contains "$shale_err" \
+    "shale:   and on $HOME/.cache, where it never widens a directory that was already there" 'stderr'
+  assert_contains "$shale_err" \
+    "shale: note: '.cache' is on the ignore list — no apply links it" 'stderr'
+  # And below an ignored directory, which is the ancestor walk rather than the
+  # matcher: '/.cache' is anchored and does not match '.cache/inner' on its own.
+  run_shale which .cache/inner
+  assert_status 0 "$shale_status" 'below the ignored directory'
+  assert_not_contains "$shale_err" \
+    "shale:   and on $HOME/.cache/inner, where it never widens a directory that was already there" \
+    'below the ignored directory'
+}
+
+# An ordinary path says nothing about a mode: most paths have no declaration,
+# and a note on every one of them would be noise on the command people run to
+# ask one question.
+test_which_says_nothing_about_a_path_no_line_declares() {
+  conf 'base personal/base'
+  mklayer personal/base .ssh/config
+  mklayer personal/base .zshrc
+  mkmodes personal '700  .ssh'
+  run_shale which .zshrc
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_err" "shale: note: '.zshrc' is declared mode" 'stderr'
+}
+
+# A declaration outliving the path it names is what the reader has in front of
+# them, and no build runs until it is fixed - so which says that rather than a
+# mode, and exits 1 as it does for any path no layer provides.
+test_which_names_a_declaration_whose_path_no_layer_provides() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mkmodes personal '700  .ssh'
+  run_shale which .ssh
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" "shale: no layer provides '.ssh'" 'stderr'
+  assert_contains "$shale_err" \
+    "shale: note: '.ssh' is declared mode 700 at $HOME/.dotfiles/personal/.shale-modes:1" 'stderr'
+  assert_contains "$shale_err" \
+    "shale:   no layer provides that path, so no build composes one at it and 'shale build' refuses the line" \
+    'stderr'
+  assert_not_contains "$shale_err" \
+    "shale:   shale sets that mode on $HOME/.dotfiles/current/.ssh" 'stderr'
+}
+
+# which refuses a declaration it will not read for the reason it refuses a
+# pattern: it cannot say what mode the path gets from a line it did not parse,
+# and every build refuses it too.
+test_which_refuses_a_declaration_it_will_not_read() {
+  conf 'base common/base'
+  mkmodes common '700'
+  mklayer common/base .zshrc
+  run_shale which .zshrc
+  assert_status 1 "$shale_status"
+  assert_empty "$shale_out" 'stdout'
+  assert_contains "$shale_err" \
+    "shale: $HOME/.dotfiles/common/.shale-modes:1: '700' is a mode with no path after it" 'stderr'
 }
 
 # which refuses a pattern it will not read rather than answering around it: it


### PR DESCRIPTION
Closes #140.

Git records no permission bits for a directory and only a file's exec bit, so a cloned layer has whatever the clone's umask gave it. #119 made shale copy a layer's directory modes — which for a cloned layer faithfully reproduces that umask — and carried a footgun: a directory's mode came from the highest layer *providing* it, so adding one file inside a directory reassigned its permissions.

A committed `.shale-modes` at the clone root now declares modes explicitly, and the inference is gone. Verified across 16 combinations of clone umask × build umask: a declared `700 .ssh` is `700` in `current/` and in `$HOME` every time, where the baseline reproduces the clone's umask.

**Behaviour change.** Where no line declares a mode, `$HOME` directory modes loosen on the first apply after upgrading — the old inference only worked on the machine whose working tree still held the committed mode. A `700  .ssh` line restores it everywhere. File modes are unaffected.

Both reviews independently found an escape in the first revision: `chmod` resolves every component, so a symlink above a declared path set the mode of a file outside both trees, silently, exit 0. Four sites needed the guard — the fourth found by the implementer, not by either review.