### PR TITLE
Answer which about the name that was typed, not the one a volume folded it to

### DIFF
--- a/shale
+++ b/shale
@@ -4526,6 +4526,92 @@ unresolvable_ancestor() {
   done
 }
 
+# Zero when something is at $1/$2 and every component of $2 is spelled on disk
+# exactly as it was given, byte for byte.  which's own, and the only test in
+# this script that resolves a path somebody typed rather than one read out of a
+# directory.
+#
+# -e and -L answer through the filesystem's idea of when two names are one name,
+# and on a case-insensitive volume - APFS's default, so macOS's, so the floor's -
+# '.git' and '.GIT' are one name to them.  Every test that decides whether the
+# composer reaches a path compares a name read from a listing against a literal,
+# byte for byte: compose_dir's three skips, doctor's three, and which's own
+# 'unreached'.  So on such a volume a bare -e disagrees with all of them at once.
+# A layer's 'd/.GIT/c' is composed - '.GIT' is not the string '.git' - and build
+# exits 1 at a collision there, while which resolved a typed 'd/.git/c' to that
+# same file, read its own '.git' out of the string it was given, and called the
+# path one no build reaches: silent where build fails, which is the wrong
+# direction to be silent in.  Reproduced on macOS 26.4, and unreproducible on
+# ext4.
+#
+# So which asks the composer's question rather than the filesystem's, and the
+# answer is that '.GIT' is a different name from '.git' everywhere.  No case rule
+# is involved and none is wanted: folding case is locale business - the Turkish
+# dotless i - and a comparison that moved with LC_CTYPE would be the defect this
+# closes wearing a different hat.  Byte equality is what '=' inside a [ already
+# is, and the listing itself runs in list_dir's byte locale.
+#
+# On a case-sensitive volume every answer here is the answer -e gave, so nothing
+# there changes and no case in this suite can tell the difference.
+#
+# A directory that cannot be listed falls back to the filesystem's answer, which
+# is what -e alone gave before: telling '.git' from '.GIT' needs the parent's
+# entries, and the read bit is what hands them over.  A directory that is
+# searchable but not readable is therefore the one state where which is back to
+# folding, and it says nothing about it - obscured_ancestor, which is where
+# which reports a directory it cannot look in, tests only -x and is silent on a
+# missing -r.  What the reader gets instead is build's own refusal, compose_dir
+# dying on a layer directory it cannot read; so the wrong answer here never
+# describes a build that runs, and nothing tells them so until they run one.
+#
+# '.' and an empty component are left to the kernel, so that a typed 'a/./b' and
+# 'a//b' resolve here as they do at every -e in this script; '..' is refused by
+# which_normalise before anything reaches this.
+path_exists_as_spelled() {
+  local here=$1 rest=$2 want e base found
+  while :; do
+    case "$rest" in
+      */*)
+        want=${rest%%/*}
+        rest=${rest#*/}
+        ;;
+      *)
+        want=$rest
+        rest=
+        ;;
+    esac
+    case "$want" in
+      '' | '.')
+        [ -n "$rest" ] || break
+        continue
+        ;;
+    esac
+    if [ -r "$here" ] && [ -x "$here" ]; then
+      found=0
+      list_dir "$here" 1
+      for e in ${DIR_ENTRIES[@]+"${DIR_ENTRIES[@]}"}; do
+        base=${e##*/}
+        # Dropped by name, as at every glob in this script: bash 3.2 matches '.'
+        # and '..' with "$here"/.* where 5.2's globskipdots does not.
+        case "$base" in
+          . | ..) continue ;;
+        esac
+        [ "$base" = "$want" ] || continue
+        # Also where an unmatched glob lands, its literal being at no path - so
+        # a layer holding a file genuinely called '*' answers here and a layer
+        # holding none does not.
+        { [ -e "$e" ] || [ -L "$e" ]; } || continue
+        found=1
+        break
+      done
+      [ "$found" -eq 1 ] || return 1
+    fi
+    here=$here/$want
+    [ -n "$rest" ] || break
+  done
+  [ -e "$here" ] || [ -L "$here" ]
+}
+
 # How $1 is composed, in WHICH_KIND, and how it is shown, in WHICH_SHOW.  A
 # symlink is a leaf whatever it points at, because the composer treats one that
 # way: calling it a directory here promises a merge build refuses to perform.
@@ -6243,7 +6329,11 @@ cmd_which() {
   while [ "$i" -gt 0 ]; do
     i=$((i - 1))
     path=$DOTFILES/${LAYER_PATHS[$i]}/$rel
-    if [ -e "$path" ] || [ -L "$path" ]; then
+    # Spelled as given rather than -e alone: on a case-insensitive volume a
+    # layer's '.GIT' answers -e for a typed '.git', and every other test in this
+    # command reads the spelling it was given.  A layer providing one name and
+    # not the other is a layer this loop must not name for the other.
+    if path_exists_as_spelled "$DOTFILES/${LAYER_PATHS[$i]}" "$rel"; then
       which_describe "$path"
       WHICH_NAMES+=("${LAYER_NAMES[$i]}")
       WHICH_KINDS+=("$WHICH_KIND")
@@ -6293,7 +6383,10 @@ cmd_which() {
     # that an ordinary build copies.
     if [ "${rel%%/*}" = .stow-local-ignore ]; then
       emit "note: shale writes $CUR/.stow-local-ignore itself, and no build accepts a layer providing one"
-    elif [ -e "$CUR/$rel" ] || [ -L "$CUR/$rel" ]; then
+    elif path_exists_as_spelled "$CUR" "$rel"; then
+      # The same spelling the loop above answered 'no layer provides' on: with a
+      # bare -e a built '.GIT' answers for a typed '.git' on a case-insensitive
+      # volume, and this would call a tree the last build wrote stale.
       emit "note: present in current/ but no layer provides it — current/ is stale, run 'shale build'"
     fi
     exit 1
@@ -6522,8 +6615,13 @@ cmd_which() {
   # directories above it in $HOME: one that cannot be searched, and one that is a
   # link resolving to nothing shale can reach.  Every test below either answers
   # no, which is what the file not being there answers too.
+  # Spelled as given on the built tree, as everywhere else here.  Not on $HOME:
+  # that half is a negative, and answering it through the filesystem is the safe
+  # direction - a link at a name differing only in case suppresses the note
+  # rather than adding a false one, and only a hand puts such a link there, no
+  # build having composed the name it would have come from.
   if [ "$explained" -eq 0 ] && [ -n "${HOME-}" ] &&
-    { [ -e "$CUR/$rel" ] || [ -L "$CUR/$rel" ]; } &&
+    path_exists_as_spelled "$CUR" "$rel" &&
     [ ! -e "$HOME_PREFIX/$rel" ] && [ ! -L "$HOME_PREFIX/$rel" ] &&
     ! obscured_ancestor "$HOME_PREFIX" "$rel" &&
     ! unresolvable_ancestor "$HOME_PREFIX" "$rel"; then

--- a/tests/run
+++ b/tests/run
@@ -1071,6 +1071,33 @@ find_utf8_locale() {
     'tried: en_US.UTF-8 C.UTF-8 en_US.utf8 C.utf8'
 }
 
+# Zero when this machine has locale $1, for a case that wants an extra locale
+# rather than needing one.
+#
+# The system's list, and never the shell's own complaint about a locale it has
+# not got, which is the trap this walked into first: bash 5.2 warns 'cannot
+# change locale' on stderr, and bash 3.2.57 - the floor, and what macOS ships -
+# says nothing at all and exits 0.  So a probe reading that warning answers yes
+# to every name on the floor platform, which is exactly the machine an extra
+# locale is wanted for.  Measured: under LC_ALL=no_SUCH.UTF-8 the mac's
+# /bin/bash prints nothing and 'locale' under it reports LC_CTYPE="C", so the
+# caller's extra arm would have run under C believing it ran under the name it
+# asked for - and passed.  That is the one way this helper can be wrong with
+# nothing going red, which is why it is the mechanism and not the answers that
+# has to be right here.
+#
+# -x and -F rather than a substring or a pattern, so that 'C' does not answer
+# for 'C.utf8' and the '.' in a locale name is a '.'.
+#
+# Unlike find_utf8_locale directly above, this never fails the case: its one
+# caller asserts the same answer under every locale it is given, and a machine
+# with one locale fewer asserts that over a shorter list.  The caller says in
+# its comment which machine has which.  A machine with no 'locale' command at
+# all answers no to everything and takes the same shorter list.
+have_locale() {
+  locale -a 2>/dev/null | grep -qxF "${1-}"
+}
+
 # The whole of doctor's report on a machine that has built and never applied, on
 # stdout for a whole-report assertion to compare against.
 #
@@ -15115,6 +15142,141 @@ test_which_predicts_a_collision_beside_the_skipped_names() {
   assert_contains "$shale_err" 'shale: conflict at x/git/c' 'the build stderr'
   assert_contains "$shale_err" 'shale: conflict at y/.gitignore' 'the build stderr'
   assert_contains "$shale_err" "shale: 4 conflicts; $HOME/.dotfiles/current not rebuilt" 'the build stderr'
+}
+
+# A name that differs from a skipped one in case alone, which is an ordinary
+# name and not the skipped one: '.GIT' is not the string '.git', so the composer
+# walks it, and build exits 1 at the collision inside it.
+#
+# ONLY A CASE-INSENSITIVE VOLUME CAN TURN THIS RED - APFS's default, so macOS's,
+# so the platform of the bash 3.2 floor.  A green run on ext4 is evidence about
+# ext4 and about nothing else: there 'd/.git/c' is simply not there, and it was
+# there on macOS, where -e resolved a typed 'd/.git/c' to the '.GIT' beside it
+# while which went on reading its own '.git' out of the string it was given.
+# What that bought was 'no build composes a .git' printed over a path every
+# build composes, and the collision prediction taken off a build that exits 1:
+# silent where build fails.  Measured on macOS 26.4 before the fix.
+#
+# The assertions are identical on both volumes, which is the whole point - the
+# answer is about the spelling that was typed, and which volume it landed on
+# does not enter it.
+#
+# Locale-independence is demonstrated rather than asserted, and 'd/.GIT/c' is
+# the demonstration: shale compares these names with '=' inside a [, which is
+# byte equality on every locale there is, and reads them out of list_dir's byte
+# locale.  Any implementation that folded case instead would have to fold that
+# 'I', and tr_TR is where folding an 'I' stops meaning 'i' - the dotless-i
+# problem #103 and #109 both refused to let into an answer.  So the pair of
+# which runs below is made under every locale the machine has of C, UTF-8 and
+# tr_TR.UTF-8, and must answer byte for byte the same under each.  The container
+# has no tr_TR and the mac has all three, so the arm that separates a fold from
+# a byte comparison runs on the macOS job alone; the C and UTF-8 arms run
+# everywhere.
+test_which_a_case_variant_of_a_skipped_name_is_not_the_skipped_name() {
+  local loc locales
+  conf 'base personal/base' 'local local'
+  mklayer personal/base d/.GIT/c
+  mklayer local d/.GIT/c/inside
+  # What the two which answers below are measured against: the composer reaches
+  # this path, so the collision in it is one build dies at.
+  run_shale build
+  assert_status 1 "$shale_status" 'the build'
+  assert_contains "$shale_err" 'shale: conflict at d/.GIT/c' 'the build stderr'
+  assert_contains "$shale_err" "shale: 1 conflict; $HOME/.dotfiles/current not rebuilt" 'the build stderr'
+  find_utf8_locale \
+    'it asserts that the answer for a name differing in case alone is the same under every locale'
+  locales="C $utf8_locale"
+  ! have_locale tr_TR.UTF-8 || locales="$locales tr_TR.UTF-8"
+  for loc in $locales; do
+    # The name that is on disk: composed like any other, so the prediction
+    # stands and no note claims the path never reaches the built tree.
+    LC_ALL=$loc run_shale which d/.GIT/c
+    assert_status 0 "$shale_status" "the name on disk under LC_ALL=$loc"
+    assert_eq "shale: note: 'build' would fail here — d/.GIT/c is a file in 'base' and a directory in 'local'" \
+      "$shale_err" "stderr for the name on disk under LC_ALL=$loc"
+    # The name nobody wrote.  No layer holds it, whatever the volume makes of
+    # the two names being one file, and the notes are the ones for a path no
+    # layer provides rather than the ones for a path the composer skips.
+    LC_ALL=$loc run_shale which d/.git/c
+    assert_status 1 "$shale_status" "the name nobody wrote under LC_ALL=$loc"
+    assert_eq "shale: no layer provides 'd/.git/c'
+shale: note: 'd/.git/c' is on stow's own ignore list — no apply links it
+shale:   stow's default ignore list: \\.git
+shale:   shale writes that list into $HOME/.dotfiles/current/.stow-local-ignore on every build
+shale:   that list has no line to edit: nothing but a different name gets this path past it" \
+      "$shale_err" "stderr for the name nobody wrote under LC_ALL=$loc"
+  done
+  # doctor's side of it, which was already the composer's on both volumes: all
+  # three commands name 'd/.GIT/c' and none of them names 'd/.git/c'.
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" "shale: 'build' would fail at d/.GIT/c" 'the doctor stdout'
+  assert_not_contains "$shale_out" 'would fail at d/.git/c' 'the doctor stdout'
+}
+
+# The other side of the same fix, and the one a bare -e got wrong in the
+# direction that reads worst: a built tree called stale while it holds exactly
+# what the layer holds.
+#
+# ALSO RED ONLY ON A CASE-INSENSITIVE VOLUME, for the same reason and on the
+# same machines.  With '.GIT' composed and no layer providing 'd/.git/c', -e on
+# the built tree answered yes for the typed spelling and which prescribed a
+# rebuild that would compose the very same tree again.  Every build here exits 0
+# - there is no collision - so the tree under test is a good one.
+test_which_does_not_call_a_tree_stale_for_a_name_differing_in_case() {
+  conf 'base personal/base'
+  mklayer personal/base d/.GIT/c
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_exists "$HOME/.dotfiles/current/d/.GIT/c" 'the composed copy'
+  run_shale which d/.git/c
+  assert_status 1 "$shale_status" 'the name nobody wrote'
+  assert_not_contains "$shale_err" "current/ is stale" 'the stale note'
+  assert_eq "shale: no layer provides 'd/.git/c'
+shale: note: 'd/.git/c' is on stow's own ignore list — no apply links it
+shale:   stow's default ignore list: \\.git
+shale:   shale writes that list into $HOME/.dotfiles/current/.stow-local-ignore on every build
+shale:   that list has no line to edit: nothing but a different name gets this path past it" \
+    "$shale_err" 'stderr for the name nobody wrote'
+}
+
+# The third and last place which resolves a typed path against a real tree, and
+# the only one a name outside the three skipped ones can reach: the test that
+# the path is in the built tree, which is what the residual note is about.
+#
+# ALSO RED ONLY ON A CASE-INSENSITIVE VOLUME, on the same machines and for the
+# same reason.  A layer file renamed in case alone leaves the earlier build's
+# 'Foo' in the tree and 'foo' in the layer; -e answered yes for 'current/foo',
+# so which said this path was in the built tree at a name that tree does not
+# hold.  Byte for byte it is not there, which is also what a rebuild would tell
+# anyone who looked.
+#
+# The rename is the fixture and the volume decides what it means: on ext4 it
+# makes a second file and 'current/foo' is absent either way, on APFS it renames
+# the one file and 'current/foo' is the old spelling of it.  Both must answer
+# the same, and silence is the answer - the path is in the layer, no build has
+# put this spelling in the tree, and there is nothing for a note to say.
+test_which_does_not_place_a_typed_name_in_a_tree_holding_another_case() {
+  local layer
+  conf 'base personal/base'
+  mklayer personal/base Foo
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_exists "$HOME/.dotfiles/current/Foo" 'the composed copy'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  layer=$sandbox_dir
+  sandbox_leaf "$layer" Foo
+  # Not 'new' for the destination: on a case-insensitive volume the name it is
+  # about already exists under the spelling being renamed away from, so the
+  # guard's strong mode would refuse the fixture this case is made of.
+  sandbox_leaf "$layer" foo
+  mv "$layer/Foo" "$layer/foo" || fail 'could not rename the layer file'
+  run_shale which foo
+  assert_status 0 "$shale_status" 'the renamed layer file'
+  assert_contains "$shale_out" "$layer/foo" 'stdout for the renamed layer file'
+  assert_empty "$shale_err" 'stderr for the renamed layer file'
 }
 
 # The claim measured against the thing claimed, over a corpus holding both


### PR DESCRIPTION
Closes #129.

On a case-insensitive volume — APFS by default, which is macOS, which is a
supported platform — `shale which d/.git/c` used `[ -e ]` to resolve a path the
user typed, so it found a layer directory actually named `.GIT` and then
reported that no build composes a `.git` and the path never reaches `current/`.
`compose_dir` compares byte for byte, so `.GIT` is composed and a collision
there really does make `build` exit 1. Silent where `build` fails.

The two string tests never disagreed; `which`'s *existence* test was the odd
one out, because it asks the filesystem when two names are one name. So
`which`'s lookup now goes through the composer's rule instead: a new
`path_exists_as_spelled` walks the components of a typed path and matches each
against its parent's listing with byte equality.

No case-folding anywhere. Folding is locale-dependent — the Turkish dotless-i —
and #103 and #109 both landed on refusing to let a locale change an answer. The
new case asserts byte-identical output under `LC_ALL=C`, under a UTF-8 locale,
and under `tr_TR.UTF-8` where the machine has it; the `I` in `.GIT` is the
character that would move under a fold.

Reproduced on macOS before the fix and verified after, on a real
case-insensitive volume rather than only in the macOS CI job. Each of the three
replaced sites was measured load-bearing by reverting it alone. `which` costs
0.21s against 0.16s for a 12-deep path through 400-sibling directories, where
`build` on the same tree is 15.6s.

Two adjacent defects found and left alone, filed as #143 and #144.

545 -> 549 cases with #136 merged, `0 failed, 0 skipped`, on bash 5.2.21 with
GNU Stow 2.3.1 and on macOS 26.4 under bash 3.2.57 with GNU Stow 2.4.1.