### PR TITLE
Ask one question before offering an apply, in one place

### DIFF
--- a/shale
+++ b/shale
@@ -2525,6 +2525,39 @@ blocking_finding() {
   finding "$@"
 }
 
+# Both zeroed here as well as in cmd_doctor, which is their one writer today:
+# apply_offerable below reads them, and an unbound expansion under 'set -u' kills
+# the script rather than answering wrongly, so the first call from anywhere else
+# would take shale down with it.
+BUILD_BLOCKED=0
+# The tools an apply needs that a build does not, counted where they are missing.
+# stow is the whole of that list, and its absence is deliberately not blocking: a
+# build runs without it, so a report that stopped offering one would be wrong
+# about the command that still works.
+APPLY_TOOL_MISSING=0
+
+# Zero when doctor may offer an apply.  Every line it prints that names 'shale
+# apply' is gated on this - one question, answered in one place, so that the
+# report cannot refuse an apply in one check and offer it in the next.  It gates
+# the lines that name the command and not every mention of an apply: a line
+# saying what an apply is for states a mechanism, and stays true whether or not
+# one can run today.
+#
+# Three inputs, each sufficient on its own.  An apply builds before it stows, so
+# everything that stops a build stops it.  stow will not write over what it did
+# not create, so a path in $HOME that a layer provides stops the stow half; that
+# is APPLY_CONFLICTS, which blocks no build and so is not counted in
+# BUILD_BLOCKED.  And stow is the one tool an apply needs that a build does not,
+# so a machine without it composes every layer and links none of them.
+#
+# Read where the line is printed rather than answered once: BUILD_BLOCKED and
+# APPLY_CONFLICTS go on rising until the last check has run.
+apply_offerable() {
+  [ "$BUILD_BLOCKED" -eq 0 ] &&
+    [ "$APPLY_CONFLICTS" -eq 0 ] &&
+    [ "$APPLY_TOOL_MISSING" -eq 0 ]
+}
+
 # Counted, though a note never changes the exit status: the summary says how
 # many were printed, so that a report ending 'no problems found' cannot be read
 # as a report that said nothing.
@@ -3666,13 +3699,12 @@ audit_unapplied_tree() {
   lines=("nothing in the built tree at $CUR is linked in $HOME"
     "build composes that tree and apply is what links it into $HOME, so until an apply runs none of it is in use")
   # Offered only where it would work, which is audit_broken_links' rule for the
-  # build it offers.  An apply builds before it stows, so everything that stops
-  # a build stops it; a path in $HOME that a layer provides stops the stow half,
-  # in a finding that says what to move aside.
-  if [ "$BUILD_BLOCKED" -gt 0 ] || [ "$APPLY_CONFLICTS" -gt 0 ]; then
-    lines[${#lines[@]}]='no apply will finish until the problems above are fixed'
-  else
+  # build it offers.  apply_offerable holds the three reasons an apply cannot
+  # finish, and every remedy that names one asks it.
+  if apply_offerable; then
     lines[${#lines[@]}]='apply it with: shale apply'
+  else
+    lines[${#lines[@]}]='no apply will finish until the problems above are fixed'
   fi
   note ${lines[@]+"${lines[@]}"}
 }
@@ -4006,7 +4038,17 @@ audit_declared_modes() {
     fi
     lines+=("shale sets the mode of a directory it creates in $HOME, and never widens one that was already there")
     lines+=('to take the mode the declaration asks for, chmod that directory yourself')
-    lines+=("to keep the mode it has, change the declaration: 'shale which' names the line that decides a path")
+    # 'which' parses the config before it answers anything, and CONFIG_ERRORS is
+    # what a refused line leaves, so a report holding one may not send the reader
+    # to a command that exits 1 printing those same errors back.  The remedy
+    # stands without the pointer: it is the declaration to edit either way, and
+    # the parse errors at the top of the report are the one thing to act on
+    # first.
+    if [ "$CONFIG_ERRORS" -eq 0 ]; then
+      lines+=("to keep the mode it has, change the declaration: 'shale which' names the line that decides a path")
+    else
+      lines+=('to keep the mode it has, change the declaration')
+    fi
     note ${lines[@]+"${lines[@]}"}
   fi
 
@@ -4035,7 +4077,11 @@ audit_declared_modes() {
     lines+=("and $rest more, not named here")
   fi
   lines+=("the built tree holds each of these paths with the declared mode on it, and an apply is what puts one in $HOME")
-  lines+=("'shale which PATH' says why a path in the tree is not linked")
+  # The pointer above's rule, and the whole of this line: with a config error
+  # 'shale which' answers nothing but those errors, which the top of this report
+  # has already printed.
+  [ "$CONFIG_ERRORS" -ne 0 ] ||
+    lines+=("'shale which PATH' says why a path in the tree is not linked")
   note ${lines[@]+"${lines[@]}"}
 }
 
@@ -4293,12 +4339,27 @@ EOF
   # sweep under it is the alternative to doing that by hand.  Where the two are
   # mixed, the rm is what covers all of them and the apply is named for what it
   # takes off the list.
+  #
+  # Every line here that names an apply asks apply_offerable first, exactly as
+  # the note about the unapplied tree does: with a blocked build, a conflict in
+  # $HOME or no stow installed, 'clear them with: shale apply' is a command that
+  # cannot finish, and the report has already said so a few lines above.  What
+  # replaces it says which state it is waiting on rather than a second remedy:
+  # the apply is still the right answer for these links, once it can run.
   if [ "$prunable" -eq "$n" ] && [ "$n" -eq 1 ]; then
-    remedy=('clear it with: shale apply'
-      'stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and this is one of them')
+    if apply_offerable; then
+      remedy=('clear it with: shale apply')
+    else
+      remedy=('no apply will finish until the problems above are fixed, so this link stays')
+    fi
+    remedy+=('stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and this is one of them')
   elif [ "$prunable" -eq "$n" ]; then
-    remedy=('clear them with: shale apply'
-      'stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and every one of these is one of them')
+    if apply_offerable; then
+      remedy=('clear them with: shale apply')
+    else
+      remedy=('no apply will finish until the problems above are fixed, so these links stay')
+    fi
+    remedy+=('stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and every one of these is one of them')
   else
     if [ "$n" -le "$cap" ]; then
       if [ "$prunable" -eq 0 ]; then
@@ -4315,14 +4376,24 @@ EOF
         remedy=('remove them; the built tree is correct and needs no rebuilding')
       fi
     fi
-    if [ "$prunable" -gt 0 ]; then
+    if [ "$prunable" -gt 0 ] && apply_offerable; then
       remedy+=("an apply clears $prunable of them and leaves the rest: stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds")
+    elif [ "$prunable" -gt 0 ]; then
+      remedy+=("an apply would clear $prunable of them and leave the rest: stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds" \
+        'no apply will finish until the problems above are fixed')
     else
       remedy+=('stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links')
     fi
-    remedy+=('stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
-      "  stow -D -p --no-folding -d $qdots -t $qhome current && shale apply" \
-      'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory')
+    # The sweep goes with the apply rather than standing without it.  Its '&&'
+    # is on stow's exit status and not on the apply's, so where the apply cannot
+    # finish the unstow still succeeds, the apply then exits 1, and $HOME is
+    # left unstowed and not restowed - worse than where the reader started.  The
+    # rm leading this block is the remedy that stands whatever else is broken.
+    if apply_offerable; then
+      remedy+=('stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
+        "  stow -D -p --no-folding -d $qdots -t $qhome current && shale apply" \
+        'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory')
+    fi
   fi
 
   if [ "$n" -le "$cap" ]; then
@@ -5792,6 +5863,7 @@ cmd_doctor() {
   FINDINGS=0
   NOTES=0
   BUILD_BLOCKED=0
+  APPLY_TOOL_MISSING=0
   pending=0
 
   # Every tool shale runs, and the list a new one joins.  Elsewhere a tool is
@@ -5805,8 +5877,13 @@ cmd_doctor() {
   for tool in chmod cp ls mkdir mv rm rmdir stow; do
     command -v "$tool" >/dev/null 2>&1 && continue
     # stow is wanted only by apply, so it stops no build on its own; every other
-    # name here does, and no line below may then offer one.
-    [ "$tool" = stow ] || BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
+    # name here does, and no line below may then offer one.  What it does stop is
+    # every apply, which is apply_offerable's third input.
+    if [ "$tool" = stow ]; then
+      APPLY_TOOL_MISSING=$((APPLY_TOOL_MISSING + 1))
+    else
+      BUILD_BLOCKED=$((BUILD_BLOCKED + 1))
+    fi
     finding "$tool is not installed" \
       "install it with your system package manager: shale installs nothing"
   done

--- a/tests/run
+++ b/tests/run
@@ -9275,6 +9275,54 @@ test_doctor_names_a_directory_an_apply_left_as_it_is() {
     "shale: an apply left 1 directory in $HOME as it is" 'stdout'
 }
 
+# 'shale which' is a remedy like any other, and the one state it refuses in is a
+# state doctor is often run in: it parses the config before it answers anything,
+# and a config error is exactly what BUILD_BLOCKED is folded from.  So both
+# lines that name it are gated on the parse rather than on apply_offerable -
+# which is a different question, and would suppress them for a missing stow that
+# 'which' does not need.
+#
+# Both notes in one fixture, because both name it: a directory an apply left as
+# it is, and a declaration nothing in $HOME answers.
+test_doctor_offers_no_which_while_the_config_does_not_parse() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .ssh/config
+  mklayer personal/base .gnupg/gpg.conf
+  mkmodes personal '755  .ssh' '700  .gnupg'
+  sandbox_mkdir "$HOME/.ssh"
+  chmod 0700 "$sandbox_dir" || fail 'could not set the home directory mode'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  # The second note: a declared path with nothing in $HOME at it, while the rest
+  # of the tree is linked.
+  sandbox_mkdir "$HOME"
+  rm -rf "$sandbox_dir/.gnupg" || fail 'could not remove the declared directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" \
+    "shale:   to keep the mode it has, change the declaration: 'shale which' names the line that decides a path" \
+    'the sound stdout'
+  assert_contains "$shale_out" \
+    "shale:   'shale which PATH' says why a path in the tree is not linked" 'the sound stdout'
+  # A duplicate layer name: the line is refused, the layer above it stands, and
+  # every command that parses this file exits 1 - 'which' included.
+  conf 'base personal/base' 'base personal/other'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the setup with the config error'
+  # The notes themselves stay: what they say about $HOME is still true, and only
+  # the command they named has stopped working.
+  assert_contains "$shale_out" \
+    "shale: an apply left 1 directory in $HOME as it is" 'the blocked stdout'
+  assert_contains "$shale_out" \
+    "shale: 1 declared mode is not on anything in $HOME" 'the blocked stdout'
+  assert_not_contains "$shale_out" 'shale which' 'the blocked stdout'
+  # The command those lines would have named.
+  run_shale which .ssh/config
+  assert_status 1 "$shale_status" 'the which the lines refuse to offer'
+  assert_contains "$shale_err" 'duplicate layer name' 'the which stderr'
+}
+
 # The note may not swallow a real problem, and a real problem may not swallow
 # the note: one run holding both has to exit 1 for the finding, print the
 # finding's own count, and still carry every line of the note.
@@ -10242,6 +10290,151 @@ test_doctor_the_remedy_names_both_where_an_apply_clears_only_some() {
   assert_contains "$shale_out" \
     'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
     'the stdout after the apply'
+}
+
+# The three cases below are one rule in three states: a link an apply would
+# clear is still a link no apply is going to clear while something else in the
+# report stops the apply.  Each is written around a single gate, and each runs
+# the sound state first - the line is right in that half, and a doctor that had
+# simply stopped printing it would pass a case that only looked at the blocked
+# one.
+#
+# A blocked build, which stops the apply's first half: an apply builds before it
+# stows.  The mixed shape, because it is where the apply is named twice - once
+# for the links it takes off the list, and once at the end of the sweep.
+test_doctor_offers_no_apply_for_an_orphan_while_the_build_is_blocked() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .tmux.conf
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  # One file that left its only layer, which stow prunes, and one directory that
+  # left every layer, which it does not.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .tmux.conf
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" \
+    'shale:   an apply clears 1 of them and leaves the rest: stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds' \
+    'the sound stdout'
+  assert_contains "$shale_out" \
+    "shale:     stow -D -p --no-folding -d '$HOME/.dotfiles' -t '$HOME' current && shale apply" \
+    'the sound stdout'
+  # The same links, with two layers now disagreeing about a path: every build
+  # from here exits 1, and so does every apply.
+  conf 'base personal/base' 'work work'
+  mklayer personal/base both/inner
+  mklayer work both
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the setup that cannot build'
+  assert_contains "$shale_out" \
+    'shale:   an apply would clear 1 of them and leave the rest: stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds' \
+    'the blocked stdout'
+  assert_contains "$shale_out" \
+    'shale:   no apply will finish until the problems above are fixed' 'the blocked stdout'
+  assert_not_contains "$shale_out" 'an apply clears 1 of them' 'the blocked stdout'
+  # The sweep goes with it: it unstows the whole target tree and the apply after
+  # it is what puts the links back, so half of it is not half a remedy.
+  assert_not_contains "$shale_out" 'stow -D -p' 'the blocked stdout'
+  # The whole report, which is the claim: 'shale apply' is not offered anywhere
+  # in it while one line of it says no apply will finish.
+  assert_not_contains "$shale_out" 'shale apply' 'the blocked stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply no line offered'
+}
+
+# The second gate: a path in $HOME that a layer provides, which stops the stow
+# half and no build at all.  The plural shape of the remedy, whose whole line is
+# the offer.
+test_doctor_offers_no_apply_for_an_orphan_while_a_path_in_home_conflicts() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .config/nvim/init.lua
+  mklayer local .config/nvim/extra.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  # The directory stays in the built tree, because the higher layer keeps it
+  # alive, so both links are ones stow prunes.
+  mklayer personal/base .config/nvim/keep.lua
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" 'shale: clear them with: shale apply' 'the sound stdout'
+  # A real file where a layer provides one: stow refuses the whole operation.
+  mklayer personal/base .vimrc
+  sandbox_write "$HOME" .vimrc 'mine, and not a link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the setup with the conflict'
+  assert_contains "$shale_out" \
+    'shale: no apply will finish until the problems above are fixed, so these links stay' \
+    'the blocked stdout'
+  assert_contains "$shale_out" \
+    'shale:   stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and every one of these is one of them' \
+    'the blocked stdout'
+  assert_not_contains "$shale_out" 'clear them with' 'the blocked stdout'
+  assert_not_contains "$shale_out" 'shale apply' 'the blocked stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply no line offered'
+}
+
+# The third gate, which neither of the others covers: stow is the one tool an
+# apply needs that a build does not, so a machine without it composes every
+# layer, links none of them, and has a build doctor may still offer.  The
+# singular shape of the remedy.
+test_doctor_offers_no_apply_for_an_orphan_where_stow_is_not_installed() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .tmux.conf
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .tmux.conf
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" 'shale: clear it with: shale apply' 'the sound stdout'
+  stub_path_without stow
+  saved=$PATH
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 1 "$shale_status" 'the setup without stow'
+  # The finding is still made: this gate suppresses the remedy and never the
+  # report of what is missing.
+  assert_contains "$shale_out" 'shale: stow is not installed' 'the blocked stdout'
+  assert_contains "$shale_out" \
+    'shale: no apply will finish until the problems above are fixed, so this link stays' \
+    'the blocked stdout'
+  assert_contains "$shale_out" \
+    'shale:   stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and this is one of them' \
+    'the blocked stdout'
+  assert_not_contains "$shale_out" 'clear it with' 'the blocked stdout'
+  assert_not_contains "$shale_out" 'shale apply' 'the blocked stdout'
+  # A build is still offered where one is offered at all: the missing tool stops
+  # no build, and a report that suppressed both would be wrong about the command
+  # that still works.
+  PATH=$stub_path
+  run_shale build
+  PATH=$saved
+  assert_status 0 "$shale_status" 'the build stow does not stop'
+  PATH=$stub_path
+  run_shale apply
+  PATH=$saved
+  assert_status 1 "$shale_status" 'the apply no line offered'
+  assert_contains "$shale_err" \
+    'shale: stow is not installed, and apply links the built tree with it' 'the apply stderr'
 }
 
 # plant_orphans DIR N - N links in $HOME/DIR into the built tree at paths it has
@@ -12756,6 +12949,7 @@ test_doctor_the_unapplied_note_sits_beside_a_finding() {
 # did not create, so a path in $HOME that a layer provides stops the other half.
 # Both are run rather than quoted.
 test_doctor_offers_no_apply_that_would_not_finish() {
+  local saved
   conf 'base personal/base'
   mklayer personal/base .zshrc
   run_shale build
@@ -12787,6 +12981,27 @@ test_doctor_offers_no_apply_that_would_not_finish() {
   assert_not_contains "$shale_out" 'shale:   apply it with: shale apply' 'the second stdout'
   run_shale apply
   assert_status 1 "$shale_status" 'the apply after the collision'
+  # stow's other half, which stops no build: the tool an apply links with, and
+  # the one name in doctor's tool list that is deliberately not blocking.
+  conf 'base personal/base'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/both" || fail 'could not remove the colliding layer path'
+  stub_path_without stow
+  saved=$PATH
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 1 "$shale_status" 'doctor without stow'
+  assert_contains "$shale_out" 'shale: stow is not installed' 'the third stdout'
+  assert_contains "$shale_out" \
+    "shale: nothing in the built tree at $HOME/.dotfiles/current is linked in $HOME" 'the third stdout'
+  assert_contains "$shale_out" \
+    'shale:   no apply will finish until the problems above are fixed' 'the third stdout'
+  assert_not_contains "$shale_out" 'shale:   apply it with: shale apply' 'the third stdout'
+  PATH=$stub_path
+  run_shale apply
+  PATH=$saved
+  assert_status 1 "$shale_status" 'the apply without stow'
 }
 
 # A tree shale could not read whole is a tree it may not conclude about: a


### PR DESCRIPTION
Closes #135.

`doctor` told the reader to run an apply in four places gated on nothing, so a
report could print `no apply will finish until the problems above are fixed`
three lines above `clear them with: shale apply`. One question — may doctor
offer an apply right now? — answered in several places, inconsistently.

A predicate answers it once. It is true when `BUILD_BLOCKED`, `APPLY_CONFLICTS`
and a new `APPLY_TOOL_MISSING` are all zero. `stow` counts into the third rather
than into `BUILD_BLOCKED`, keeping the existing rule that a build does not need
stow while stopping doctor recommending an apply that does.

The `stow -D -p --no-folding … && shale apply` sweep is suppressed whole rather
than trimmed: the `&&` is on stow's exit status, not the apply's, so with a
blocked build the unstow succeeds, the apply exits 1, and `$HOME` is left
unstowed and not restowed — worse than the state the reader started in.

The review also found `doctor` offering `shale which` while the config does not
parse, which is the state `which` itself refuses in; those two lines are gated
on `CONFIG_ERRORS`.

Each gate has a case, red before green, and a mutant dropping one input at a
time — `BUILD_BLOCKED` reddens four cases, `APPLY_CONFLICTS` two,
`APPLY_TOOL_MISSING` two, the config gates one — so no gate is redundant.
Functional review diffed the whole report against `main` on ten sound fixtures:
byte-identical stdout, stderr and exit code on every one.

549 -> 553 cases, `0 failed, 0 skipped`, on bash 5.2.21 with GNU Stow 2.3.1 and
on macOS 26.4 under bash 3.2.57 with GNU Stow 2.4.1.