### PR TITLE
Say nothing in doctor about the everyday states

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ alone, so `bash -x shale build` still works.
 
 The file is still composed into `current/`; the pattern changes only what stow links. So a pattern
 that matches more than it was meant to leaves a real file unlinked with `shale apply` exiting 0, and
-two commands report that: `shale doctor` names every pattern in force with the file and line it came
-from, and `shale which PATH` says when a path is on the list and which pattern put it there. Adding a
-pattern does not unlink what an earlier apply already linked — stow skips an ignored path rather than
-unstowing it — so `doctor` names those leftover links too, and removing them is the whole of the fix.
+two commands report that: `shale doctor` names the patterns in force, with the file and line each
+came from, where the built tree holds a file they cover, and `shale which PATH` says when a path is
+on the list and which pattern put it there. Adding a pattern does not unlink what an earlier apply
+already linked — stow skips an ignored path rather than unstowing it — so `doctor` names those
+leftover links too, and removing them is the whole of the fix.
 [docs/layers.md](docs/layers.md#blocking-a-file-without-removing-it) has the detail.
 
 ## Declaring the mode of a path
@@ -215,8 +216,9 @@ Builds are quiet. A build that finds `current` holding a copy older than the lay
 keeps the previous tree at `~/.dotfiles/current.old` and says nothing, because an edited layer leaves
 exactly that state and a message there would be a message on every edit. `shale doctor` is what
 reports the mismatch, as a note rather than a problem, and only until the build that overwrites it.
-After that build it reports `current.old` instead, until the build after that removes it — see
-[docs/layers.md](docs/layers.md).
+After that build nothing reports it: what was there sits at `~/.dotfiles/current.old` until the next
+build removes it, and `doctor` names it again only where a problem it found means no build is coming
+— see [docs/layers.md](docs/layers.md).
 
 Shale chooses between three exit codes, and no others:
 
@@ -365,9 +367,9 @@ nothing in `$HOME` at a path the layers provide is something no apply put there 
 directory, or a link of your own, none of which stow will write over — that no layer ships
 `.stow-local-ignore`, which shale writes itself, or shale itself, that `~/.dotfiles/current` is a
 directory rather than a file or a link to one, that the
-build lock is neither held nor uncreatable, that nothing in `~/.dotfiles` is a stray, that neither
-`current.new` nor `current.old` has been left beside `current`, and that no
-link in `$HOME` points into the built tree at a path it no longer provides, and that something from
+build lock is neither held nor uncreatable, that nothing in `~/.dotfiles` is a stray, that no
+`current.new` has been left beside `current` and no `current.old` that no build is coming to
+remove, and that no link in `$HOME` points into the built tree at a path it no longer provides, and that something from
 that tree is linked in `$HOME` at all — a built tree with nothing linked is what a machine that has
 never been applied looks like, and nothing in it is in use. Where a `.stowrc` exists
 it names the stow options that file sets, because several of them change an apply and three of them

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -664,13 +664,15 @@ before this syntax existed.
 ### When a pattern arrives late
 
 The file is still composed into `current/`; the pattern changes only what stow links. Two commands
-report what the list is doing:
+report what the list is doing. `doctor` names the list where the built tree holds a file it covers,
+and says nothing about a list that is covering nothing — a pattern written before the junk it is for
+is withholding no file from `$HOME` and has nothing to report:
 
 ```
 $ shale doctor
-shale: 3 ignore patterns are in force
+shale: 3 ignore patterns are in force, and the built tree holds 1 file they cover
 shale:   shale writes them into /home/you/.dotfiles/current/.stow-local-ignore, below stow's own list, so no apply links a path they match
-shale:   a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named below
+shale:   a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named above
 shale:   /home/you/.dotfiles/personal/.shale-ignore
 shale:   line 3: .DS_Store
 shale:   line 4: *.swp
@@ -774,9 +776,11 @@ are still named; what changes is that nothing promises you a `current.old` that 
 never creates.
 
 `doctor` names the files only in the window between one arriving and the next build. Afterwards the
-built copy is the layer's again and the mismatch is gone; what `doctor` says then is that
-`current.old` is there and that the next build removes it, so recovery is `current.old` and one
-build deep. If you use `stow --adopt` against `current/`, run `shale doctor` before you build.
+built copy is the layer's again, the mismatch is gone, and `doctor` says nothing at all — the copy
+is still in `current.old` and still one build from gone, but that tree is what every rebuild leaves
+and naming it after each one would be naming it after every edit. `doctor` names `current.old`
+where a problem it found means no build is coming to clear it, and there only. So the window is the
+one before the build: if you use `stow --adopt` against `current/`, run `shale doctor` first.
 
 ## The everyday loop: build, and when to apply
 
@@ -789,8 +793,9 @@ each layer. It keeps `current.old` — the built copy your edit replaced was old
 the layer copy, which is the state a file moved into the tree also leaves, and shale keeps the
 previous tree either way — but it prints no message about it, because a message there is a message
 on every edit. `shale doctor` is where a built tree its layers have moved past is reported, and
-after a build the mismatch is gone; what doctor names then is `current.old` itself — what it holds,
-and that the next build removes it.
+after a build the mismatch is gone. Doctor is silent about the `current.old` that build left as
+well, for the reason the build is: the next build removes it, and a line about it after every
+rebuild is a line after every edit.
 
 `shale apply` is what you need when a **path** appears or disappears, since making and unmaking links
 is stow's job and nothing else does it:

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -15,12 +15,17 @@ this over a connection you are not relying on the dotfiles to make.
 One thing to know before you start, rather than after: do not use `stow --adopt`. Your first apply
 will refuse a pile of conflicts, `--adopt` is what a search turns up for clearing them, and here it
 moves your file out of `$HOME` and into `~/.dotfiles/current`, which is generated output that the
-next `shale build` overwrites. That build says nothing about it — it keeps the whole previous tree
-at `current.old`, so an adopted file survives one build and no more, and the build after that
-removes `current.old`. The command that tells you is `shale doctor`: run it before you build and it
-names the file, run it after and it names `current.old` as a tree the next build removes. Or copy
-the file into a layer instead, and there is nothing to recover. The refusals themselves are covered
-below, each with what to do about it.
+next `shale build` overwrites. That build keeps the whole previous tree at `current.old`, so an
+adopted file survives one build and no more, and the build after that removes `current.old`. What
+the build says about it depends on which way the timestamps fall: a file newer than the layer copy
+it replaces gets three lines on stderr naming it and naming its copy in `current.old`, and one older
+— which is what `--adopt` leaves when the file in `$HOME` predates the layer's — gets nothing,
+because an edited layer leaves that same state and the message would be on the loop you run all day.
+`shale doctor` is what covers the silent direction, and the time to run it is before you build,
+while it still names the file: after the build the copy is in `current.old` and doctor says nothing
+about it either, that tree being what every rebuild leaves. Or copy the file into a layer instead,
+and there is nothing to recover. The refusals themselves are covered below, each with what to do
+about it.
 
 ## Coming from plain files
 
@@ -318,10 +323,11 @@ not detectable — one more reason to copy the file into a layer rather than ado
 same note from a `doctor` run any time after pulling a layer and before building, and it is nothing
 to act on there —
 which is why it is a note and `doctor` still exits 0. Either way the previous tree is at
-`current.old` and your file is in it, until the next clean build removes it. After that build
-`doctor` cannot see the mismatch any more, because the built copy matches the layer again — what it
-still says is that `current.old` is there, what it holds and that the next build removes it, which is
-the last warning you get. Copy the file into a layer instead and there is nothing to recover.
+`current.old` and your file is in it, until the next clean build removes it. The note above is the
+last warning you get: after that build `doctor` cannot see the mismatch any more, because the built
+copy matches the layer again, and it says nothing about `current.old` either — every rebuild leaves
+one, so a line about it would be a line after every edit. Copy the file into a layer instead and
+there is nothing to recover.
 
 ## Links left behind after layers change
 

--- a/shale
+++ b/shale
@@ -2535,6 +2535,13 @@ BUILD_BLOCKED=0
 # build runs without it, so a report that stopped offering one would be wrong
 # about the command that still works.
 APPLY_TOOL_MISSING=0
+# The same, for the two audit_ignored_links leaves behind it: cmd_doctor reads
+# both from outside the function that writes them, and the shell takes an
+# increment of an unset name under 'set -u' down with it rather than counting
+# wrongly.  A 'return' added above the pair inside that function would otherwise
+# turn a wrong count into a dead script.
+IGNORED_FILE_COUNT=0
+IGNORED_WALK_PARTIAL=0
 
 # Zero when doctor may offer an apply.  Every line it prints that names 'shale
 # apply' is gated on this - one question, answered in one place, so that the
@@ -3736,7 +3743,14 @@ audit_unapplied_tree() {
 scan_ignored_links() {
   local rel=$1 inherited=$2 cap=$3 here e base srel ignored link
   here=$CUR${rel:+/$rel}
-  { [ -r "$here" ] && [ -x "$here" ]; } || return 0
+  if [ ! -r "$here" ] || [ ! -x "$here" ]; then
+    # Recorded, because the count this walk fills is read as an answer about the
+    # whole tree: a directory it could not open holds files it cannot say are
+    # covered, and 'covered nothing' and 'could not look' are not the same
+    # report.  audit_built_tree names the directory itself, so nothing here does.
+    IGNORED_WALK_PARTIAL=1
+    return 0
+  fi
   # Both patterns, and '.' and '..' dropped by name, whatever the glob options
   # say about them.
   list_dir "$here" 1
@@ -3765,6 +3779,13 @@ scan_ignored_links() {
       continue
     fi
     [ "$ignored" -ne 0 ] || continue
+    # The files an ignore file's own patterns hold out of $HOME, whether or not
+    # a link was ever made at one: what makes the list worth naming is that it
+    # is withholding something, and this is the count that says whether it is.
+    # stow's own list is not counted - there is no line of anybody's to edit for
+    # it, so a report naming the configured patterns for it would send the
+    # reader to the wrong file.
+    [ "$ignored" -ne 1 ] || IGNORED_FILE_COUNT=$((IGNORED_FILE_COUNT + 1))
     # --no-folding gives every file its own link, so the link that has to go is
     # at the leaf however far above it the pattern matched.
     link=$HOME_PREFIX/$srel
@@ -3797,6 +3818,12 @@ scan_ignored_links() {
 # They stop no build, so BUILD_BLOCKED is left alone.
 audit_ignored_links() {
   local cap n i rest msg lines links made removes
+  # Ahead of the three refusals below, and the whole of what says the walk
+  # happened: the note cmd_doctor prints from this count reads a tree that was
+  # never walked as a list covering nothing, which is what a tree that is not
+  # there holds.
+  IGNORED_FILE_COUNT=0
+  IGNORED_WALK_PARTIAL=0
   [ -d "$CUR" ] || return 0
   [ ! -L "$CUR" ] || return 0
   [ -n "${HOME-}" ] || return 0
@@ -5858,7 +5885,7 @@ cmd_apply() {
 # before it found, and only the finding count decides the exit status.
 cmd_doctor() {
   local tool i n name path root dir entry leaf known remedy qlock lines layers
-  local pending removed
+  local pending removed covers
 
   FINDINGS=0
   NOTES=0
@@ -6158,43 +6185,6 @@ cmd_doctor() {
     done
   fi
 
-  # The patterns in force, named for the reason the resource file below is: one
-  # that matches more than it was meant to leaves a real file unlinked with
-  # apply exiting 0, and this is the only place they are all shown without
-  # reading the built tree by hand.  A note, never a finding - somebody wrote
-  # them on purpose - and printed only where there are some, so a tree with no
-  # ignore file reports exactly as it did before there were any.
-  #
-  # Grouped by file, because they concatenate across clone roots and 'which
-  # file do I edit' is the question the list is read with.
-  if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ]; then
-    n=${#IGNORE_PATTERNS[@]}
-    # The second line says what an apply does and the third what it does not
-    # undo, because without the third this headline reads as a claim about
-    # $HOME as it stands - and the links audit_ignored_links names below are
-    # exactly the paths it would then be contradicting.
-    if [ "$n" -eq 1 ]; then
-      lines=('1 ignore pattern is in force'
-        "shale writes it into $CUR/.stow-local-ignore, below stow's own list, so no apply links a path it matches"
-        'a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named below')
-    else
-      lines=("$n ignore patterns are in force"
-        "shale writes them into $CUR/.stow-local-ignore, below stow's own list, so no apply links a path they match"
-        'a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named below')
-    fi
-    entry=
-    i=0
-    while [ "$i" -lt "$n" ]; do
-      if [ "${IGNORE_FILES[$i]}" != "$entry" ]; then
-        entry=${IGNORE_FILES[$i]}
-        lines[${#lines[@]}]=$entry
-      fi
-      lines[${#lines[@]}]="line ${IGNORE_LINES[$i]}: ${IGNORE_PATTERNS[$i]}"
-      i=$((i + 1))
-    done
-    note ${lines[@]+"${lines[@]}"}
-  fi
-
   # One of shale's own two files where shale does not read it: beside the
   # config, where the config is, or anywhere inside a layer, which the walk
   # above found at any depth.  Neither is read by anything and neither is
@@ -6268,6 +6258,65 @@ cmd_doctor() {
   # list covers, against what $HOME still links.
   audit_ignored_links
 
+  # The patterns in force, under the walk that says whether they are doing
+  # anything: one that matches more than it was meant to leaves a real file
+  # unlinked with apply exiting 0, and this is the only place they are all shown
+  # without reading the built tree by hand.  A note, never a finding - somebody
+  # wrote them on purpose.
+  #
+  # Printed where the built tree holds a file they cover, which is what gives
+  # the reader something to check the list against.  Having patterns is not
+  # news: README tells a first-time reader to write '.DS_Store' into an ignore
+  # file, and a report that named the list for existing put five lines above
+  # every run they ever made and left 'no problems found' saying nothing by
+  # never appearing alone.  A pattern that covers nothing is withholding
+  # nothing, and has no file in $HOME or in the tree to be wrong about.
+  #
+  # And printed where the walk could not read the whole tree, with the count
+  # left off rather than stated: a directory it could not open is where a
+  # covered file hides, so silence there would be this report answering 'none'
+  # to a question it did not get to ask.  audit_built_tree has already named the
+  # directory; this says the list exists, which is the half that walk cannot.
+  #
+  # Grouped by file, because they concatenate across clone roots and 'which
+  # file do I edit' is the question the list is read with.
+  if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] &&
+    { [ "$IGNORED_FILE_COUNT" -gt 0 ] || [ "$IGNORED_WALK_PARTIAL" -eq 1 ]; }; then
+    n=${#IGNORE_PATTERNS[@]}
+    entry='files'
+    [ "$IGNORED_FILE_COUNT" -ne 1 ] || entry='file'
+    # The second line says what an apply does and the third what it does not
+    # undo, because without the third this headline reads as a claim about
+    # $HOME as it stands - and the links audit_ignored_links names above are
+    # exactly the paths it would then be contradicting.
+    if [ "$n" -eq 1 ]; then
+      covers=
+      [ "$IGNORED_WALK_PARTIAL" -eq 1 ] ||
+        covers=", and the built tree holds $IGNORED_FILE_COUNT $entry it covers"
+      lines=("1 ignore pattern is in force$covers"
+        "shale writes it into $CUR/.stow-local-ignore, below stow's own list, so no apply links a path it matches"
+        'a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named above')
+    else
+      covers=
+      [ "$IGNORED_WALK_PARTIAL" -eq 1 ] ||
+        covers=", and the built tree holds $IGNORED_FILE_COUNT $entry they cover"
+      lines=("$n ignore patterns are in force$covers"
+        "shale writes them into $CUR/.stow-local-ignore, below stow's own list, so no apply links a path they match"
+        'a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named above')
+    fi
+    entry=
+    i=0
+    while [ "$i" -lt "$n" ]; do
+      if [ "${IGNORE_FILES[$i]}" != "$entry" ]; then
+        entry=${IGNORE_FILES[$i]}
+        lines[${#lines[@]}]=$entry
+      fi
+      lines[${#lines[@]}]="line ${IGNORE_LINES[$i]}: ${IGNORE_PATTERNS[$i]}"
+      i=$((i + 1))
+    done
+    note ${lines[@]+"${lines[@]}"}
+  fi
+
   # The declarations against $HOME: the detail behind the one line an apply
   # prints when it leaves a directory as it is, and the declarations that never
   # reached $HOME at all.
@@ -6306,14 +6355,26 @@ cmd_doctor() {
         'shale clears that path before it swaps' \
         "$removed"
     elif [ -d "$CUR" ] && [ ! -L "$CUR" ]; then
+      # Only where the build that reaps it is not going to run.  Either
+      # direction of the comparison keeps this tree, and an edited layer is one
+      # of them - it leaves every path that layer provides newer than the copy
+      # in the tree - so the everyday loop keeps one on every rebuild, and a
+      # line about it on every run is a line nobody reads.  Neither direction is
+      # named, for the reason the build names neither: what is in the tree is
+      # not doctor's to say, and a cause guessed at sends a reader looking for
+      # the wrong file.  What is left is the one thing the build that kept it
+      # could not know, which is that nothing is coming to clear it.
+      #
       # What the path is for, never what is in it: nothing here has looked, and
       # a build that kept it because one file differed leaves a whole tree, while
       # an empty one told that it holds the last copy of something is a lie in
       # the direction that costs a reader time.
-      note "$OLD is where a build leaves the tree it replaced" \
-        'a build keeps it where it replaced a file that did not match the layer copy providing it' \
-        "$removed" \
-        'copy anything in it you want to keep into a layer first'
+      if [ "$BUILD_BLOCKED" -gt 0 ]; then
+        note "$OLD is where a build leaves the tree it replaced" \
+          'the last build kept it because the copies it replaced were not the ones the layers now provide' \
+          "$removed" \
+          'copy anything in it you want to keep into a layer first'
+      fi
     else
       # The shape a kill between the two renames leaves, and the one a hand that
       # removed $CUR leaves too.  Only what is on disk is stated: the composed

--- a/tests/run
+++ b/tests/run
@@ -8082,6 +8082,12 @@ test_doctor_names_the_ignore_patterns_in_force() {
   conf 'base common/base' 'local local'
   mklayer common/base .zshrc
   mklayer local .vimrc
+  # The junk the patterns below are written for, in the layers before the build
+  # so the tree holds it: what the list is withholding from $HOME is the whole
+  # of why the list is named at all.
+  mklayer common/base .DS_Store
+  mklayer common/base notes.swp
+  mklayer local Thumbs.db
   mkignore common '# junk' '.DS_Store' '*.swp'
   mkignore local 'Thumbs.db'
   # Applied first, so that the closing line counts this note and nothing else:
@@ -8091,15 +8097,16 @@ test_doctor_names_the_ignore_patterns_in_force() {
   assert_status 0 "$shale_status" 'the apply'
   run_shale doctor
   assert_status 0 "$shale_status"
-  assert_contains "$shale_out" 'shale: 3 ignore patterns are in force' 'stdout'
+  assert_contains "$shale_out" \
+    'shale: 3 ignore patterns are in force, and the built tree holds 3 files they cover' 'stdout'
   assert_contains "$shale_out" \
     "shale:   shale writes them into $HOME/.dotfiles/current/.stow-local-ignore, below stow's own list, so no apply links a path they match" \
     'stdout'
   # The qualification is not decoration: without it this headline reads as a
-  # claim about $HOME as it stands, four lines above findings naming links at
-  # exactly the paths it just said nothing links.
+  # claim about $HOME as it stands, above findings naming links at exactly the
+  # paths it just said nothing links.
   assert_contains "$shale_out" \
-    'shale:   a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named below' \
+    'shale:   a link an earlier apply made at such a path stays until it is removed by hand, and any this report found are named above' \
     'stdout'
   assert_contains "$shale_out" "shale:   $HOME/.dotfiles/common/.shale-ignore" 'stdout'
   assert_contains "$shale_out" 'shale:   line 2: .DS_Store' 'stdout'
@@ -8110,11 +8117,13 @@ test_doctor_names_the_ignore_patterns_in_force() {
   mkignore local '# nothing here now'
   run_shale doctor
   assert_status 0 "$shale_status" 'the second doctor'
-  assert_contains "$shale_out" 'shale: 2 ignore patterns are in force' 'the second stdout'
+  assert_contains "$shale_out" \
+    'shale: 2 ignore patterns are in force, and the built tree holds 2 files they cover' 'the second stdout'
   mkignore common '.DS_Store'
   run_shale doctor
   assert_status 0 "$shale_status" 'the third doctor'
-  assert_contains "$shale_out" 'shale: 1 ignore pattern is in force' 'the third stdout'
+  assert_contains "$shale_out" \
+    'shale: 1 ignore pattern is in force, and the built tree holds 1 file it covers' 'the third stdout'
   assert_contains "$shale_out" \
     "shale:   shale writes it into $HOME/.dotfiles/current/.stow-local-ignore, below stow's own list, so no apply links a path it matches" \
     'the third stdout'
@@ -8132,6 +8141,52 @@ test_doctor_says_nothing_about_ignoring_without_an_ignore_file() {
   assert_not_contains "$shale_out" 'ignore pattern' 'stdout'
   assert_not_contains "$shale_out" 'stow-local-ignore' 'stdout'
   assert_eq "$(doctor_unapplied_report)" "$shale_out" 'stdout'
+}
+
+# A walk that could not read the whole built tree may not answer 'nothing': the
+# directory it could not open is exactly where a covered file hides, so a report
+# that went quiet about the list there would be answering a question it never
+# got to ask.  What goes is the count, not the note.
+test_doctor_names_the_ignore_patterns_where_it_could_not_read_the_tree() {
+  local doctor_out doctor_status
+  skip_if_root
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mklayer common/base sub/.DS_Store
+  mkignore common '.DS_Store'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  chmod 0000 "$HOME/.dotfiles/current/sub" || fail 'could not remove the mode bits'
+  run_shale doctor
+  doctor_out=$shale_out
+  doctor_status=$shale_status
+  chmod 0755 "$HOME/.dotfiles/current/sub" || fail 'could not restore the mode'
+  assert_status 0 "$doctor_status"
+  assert_contains "$doctor_out" 'shale: 1 ignore pattern is in force' 'stdout'
+  # The only file the pattern covers is under the directory nothing could open,
+  # so there is no count to state and none is stated.
+  assert_not_contains "$doctor_out" 'the built tree holds' 'stdout'
+  assert_contains "$doctor_out" "shale:   $HOME/.dotfiles/common/.shale-ignore" 'stdout'
+  assert_contains "$doctor_out" 'shale:   line 1: .DS_Store' 'stdout'
+}
+
+# And the silence that matters more, because README tells a first-time reader to
+# write exactly this file: patterns that cover nothing in the built tree are
+# withholding nothing from $HOME, and a list is not news for existing.  Naming
+# it on every run put five lines above every report and left 'no problems found'
+# unreachable for anyone who took that advice.
+test_doctor_says_nothing_about_an_ignore_list_that_covers_nothing() {
+  conf 'base common/base'
+  mklayer common/base .zshrc
+  mkignore common '.DS_Store' '*.swp'
+  # Applied, so that the report below is the bare verdict rather than the note
+  # doctor prints for a tree nothing has linked.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  assert_empty "$shale_err" 'stderr'
 }
 
 # doctor names the paths in $HOME that stow will refuse to write over, and it
@@ -8514,6 +8569,12 @@ test_doctor_names_links_left_behind_by_a_new_pattern() {
   assert_contains "$shale_out" 'shale: remove the links named above' 'stdout'
   assert_contains "$shale_out" \
     'shale:   stow skips an ignored path rather than unstowing it, so no build or apply removes one' 'stdout'
+  # The list itself, under the links it covers: this is the report that has a
+  # reason to show which pattern took which file out of $HOME, and the file to
+  # edit is the one thing a reader with a link to remove still has to find.
+  assert_contains "$shale_out" \
+    'shale: 2 ignore patterns are in force, and the built tree holds 2 files they cover' 'stdout'
+  assert_contains "$shale_out" 'shale:   line 2: junk' 'stdout'
   assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
   # The remedy is the whole of the fix: no rebuild, no reapply.  The directory
   # is resolved and the leaf removed from it, sandbox_leaf refusing to hand back
@@ -8676,6 +8737,9 @@ test_doctor_notes_an_ignore_file_nothing_reads() {
   mklayer common/base .zshrc
   mklayer local .vimrc
   mklayer local/sub .inputrc
+  # Covered by the one ignore file shale does read, so that its patterns are in
+  # the report below to contrast with the four that are read by nothing.
+  mklayer local Thumbs.db
   sandbox_write "$HOME/.dotfiles" .shale-ignore '.DS_Store'
   sandbox_write "$HOME/.dotfiles/common/base" .shale-ignore '.DS_Store'
   sandbox_write "$HOME/.dotfiles/common/base/.config/nvim" .shale-ignore '.DS_Store'
@@ -8698,7 +8762,8 @@ test_doctor_notes_an_ignore_file_nothing_reads() {
   # The one shale does read is a layer's top as well, and is not named.
   assert_not_contains "$shale_out" \
     "shale: $HOME/.dotfiles/local/.shale-ignore is read by nothing" 'stdout'
-  assert_contains "$shale_out" 'shale: 1 ignore pattern is in force' 'stdout'
+  assert_contains "$shale_out" \
+    'shale: 1 ignore pattern is in force, and the built tree holds 1 file it covers' 'stdout'
   # Once, however many layers' walks reach it: 'local' descends into 'sub' and
   # 'local/sub' lists it directly, so without the dedup this file is named
   # twice and counted twice.
@@ -10978,17 +11043,19 @@ test_doctor_notes_a_leftover_scratch_tree() {
   assert_eq 'shale: no problems found' "$shale_out" 'the whole report after the build'
 }
 
-# The tree a build keeps deliberately, which until now sat in ~/.dotfiles with
-# nothing saying what it was: the build that kept it named the one file, and one
-# build later that message is scrollback and the copy is gone.
-test_doctor_notes_the_tree_the_last_build_kept() {
+# The tree a build keeps deliberately, and the state that made 'no problems
+# found' unreachable: editing a layer is what keeps it, so a report that named
+# it said something on every run for two builds after every edit.  The build
+# that kept it is what names the file it kept - here, the hand-edited copy - and
+# the next build reaps the tree, so doctor has nothing of its own to add.
+test_doctor_says_nothing_about_the_tree_the_last_build_kept() {
   conf 'base personal/base' 'local local'
   mklayer personal/base .zshrc
   mklayer local .zshrc
   sandbox_mkdir "$HOME/.dotfiles/local"
   touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
-  # Applied, so that the note counted below is this one: a built tree nothing
-  # has linked is a note of its own.
+  # Applied, so that a clean report here is the bare verdict: a built tree
+  # nothing has linked is a note of its own.
   run_shale apply
   assert_status 0 "$shale_status" 'the first apply'
   assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
@@ -10999,18 +11066,87 @@ test_doctor_notes_the_tree_the_last_build_kept() {
   run_shale build
   assert_status 0 "$shale_status" 'the build that keeps the tree'
   assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
+  # The signal that survives this silence, and the one that names the path: the
+  # build itself, at the moment it keeps the tree.
+  assert_contains "$shale_err" \
+    "shale:   the layer copy wins; what was there is kept at $HOME/.dotfiles/current.old/.zshrc until the next build, to copy into a layer if it was your edit" \
+    'the build stderr'
   run_shale doctor
   assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# The everyday loop the report has to stay quiet through: edit one line of one
+# layer file, rebuild, and every path that layer provides is newer than the copy
+# the build replaces, so the build keeps current.old.  Doing what README
+# recommends may not cost a reader their clean report.
+test_doctor_says_nothing_about_the_tree_an_ordinary_rebuild_kept() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  # Dated, so that the edit below is newer than the built copy by more than a
+  # filesystem's timestamp resolution, whatever that resolution is.
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
+  mklayer personal/base .zshrc 'edited'
+  run_shale build
+  assert_status 0 "$shale_status" 'the rebuild'
+  assert_empty "$shale_err" 'the rebuild stderr'
+  assert_exists "$HOME/.dotfiles/current.old" 'the tree the rebuild kept'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# And where that silence would be wrong: the tree is reaped by the next build,
+# so it is worth a line exactly where there is not going to be one.  The note
+# says what happened rather than reporting a fault - an edited layer is the
+# ordinary cause, and a reader told their build 'replaced a file that did not
+# match' goes looking for damage that is not there.
+test_doctor_names_the_kept_tree_no_build_will_clear() {
+  local line first
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.dotfiles/current.old"
+  # A layer with no directory and no url, which stops every build from now on.
+  conf 'base personal/base' 'gone gone'
+  run_shale doctor
+  assert_status 1 "$shale_status"
   assert_contains "$shale_out" \
     "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
   assert_contains "$shale_out" \
-    'shale:   a build keeps it where it replaced a file that did not match the layer copy providing it' \
+    'shale:   the last build kept it because the copies it replaced were not the ones the layers now provide' \
     'stdout'
-  assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
+  # Neither direction of the comparison is named: an edited layer keeps this
+  # tree and so does a file moved into the built tree, and the line under this
+  # one is only worth reading if the cause was the second.
+  assert_not_contains "$shale_out" 'which is what editing a layer does' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   no build will run until the problems above are fixed, so it stays where it is' 'stdout'
   assert_contains "$shale_out" \
     'shale:   copy anything in it you want to keep into a layer first' 'stdout'
-  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
-  assert_empty "$shale_err" 'stderr'
+  assert_not_contains "$shale_out" 'did not match the layer copy' 'stdout'
+  # The finding is the first thing the report says, not the fifth: a note that
+  # follows the reader's ordinary use may not stand above the one line they ran
+  # doctor to find.
+  first=
+  while IFS= read -r line; do
+    case "$line" in
+      'shale:   '*) ;;
+      'shale: '*) [ -n "$first" ] || first=$line ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq \
+    "shale: layer 'gone' has no directory at $HOME/.dotfiles/gone and no url for 'gone'" \
+    "$first" 'the first line of the report'
 }
 
 # The state a kill between the two renames leaves, which is the one where saying
@@ -11104,22 +11240,22 @@ test_doctor_names_no_interrupted_build_where_there_cannot_have_been_one() {
 # Nothing has looked inside either tree, so nothing may say what is in one.  An
 # empty current.old is the state a build that composed no file at all leaves,
 # and 'copy anything in it you want to keep' is the whole of what a report that
-# did not walk it can offer.
+# did not walk it can offer.  The blocked build is what makes the note print at
+# all: with one to reap the tree there is nothing to say about it.
 test_doctor_claims_no_contents_for_a_tree_it_has_not_walked() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
-  # Applied, so that the note counted below is this one: a built tree nothing
-  # has linked is a note of its own.
   run_shale apply
   assert_status 0 "$shale_status" 'the apply'
   sandbox_mkdir "$HOME/.dotfiles/current.old"
+  conf 'base personal/base' 'gone gone'
   run_shale doctor
-  assert_status 0 "$shale_status"
+  assert_status 1 "$shale_status"
   assert_contains "$shale_out" \
     "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
   assert_not_contains "$shale_out" 'holds what' 'stdout'
   assert_not_contains "$shale_out" 'it is the only copy' 'stdout'
-  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
 }
 
 # Every line doctor prints that says what the next build does is gated on there


### PR DESCRIPTION
Closes #133.

After doing the two things `README.md` recommends — create a `.shale-ignore`,
edit a layer — `doctor` never printed a bare `no problems found` again, and when
it did find something real the real line was fifth of six. A report that always
says something trains the reader to skim it.

The ignore-list note now prints only where the built tree holds a file the list
covers, and the `current.old` note's routine arm only where a problem means no
build is coming to remove it. Same fixture, same script:

    main:   9 note lines, ending 'no problems found, but read the 2 notes above'
    branch: shale: no problems found

`current.old` is on disk in both runs — the suppression is doctor's, not a
change to what `build` does.

The trade, stated plainly because it is real: a file edited through a `$HOME`
symlink, or adopted into the tree newer than its layer copy, now gets one
warning instead of two. The build's own stderr names the file and the
`current.old` path; doctor no longer repeats it. Doctor keeps no state and
cannot tell an adopt from an edit without walking `current.old` against
`current`, which the note's design forbids, so the choice was a line on every
rebuild or no line.

A pattern that matches nothing deliberately does not fire the note: `README.md`
tells the reader to write `.DS_Store` before the junk exists, so that trigger
fires in exactly the scenario this issue was filed about.

Functional review diffed 17 fixtures against `main` — byte-identical on 13, the
four differences being the intended states — and reproduced the trade end to
end with a real `stow --adopt`.

553 -> 557 cases, `0 failed, 0 skipped`, on bash 5.2.21 with GNU Stow 2.3.1 and
on macOS 26.4 under bash 3.2.57 with GNU Stow 2.4.1.