### PR TITLE
Say what doctor's stray scan covers, rather than more than it covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,14 +366,14 @@ it cannot open, that no two layers disagree about whether a path is a file or a 
 nothing in `$HOME` at a path the layers provide is something no apply put there — a file, a
 directory, or a link of your own, none of which stow will write over — that no layer ships
 `.stow-local-ignore`, which shale writes itself, or shale itself, that `~/.dotfiles/current` is a
-directory rather than a file or a link to one, that the
-build lock is neither held nor uncreatable, that nothing in `~/.dotfiles` is a stray, that no
-`current.new` has been left beside `current` and no `current.old` that no build is coming to
-remove, and that no link in `$HOME` points into the built tree at a path it no longer provides, and that something from
+directory rather than a file or a link to one, that the build lock is neither held nor uncreatable,
+that nothing in `~/.dotfiles` whose name does not begin with a dot is a stray, that no `current.new`
+has been left beside `current` and no `current.old` that no build is coming to remove, and that no
+link in `$HOME` points into the built tree at a path it no longer provides, and that something from
 that tree is linked in `$HOME` at all — a built tree with nothing linked is what a machine that has
-never been applied looks like, and nothing in it is in use. Where a `.stowrc` exists
-it names the stow options that file sets, because several of them change an apply and three of them
-make it do nothing at all. It changes nothing itself.
+never been applied looks like, and nothing in it is in use. Where a `.stowrc` exists it names the
+stow options that file sets, because several of them change an apply and three of them make it do
+nothing at all. It changes nothing itself.
 
 ```
 $ shale doctor
@@ -401,6 +401,31 @@ shale:   add a url on that line, or create the directory
 shale: /home/you/.dotfiles/old-tmux is not a configured layer
 shale:   it may be a leftover stow package, a stray clone, or a layer you removed from the config
 shale: 1 problem found
+```
+
+That scan reads the names in `~/.dotfiles` that do not begin with a dot, and only those. The
+directory is usually a git clone, so it is full of dot names that are exactly where they belong —
+`.git`, `.gitignore`, `.github` — and naming those would bury the strays worth reading under a list
+of files there is nothing to do about. What that costs is the dot-named stray: put a `.tmux.conf`,
+or a leftover `.old-layer` directory, straight into `~/.dotfiles` rather than into a layer and
+doctor says nothing about it, where the same two without the dot are both reported. `shale which
+.tmux.conf` will not lead you to it either — it answers about layers, and no layer provides it.
+Dotfiles belong inside a layer, at the path they take in `$HOME`.
+
+The dot names doctor does report come from checks of their own rather than from that scan, and each
+knows one thing: a `.stowrc` gets the note about the stow options it sets, a `.lock` the report on
+the build lock, and `.shale-ignore` and `.shale-modes` are looked for by name beside the config and
+inside every configured layer, so a misplaced one is reported at either, up to the ten doctor names
+before it counts the rest. A copy anywhere else — beside a clone root's layers rather than at the
+top of it, or under a directory no config line makes a layer — is in neither place, and is as
+silent as any other dot name:
+
+```
+$ shale doctor
+shale: /home/you/.dotfiles/.shale-ignore is read by nothing
+shale:   shale reads one .shale-ignore per clone root, at /home/you/.dotfiles/<root>/.shale-ignore
+shale:   move it into the clone root whose layers it is about
+shale: no problems found, but read the note above
 ```
 
 ## Adding to a config file instead of replacing it

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -245,8 +245,9 @@ shale build
 shale which .zshrc
 ```
 
-`doctor` reports any package left in `~/.dotfiles` that no config line claims, which is how a
-package you forgot to convert shows up:
+`doctor` reports any package left in `~/.dotfiles` whose name does not begin with a dot and that no
+config line claims, which is how a package you forgot to convert shows up. One named with a leading
+dot is not reported — that scan reads no dot name at all — so check for those yourself:
 
 ```
 shale: /home/you/.dotfiles/common is not a configured layer

--- a/tests/run
+++ b/tests/run
@@ -7925,6 +7925,9 @@ test_doctor_dot_entries_are_never_strays() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
   sandbox_mkdir "$HOME/.dotfiles/.git"
+  # The three a clone root has of its own, which is the common shape of
+  # $HOME/.dotfiles and the one a scan reaching dot names would be noisiest on.
+  sandbox_mkdir "$HOME/.dotfiles/.github"
   # Not '.stowrc' and not '.lock': doctor has a line of its own for each of
   # those, and this case is about the ones it should say nothing at all about.
   sandbox_write "$HOME/.dotfiles" .gitignore 'current/'
@@ -7933,6 +7936,64 @@ test_doctor_dot_entries_are_never_strays() {
   assert_not_contains "$shale_out" 'is not a configured layer' 'stdout'
   assert_not_contains "$shale_out" 'is not a layer' 'stdout'
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The same rule from the reader's side rather than shale's, and the whole of
+# what the README promises about it in one report: the scan stops at the leading
+# dot, so 'tmux.conf' and 'old-layer' are notes while '.tmux.conf' and
+# '.old-layer' - the same two mistakes, made by someone whose files begin with a
+# dot - are silence.  The pair is what makes that silence readable: a case
+# planting the dot names alone goes green on a doctor that has stopped scanning
+# $HOME/.dotfiles at all, which is the same green for the opposite defect.
+#
+# The last third is the exception, and it belongs here rather than in a case of
+# its own because the two are one claim.  A reader who has met the
+# '.shale-ignore is read by nothing' note has been told a dot name in that
+# directory does get reported, so a README saying dot names are skipped reads as
+# wrong until it says which two are not: those come from a check that looks for
+# them by name, and so survives a scan that never sees them.
+test_doctor_the_stray_scan_stops_at_the_leading_dot() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  # Applied, because an unbuilt tree is a note of its own and so is a built one
+  # nothing has linked: the count below is of every note in the report, and it
+  # is the count that says nothing else was reported.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_write "$HOME/.dotfiles" tmux.conf 'set -g mouse on'
+  sandbox_write "$HOME/.dotfiles" .tmux.conf 'set -g mouse on'
+  sandbox_mkdir "$HOME/.dotfiles/old-layer"
+  sandbox_mkdir "$HOME/.dotfiles/.old-layer"
+  sandbox_write "$HOME/.dotfiles" .shale-ignore '.DS_Store'
+  # The placement the exception does not cover: inside the clone root, beside
+  # the layers rather than at the top of it, and under a directory no config
+  # line makes a layer.  The by-name check reads the config's layers and the
+  # top of $HOME/.dotfiles, and this is in neither - so it is silent, and a
+  # README that promised a misplaced one is reported wherever it is would be
+  # wrong here.  'personal' is a configured layer path's first component, so
+  # nothing above notes the directory holding it either.
+  sandbox_write "$HOME/.dotfiles/personal/sub" .shale-ignore '.DS_Store'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/tmux.conf is not a layer, and no build reads it" 'stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/old-layer is not a configured layer" 'stdout'
+  # The path with the prefix on its left and a space on its right, so the needle
+  # is a whole name in a whole line and matches whatever doctor might come to
+  # say about it.  Half of one - 'is not a layer', or the path without the
+  # 'shale: ' - is true of the two notes just asserted, and would make this pass
+  # by finding the entry that is meant to be reported.
+  assert_not_contains "$shale_out" "shale: $HOME/.dotfiles/.tmux.conf " 'stdout'
+  assert_not_contains "$shale_out" "shale: $HOME/.dotfiles/.old-layer " 'stdout'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/.shale-ignore is read by nothing" 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/personal/sub/.shale-ignore " 'stdout'
+  # Three, so the three silences above are silence in a report that had
+  # something to say: a fourth note is one of them reported after all.
+  assert_contains "$shale_out" \
+    'shale: no problems found, but read the 3 notes above' 'stdout'
 }
 
 # The scan is a glob and a -d test, and a directory that cannot be listed or


### PR DESCRIPTION
Closes #134.

`README.md` said `doctor` checks "that nothing in `~/.dotfiles` is a stray". The
scan calls `list_dir "$DOTFILES" 0`, which globs `"$dir"/*` only, so a leading-dot
name is never an entry — drop a `.tmux.conf` straight into `~/.dotfiles` and
nothing says so, while `tmux.conf` is reported.

The issue put two options up: include dot-entries and carry an exclusion list, or
keep the scan and correct the documentation. The second was chosen. `~/.dotfiles`
is usually a git clone, so the list would have to grow with every dot name any
other tool invents, and the noise is paid on every run by every user.

`shale` is byte-identical to `main` — same blob hash either side. Documentation
and tests only.

Both review gates falsified a first draft of the new text, which claimed
`.shale-ignore` and `.shale-modes` are "reported wherever it is". Measured, one
sandbox per placement:

    ~/.dotfiles/.shale-ignore                        reported
    ~/.dotfiles/personal/base/deep/er/.shale-ignore  reported
    ~/.dotfiles/personal/sub/.shale-ignore           silent
    ~/.dotfiles/notalayer/.shale-ignore              silent

The rule is beside the config and inside every configured layer, capped at the
ten `STRAY_CAP` names before the rest are counted. The text now says that, and a
new case pins the silent placement, which nothing pinned before.

557 -> 558 cases, `0 failed, 0 skipped`, on bash 5.2.21 with GNU Stow 2.3.1 and
on macOS 26.4 under bash 3.2.57 with GNU Stow 2.4.1.