### PR TITLE
Let SHALE_DIR override the dotfiles root

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ nothing else does.
 
 The config is machine-specific and belongs to the machine, not to any layer repo.
 
+`~/.dotfiles` is the default and not the only choice: set `SHALE_DIR` to an absolute path and that
+directory holds `shale.conf`, the layers and the built tree instead. Every path `shale` prints names
+the directory in force, the usage text above included. Trailing slashes are ignored; an unset or
+empty `SHALE_DIR` is `~/.dotfiles` exactly as before; and a message naming the variable refuses a
+relative path, a path starting with a literal `~`, `/` itself, and `$HOME` or any directory above it
+— shale composes into that directory and stows the result into `$HOME`, and stow will not link a
+directory into itself. What `apply` links into is `$HOME` whatever the root is: the variable moves
+where the material is kept, not where it lands. Every command reads it, so export it from the
+environment rather than setting it on one command line — a build under one root and an apply under
+another leave `$HOME` linked into a tree nothing rebuilds.
+
 ## Blocking a file from every apply
 
 `.shale-ignore`, at the top of a clone root, lists the files no apply should link:
@@ -189,6 +200,8 @@ usage:
 
 PATH is relative to ~/.dotfiles.  URL says how to clone PATH's top-level
 directory; give it once per directory and leave it off the other lines.
+
+SHALE_DIR, an absolute path, names that directory; ~/.dotfiles without it.
 
 A .shale-ignore file at the top of a clone root blocks paths from every apply.
 A .shale-modes file there declares modes, one "700  .ssh" per line.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,11 +1,12 @@
 # Authoring a layer
 
 A layer is a directory tree that mirrors your home directory. Everything in it is copied, path for
-path, into `~/.dotfiles/current`, and almost everything in `current` is linked into `$HOME`. A file
-at `personal/base/.config/nvim/init.lua` becomes `~/.config/nvim/init.lua`. The exception is the
-handful of names stow never links — version-control furniture, editor backups and emacs autosaves —
-which *Where a layer lives* below sets out; apart from those there is nothing else to learn about
-the mapping.
+path, into `~/.dotfiles/current` — or into `current` under whatever `SHALE_DIR` names, which the
+README's *Configuration* section covers — and almost everything in `current` is linked into `$HOME`.
+A file at `personal/base/.config/nvim/init.lua` becomes `~/.config/nvim/init.lua`. The exception is
+the handful of names stow never links — version-control furniture, editor backups and emacs
+autosaves — which *Where a layer lives* below sets out; apart from those there is nothing else to
+learn about the mapping.
 
 Shale copies files. It never merges them, never templates them and never reads what is inside one.
 Fragment directories, numeric prefixes and shared helper files are conventions for *your* layers,

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -7,6 +7,9 @@ into one package and stows that, so the move is mechanical — unstow what is th
 into layers, list them, apply. Both paths meet at *What a first apply refuses, and why*, and the way
 back out is the same for both.
 
+Every `~/.dotfiles` below is the default root; if you set `SHALE_DIR`, read it as that directory
+instead — the README's *Configuration* section says what the variable covers.
+
 Do it from a shell you can afford to lose. Either path takes `~/.zshrc`, `~/.profile` and everything
 beside them out of `$HOME` for a while — unstowed, or moved aside — and every shell opened between
 then and the apply falls back to the system defaults. Keep a second session already running, and do

--- a/shale
+++ b/shale
@@ -172,12 +172,6 @@ esac
 HOME_PREFIX=${HOME-}
 HOME_PREFIX=${HOME_PREFIX%/}
 
-DOTFILES=$HOME_PREFIX/.dotfiles
-CONF=$DOTFILES/shale.conf
-CUR=$DOTFILES/current
-NEW=$DOTFILES/current.new
-OLD=$DOTFILES/current.old
-
 # The mode of every directory shale makes for itself: the tree a build composes
 # into, and - by the two renames that install it - $CUR and the $OLD it
 # replaced.  Every one of them was 0777 against the caller's umask, so on the
@@ -280,6 +274,88 @@ die() {
   'it decides what every directory listing returns, so a build would drop layer files and name none of them' \
   'unset it, or take the readonly off it, in whatever set it before shale ran'
 
+# The dotfiles directory: everything shale reads that is not a layer's own file,
+# every layer, and the tree a build composes.  $HOME/.dotfiles unless SHALE_DIR
+# names somewhere else, and the whole of what SHALE_DIR moves - the stow target
+# is $HOME either way, because what an apply links into is the home being built
+# and not the place the material is kept.
+#
+# Below die rather than beside HOME_PREFIX at the top, for the reason the check
+# above is: both arms here stop the run, and die is what says so.  Nothing
+# between the two reads any of these names.
+SHALE_DIR=${SHALE_DIR-}
+if [ -n "$SHALE_DIR" ]; then
+  case "$SHALE_DIR" in
+    /*) ;;
+    # A leading '~' lands here with everything else relative, and correctly: the
+    # shell expands a tilde before shale is started, so one that arrives is a
+    # literal character somebody quoted, and shale expands nothing.  Exit 1 and
+    # not 2 - the command line is well formed, and the environment is not.
+    *)
+      die "SHALE_DIR is set to '$SHALE_DIR', which is not an absolute path" \
+        'it names the directory holding shale.conf, the layers and the tree a build composes' \
+        "give it a path beginning with '/', or unset it for $HOME_PREFIX/.dotfiles"
+      ;;
+  esac
+  # Trailing slashes off, exactly as HOME's come off above: every path below is
+  # written as '$DOTFILES/...', so a root that ends in one puts a '//' in the
+  # middle of every path shale prints and compares.
+  DOTFILES=${SHALE_DIR%"${SHALE_DIR##*[!/]}"}
+  # What that leaves of a root of nothing but slashes, and the one absolute path
+  # shale will not take: '/' as the dotfiles directory makes shale.conf and the
+  # built tree furniture of the filesystem root, every entry on the machine a
+  # stray in doctor's scan, and every join above it a '//...'.  Refused whole
+  # rather than half-carried.
+  [ -n "$DOTFILES" ] ||
+    die "SHALE_DIR is set to '$SHALE_DIR', which is the root directory" \
+      'shale keeps shale.conf, the layers and its build output in that directory, and will not keep them at the root of the filesystem' \
+      "give it a directory of its own, or unset it for $HOME_PREFIX/.dotfiles"
+  # $HOME itself, and everything above it.  Both sides of the compare carry the
+  # slash that makes it a path boundary rather than a string prefix, so a home's
+  # sibling whose name merely starts with the home's is not read as holding it;
+  # HOME_PREFIX has had its own trailing slashes taken off at the top of this
+  # file and $DOTFILES a moment ago, so neither can bring a second one.  The arm cannot fire on the
+  # home that leaves HOME_PREFIX empty - a '/' root is refused above, and it is
+  # the only path that holds '/'.
+  case "$HOME_PREFIX/" in
+    "$DOTFILES"/*)
+      die "SHALE_DIR is set to '$SHALE_DIR', which is ${HOME-} or a directory holding it" \
+        'shale composes into that directory and stows the result into your home, and stow will not link a directory into itself: the apply exits 0 having linked nothing' \
+        "give it a directory of its own, or unset it for $HOME_PREFIX/.dotfiles"
+      ;;
+  esac
+else
+  DOTFILES=$HOME_PREFIX/.dotfiles
+fi
+CONF=$DOTFILES/shale.conf
+CUR=$DOTFILES/current
+NEW=$DOTFILES/current.new
+OLD=$DOTFILES/current.old
+
+# $DOTFILES spelled relative to $HOME, and empty where the root is not under the
+# home at all - which is a layout SHALE_DIR makes reachable and the default never
+# was.  The one place a $HOME-relative path has to be compared against the root,
+# in cmd_apply's count, reads it: written as the literal '.dotfiles' it excluded
+# a path that is not the root under a SHALE_DIR, and excluded nothing that is.
+DOTFILES_REL=
+case "$DOTFILES" in
+  "$HOME_PREFIX"/*) DOTFILES_REL=${DOTFILES#"$HOME_PREFIX"/} ;;
+esac
+
+# The same directory as usage spells it: abbreviated to a '~/' wherever the home
+# is the thing it is under, and absolute wherever it is not.  The abbreviation is
+# exact rather than decorative - the two arms are the two halves of the case
+# above - so the default root prints the '~/.dotfiles' this text has always said,
+# and a SHALE_DIR outside the home prints the only spelling that is true of it.
+if [ -n "$DOTFILES_REL" ]; then
+  # Quoted, and it has to be: an unquoted '~/' in an assignment is expanded by
+  # bash, which would put the home back in the very string that abbreviates it.
+  # shellcheck disable=SC2088  # a tilde to print, not one to expand
+  DOTFILES_SHOWN="~/$DOTFILES_REL"
+else
+  DOTFILES_SHOWN=$DOTFILES
+fi
+
 # 'cannot search' or 'cannot read' for the directory $1, in DENIED_VERB.  The
 # search bit is tested first, so mode 0000 - missing both - is reported as
 # 'cannot search', which is the word which uses for the same directory.
@@ -291,23 +367,29 @@ denied_verb() {
   fi
 }
 
+# Every path here is the resolved root rather than the default's spelling: with
+# SHALE_DIR set, a usage naming ~/.dotfiles describes a directory this run does
+# not read.  Under the default the three are the '~/.dotfiles' they have always
+# been, DOTFILES_SHOWN abbreviating exactly what it abbreviates.
 usage() {
   # shellcheck disable=SC2088  # a tilde to print, not one to expand
   printf '%s\n' \
     'shale - layered dotfiles builder' \
     '' \
     'usage:' \
-    '  shale build          compose the configured layers into ~/.dotfiles/current' \
+    "  shale build          compose the configured layers into $DOTFILES_SHOWN/current" \
     '  shale apply          build, then stow current into your home directory' \
     '  shale doctor         check prerequisites, config, and broken links' \
     '  shale which PATH     show which layer provides PATH, and what it shadows' \
     '' \
-    '~/.dotfiles/shale.conf lists one layer per line, lowest precedence first:' \
+    "$DOTFILES_SHOWN/shale.conf lists one layer per line, lowest precedence first:" \
     '' \
     '  NAME  PATH  [URL]' \
     '' \
-    "PATH is relative to ~/.dotfiles.  URL says how to clone PATH's top-level" \
+    "PATH is relative to $DOTFILES_SHOWN.  URL says how to clone PATH's top-level" \
     'directory; give it once per directory and leave it off the other lines.' \
+    '' \
+    'SHALE_DIR, an absolute path, names that directory; ~/.dotfiles without it.' \
     '' \
     'A .shale-ignore file at the top of a clone root blocks paths from every apply.' \
     'A .shale-modes file there declares modes, one "700  .ssh" per line.'
@@ -4065,8 +4147,12 @@ which_normalise() {
     '~/'*) path=$HOME_PREFIX/${path#'~/'} ;;
   esac
 
-  # Before the $HOME strip, not after it: $DOTFILES is itself under $HOME, so
-  # stripping $HOME first leaves a '.dotfiles/...' that matches no layer.
+  # Before the $HOME strip, not after it, whichever of the two directories holds
+  # the other.  Under the default root $DOTFILES is itself under $HOME, and
+  # stripping $HOME first leaves a '.dotfiles/...' that matches no layer; under a
+  # SHALE_DIR outside $HOME the strip below would refuse the path as being
+  # outside the home before any layer had been looked at.  What this leaves is
+  # relative, so neither arm below can fire on what it stripped.
   longest=
   root=
   for prefix in current ${LAYER_PATHS[@]+"${LAYER_PATHS[@]}"}; do
@@ -4922,9 +5008,11 @@ count_dangling_links() {
     # under this path - stow refuses to link into the stow directory it was
     # given, and says so - so the arm only ever answers for a link something
     # else made, at a path a layer once composed a '.dotfiles' of its own into.
-    case "$rel" in
-      .dotfiles | .dotfiles/*) continue ;;
-    esac
+    if [ -n "$DOTFILES_REL" ]; then
+      case "$rel" in
+        "$DOTFILES_REL" | "$DOTFILES_REL"/*) continue ;;
+      esac
+    fi
     target=$CUR/$rel
     { [ ! -e "$target" ] && [ ! -L "$target" ]; } || continue
     link=$HOME_PREFIX/$rel
@@ -5453,7 +5541,7 @@ cmd_doctor() {
   # them there is anything to read.
   audit_mode_declarations
 
-  # Everything in ~/.dotfiles that shale does not account for, a file as much as
+  # Everything in $DOTFILES that shale does not account for, a file as much as
   # a directory: an editor left a 'shale.conf.bak' beside the config and nothing
   # said so.  Nothing whose name begins with '.' - the glob does not match one,
   # so a '.git' or a '.stowrc' beside the config is out of it by construction

--- a/tests/run
+++ b/tests/run
@@ -2034,6 +2034,274 @@ test_config_reached_through_a_symlink_parses() {
   assert_empty "$shale_err" 'stderr'
 }
 
+# ------------------------------------------------------- the dotfiles root
+#
+# SHALE_DIR moves shale.conf, the layers and the built tree; the stow target
+# stays $HOME.  Every other case in this file runs with the variable unset, so
+# the default is asserted by the whole of the rest of the suite rather than here.
+
+# A whole dotfiles root at $CASE_DIR/elsewhere, in shale_root, with SHALE_DIR
+# exported to it for the rest of the case.  Inside the case's sandbox and outside
+# its $HOME, which is the layout the variable exists for and the one conf and
+# mklayer cannot express - both write under $HOME/.dotfiles by construction.
+#
+# shale_root is published rather than made local: the case owns it, exactly as
+# mkrepo publishes repo_url.
+shale_dir_fixture() {
+  sandbox_mkdir "$CASE_DIR/elsewhere"
+  shale_root=$sandbox_dir
+  sandbox_write "$shale_root/personal/base" .zshrc 'elsewhere/.zshrc'
+  sandbox_write "$shale_root" shale.conf 'base personal/base'
+  export SHALE_DIR=$shale_root
+}
+
+test_config_shale_dir_moves_the_root_out_of_home() {
+  local shale_root
+  shale_dir_fixture
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_eq 'elsewhere/.zshrc' "$(cat "$shale_root/current/.zshrc")" 'the built tree'
+  assert_missing "$HOME/.dotfiles" 'the default root'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  # The link lands in $HOME and points into the tree under SHALE_DIR: the target
+  # moved and the destination did not.
+  assert_symlink_to "$HOME/.zshrc" "$shale_root/current/.zshrc"
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" 'shale: no problems found' 'the doctor report'
+  run_shale which .zshrc
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" "$shale_root/personal/base/.zshrc" 'the which answer'
+  # After all four, because a command that created it would be the defect.
+  assert_missing "$HOME/.dotfiles" 'the default root'
+}
+
+# Every command, not one: the value is wrong before there is a command to run
+# under it, so each of the four refuses in the same words - the bare invocation
+# that prints usage included.
+test_config_shale_dir_refuses_a_relative_path_from_every_command() {
+  local args
+  export SHALE_DIR=relative/path
+  for args in build apply doctor 'which .zshrc' '' help -h --help; do
+    # Unquoted on purpose: 'which .zshrc' is two words.
+    # shellcheck disable=SC2086
+    run_shale $args
+    assert_status 1 "$shale_status" "'shale $args' exit status"
+    assert_contains "$shale_err" \
+      "shale: SHALE_DIR is set to 'relative/path', which is not an absolute path" \
+      "'shale $args' stderr"
+    assert_contains "$shale_err" \
+      "shale:   give it a path beginning with '/', or unset it for $HOME/.dotfiles" \
+      "'shale $args' stderr"
+  done
+  assert_missing "$HOME/.dotfiles" 'the default root'
+  # The case runs with its working directory at $CASE_DIR, so this is where a
+  # shale that resolved the value against $PWD would have put the tree.
+  assert_missing "$CASE_DIR/relative" 'a root resolved against the working directory'
+}
+
+# The shell expands a real tilde before shale is started, so one that reaches
+# shale is a literal character somebody quoted - and shale expands nothing.
+test_config_shale_dir_refuses_a_tilde_it_did_not_expand() {
+  local value
+  # shellcheck disable=SC2088  # a tilde to hand to shale, not one to expand
+  for value in '~' '~/elsewhere'; do
+    export SHALE_DIR=$value
+    run_shale doctor
+    assert_status 1 "$shale_status" "SHALE_DIR=$value exit status"
+    assert_contains "$shale_err" \
+      "shale: SHALE_DIR is set to '$value', which is not an absolute path" \
+      "SHALE_DIR=$value stderr"
+  done
+  assert_missing "$HOME/.dotfiles" 'the default root'
+  assert_missing "$CASE_DIR/~" 'a root taken literally'
+}
+
+# The one absolute path that is refused, and the reason is arithmetic as much as
+# taste: '/' as the root makes every '$DOTFILES/...' join a '//...'.  '//' is the
+# same value after the trailing slashes come off, and is here so that the strip
+# cannot turn a refusal into an acceptance.
+test_config_shale_dir_refuses_the_root_directory() {
+  local value
+  for value in / // ///; do
+    export SHALE_DIR=$value
+    run_shale doctor
+    assert_status 1 "$shale_status" "SHALE_DIR=$value exit status"
+    assert_contains "$shale_err" \
+      "shale: SHALE_DIR is set to '$value', which is the root directory" \
+      "SHALE_DIR=$value stderr"
+  done
+  assert_missing "$HOME/.dotfiles" 'the default root'
+}
+
+# The refusal that is about $HOME rather than about the string: a root at the
+# home, or above it, is one stow is asked to link into itself.  It accepts the
+# command and links nothing - 'WARNING: skipping target which was current stow
+# directory' on both 2.3.1 and 2.4.1, and an exit 0 - so without this arm the
+# whole of an apply is a silent no-op.  The two audits disagree there as well:
+# apply's dangling count excludes nothing under a root that is not below the
+# home, and doctor's excludes the whole walk.
+#
+# The directory under the home is in the same case because the arm is a path
+# comparison, and one written as a string prefix refuses it too.
+test_config_shale_dir_refuses_the_home_and_its_ancestors() {
+  local value under
+  for value in "$HOME" "${HOME%/*}" "${HOME%/*/*}"; do
+    export SHALE_DIR=$value
+    run_shale doctor
+    assert_status 1 "$shale_status" "SHALE_DIR=$value exit status"
+    assert_contains "$shale_err" \
+      "shale: SHALE_DIR is set to '$value', which is $HOME or a directory holding it" \
+      "SHALE_DIR=$value stderr"
+    assert_contains "$shale_err" \
+      'shale:   shale composes into that directory and stows the result into your home, and stow will not link a directory into itself: the apply exits 0 having linked nothing' \
+      "SHALE_DIR=$value stderr"
+  done
+  assert_missing "$HOME/current" 'a tree composed into the home itself'
+  assert_missing "$HOME/.dotfiles" 'the default root'
+  # A root under the home, which is what the default is and what the arm must
+  # not take with it.  A sibling of the home whose name starts with the home's,
+  # for the boundary the '/' in the compare is there for.
+  under=$HOME/elsewhere
+  sandbox_write "$under/personal/base" .zshrc 'elsewhere/.zshrc'
+  sandbox_write "$under" shale.conf 'base personal/base'
+  export SHALE_DIR=$under
+  run_shale build
+  assert_status 0 "$shale_status" 'a root under the home'
+  assert_eq 'elsewhere/.zshrc' "$(cat "$under/current/.zshrc")" 'the built tree'
+  # A sibling whose name starts with the home's, which a compare written as a
+  # string prefix rather than a path one would take for a directory under it.
+  # Asserted by building there rather than by the absence of a message: a
+  # refusal for any other reason would satisfy a negative assertion too.
+  sandbox_write "${HOME}extra/personal/base" .zshrc 'extra/.zshrc'
+  sandbox_write "${HOME}extra" shale.conf 'base personal/base'
+  export SHALE_DIR=${HOME}extra
+  run_shale build
+  assert_status 0 "$shale_status" 'a sibling of the home whose name extends it'
+  assert_empty "$shale_err" 'the stderr for a sibling of the home'
+  assert_eq 'extra/.zshrc' "$(cat "${HOME}extra/current/.zshrc")" 'the built tree'
+}
+
+# Usage names the root this run reads, and every line of it that names one.  A
+# usage that said ~/.dotfiles under a SHALE_DIR would be describing a directory
+# the run does not touch, which is the one document a reader consults precisely
+# because they do not know where things are.
+#
+# The '~/' arm is asserted against a root that is not the default: abbreviating
+# by printing the literal '~/.dotfiles' passes for the default and for nothing
+# else.
+test_config_shale_dir_usage_names_the_root_in_force() {
+  local shale_root spelling
+  run_shale
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    '  shale build          compose the configured layers into ~/.dotfiles/current' \
+    'usage under the default root'
+  shale_dir_fixture
+  run_shale
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "  shale build          compose the configured layers into $shale_root/current" \
+    'usage under a root outside the home'
+  assert_contains "$shale_out" \
+    "$shale_root/shale.conf lists one layer per line, lowest precedence first:" \
+    'usage under a root outside the home'
+  assert_contains "$shale_out" "PATH is relative to $shale_root.  URL says" \
+    'usage under a root outside the home'
+  # The spellings that would still be there had the text stayed static, each one
+  # a whole path rather than a substring of the sentence that names the variable.
+  # shellcheck disable=SC2088  # tildes to look for in shale's output, not to expand
+  for spelling in '~/.dotfiles/current' '~/.dotfiles/shale.conf' 'relative to ~/.dotfiles.'; do
+    assert_not_contains "$shale_out" "$spelling" 'usage under a root outside the home'
+  done
+  # And under the home, where the abbreviation is the whole of what is being
+  # asserted: the home is a temporary directory, so an unabbreviated path here
+  # would be unmissable.
+  export SHALE_DIR=$HOME/elsewhere
+  run_shale
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    '  shale build          compose the configured layers into ~/elsewhere/current' \
+    'usage under a root inside the home'
+  assert_not_contains "$shale_out" "$HOME/elsewhere" 'usage under a root inside the home'
+}
+
+# Not the same string, and it must be the same root: the strip is what keeps a
+# '//' out of every path a run prints and compares.
+test_config_shale_dir_ignores_trailing_slashes() {
+  local shale_root plain slashed
+  shale_dir_fixture
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale which .zshrc
+  assert_status 0 "$shale_status"
+  plain=$shale_out
+  export SHALE_DIR=$shale_root///
+  run_shale which .zshrc
+  assert_status 0 "$shale_status"
+  slashed=$shale_out
+  assert_eq "$plain" "$slashed" 'the answer under a trailing slash'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_eq "shale: composed layer 'base' from $shale_root/personal/base" \
+    "$shale_out" 'the build under a trailing slash'
+  assert_empty "$shale_err" 'the build stderr under a trailing slash'
+  assert_eq 'elsewhere/.zshrc' "$(cat "$shale_root/current/.zshrc")" 'the built tree'
+}
+
+# Empty is unset, byte for byte, and both are $HOME/.dotfiles.
+test_config_shale_dir_empty_is_the_default_root() {
+  local unset_out unset_err
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  unset_out=$shale_out
+  unset_err=$shale_err
+  assert_contains "$unset_out" 'shale: no problems found' 'the doctor report'
+  export SHALE_DIR=
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_eq "$unset_out" "$shale_out" 'the doctor report under an empty SHALE_DIR'
+  assert_eq "$unset_err" "$shale_err" 'the doctor stderr under an empty SHALE_DIR'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
+}
+
+# which strips the root's prefixes before it applies the under-$HOME rule, and
+# under a root outside $HOME that order is the whole of what makes an absolute
+# spelling answerable: taken the other way round, every path under SHALE_DIR is
+# refused as being outside the home before any layer has been looked at.
+test_config_shale_dir_which_answers_for_a_path_spelled_under_it() {
+  local shale_root by_rel by_home by_tree by_layer
+  shale_dir_fixture
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale which .zshrc
+  assert_status 0 "$shale_status"
+  by_rel=$shale_out
+  assert_contains "$by_rel" "winner    base  $shale_root/personal/base/.zshrc" 'the which answer'
+  run_shale which "$HOME/.zshrc"
+  assert_status 0 "$shale_status"
+  by_home=$shale_out
+  run_shale which "$shale_root/current/.zshrc"
+  assert_status 0 "$shale_status"
+  by_tree=$shale_out
+  run_shale which "$shale_root/personal/base/.zshrc"
+  assert_status 0 "$shale_status"
+  by_layer=$shale_out
+  assert_eq "$by_rel" "$by_home" 'the answer for the path spelled from the home'
+  assert_eq "$by_rel" "$by_tree" 'the answer for the path spelled in the built tree'
+  assert_eq "$by_rel" "$by_layer" 'the answer for the path spelled in the layer'
+  # The boundary: a path under the root that is neither the built tree nor a
+  # layer is not a path in the home being composed, and is refused as one.
+  run_shale which "$shale_root/shale.conf"
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_err" "shale: $shale_root/shale.conf is not under $HOME" 'stderr'
+}
+
 # ---------------------------------------------------------------- build cases
 #
 # build is the first command that writes anything, so most of these assert the
@@ -16184,6 +16452,11 @@ run_case() {
     export GIT_COMMITTER_NAME='shale tests'
     export GIT_COMMITTER_EMAIL='tests@shale.invalid'
     unset STOW_DIR
+    # Every case but the ones below shale_dir_fixture runs against the default
+    # root, and those set it themselves.  Without this a developer who exports it
+    # runs a different suite from CI's, and every path assertion in the file is
+    # wrong at once.
+    unset SHALE_DIR
     # cd here so no .stowrc from wherever the suite was started is reachable.
     cd "$case_dir" || exit 1
     require_sandbox


### PR DESCRIPTION
Closes #154.

Reverses the plan's "no override" decision: `SHALE_DIR`, when set and non-empty, is the dotfiles root — `shale.conf`, the layers and the built tree live under it; unset or empty stays `$HOME/.dotfiles` byte-for-byte (verified by output diff against main). The value must be absolute; trailing slashes are stripped; `/`, `$HOME` and any ancestor of `$HOME` are refused with diagnoses (a root at or above `$HOME` makes stow's apply a silent no-op). Usage prints the resolved root, `~`-abbreviated when under the home. Also fixes a latent hardcoded `.dotfiles` in apply's dangling-link exclusion via `DOTFILES_REL`.

Gates run: code review and functional verification by execution — outside-HOME roots with link resolution, decoy-default-root isolation, all refusal shapes across eight invocation forms, suite immunity to an exported bad `SHALE_DIR`. 504 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57 on both interpreters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)