### PR TITLE
Say when the dotfiles directory is writable by somebody other than its owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ command: shale is one file, and the copy you have is whatever the repository hel
 ## Bootstrap on a new machine
 
 ```sh
-mkdir -p ~/.dotfiles
+mkdir -p ~/.dotfiles && chmod 0700 ~/.dotfiles
 cp examples/wsl-work.conf ~/.dotfiles/shale.conf
 $EDITOR ~/.dotfiles/shale.conf     # list this machine's layers
 mkdir -p ~/.dotfiles/local         # a layer with no url is yours to create
@@ -506,7 +506,10 @@ overwrites, and how to carry on from a block that stopped.
   across faithfully, and the working tree after a clone is not what was committed; a directory's
   mode it does not carry at all. Where a mode matters,
   declare it in a `.shale-modes` at the top of the clone root: that file is plain text, which is the
-  one thing about a mode git reproduces exactly.
+  one thing about a mode git reproduces exactly. `doctor` says nothing about a clone root's own mode,
+  group-writable or not, and that is deliberate: the next re-clone puts the mode straight back, so
+  the note would return every time it was acted on. Narrow them yourself if the machine has other
+  people on it.
 - The built tree is `700`, so nothing but you can walk it. Nothing shale runs needs to — stow reads
   it as you — but if your `$HOME` is group-readable by design and something else reads a file shale
   linked, it resolves the link into `~/.dotfiles/current` and stops there. There is no option to
@@ -514,6 +517,11 @@ overwrites, and how to carry on from a block that stopped.
   chmodding it. `shale doctor` notes a `current` whose permission bits are not `700`. Only those
   bits are shale's — a setgid bit inherited from `~/.dotfiles` gives you `2700` on every build, and
   `doctor` says nothing about that.
+- That `700` only holds as far as the directory above it. `~/.dotfiles` is yours — shale never
+  creates it and never chmods it — and anyone who can write there can rename `current` aside and
+  leave a tree of their own at the name, which every link in `$HOME` then resolves into. So `doctor`
+  notes a `~/.dotfiles` that its group or the world can write, and prints the `chmod` that closes it;
+  `700` and `750` are silent, and no build or apply clears the note, because only you can.
 - Shale sets the mode of a directory it creates in `$HOME`, and never widens one that was already
   there. So a `~/.ssh` you keep at `700` survives a layer that declares `755`. `apply` says in one
   line that it left such a directory alone, `doctor` names each one and both ways to settle it —

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -44,6 +44,7 @@ If **your own files are to be the layer** — you are starting shale from your d
 adopting anyone else's — the move is a `mv` and an apply, and there is nothing to reconcile:
 
 ```
+$ mkdir -p ~/.dotfiles && chmod 0700 ~/.dotfiles
 $ mkdir -p ~/.dotfiles/local/.config
 $ printf "local  local\n" > ~/.dotfiles/shale.conf
 $ mv ~/.zshrc ~/.profile ~/.gitconfig ~/.dotfiles/local/

--- a/shale
+++ b/shale
@@ -3242,6 +3242,115 @@ scan_built_tree() {
   done
 }
 
+# The mode of $DOTFILES, which is the directory holding the built tree rather
+# than the tree: audit_current_mode below narrows $CUR to $OWN_DIR_MODE so that
+# nothing else can read what the layers put there, and a $DOTFILES somebody else
+# can write undoes that from one level up - the tree is renamed aside, one of
+# their own is left at the name, and every symlink an apply made in $HOME
+# resolves into it.
+#
+# A note and never a finding, for audit_current_mode's reason: nothing is broken
+# and no build or apply is blocked.  What is different from that note is the
+# remedy - $CUR fixes itself at the next build, and this cannot, because shale
+# creates $DOTFILES nowhere and chmods it nowhere.  So the chmod is printed.
+#
+# Write *and* search, per class.  Neither bit alone lets anything be put into a
+# directory or taken out of it: the entry has to be looked up before it can be
+# created, renamed or removed, and the lookup is the execute bit.  A 0764 is
+# therefore silent, and so are the 0700 and 0750 that are the ordinary answers.
+#
+# What is deliberately not asked is whether anyone else is in the group, which
+# would be the one thing that could tell an exposed 0775 from the one a 'umask
+# 002' leaves on Debian and Ubuntu.  No portable reader answers it: 'id' speaks
+# only for this user, /etc/group lists no members at all for macOS's 'staff'
+# though every local account has it as its primary group, and on a machine behind
+# a directory service the file is not the answer for any group.  A reader that
+# under-reports would be silent on exactly the setup this note is for, so the
+# note is about the mode - which is true, checkable, and cleared for good by one
+# chmod that costs the reader nothing, nothing but them needing to write there.
+#
+# Nor is it asked whether anything can reach $DOTFILES: that is the mode of every
+# directory above it, $HOME included, and answering it half way - stopping at
+# $HOME, which $DOTFILES need not even be under, SHALE_DIR being free to put it
+# on another volume - would trade a note that is merely wide for a silence that
+# is wrong.
+#
+# It stops at $DOTFILES and says nothing about the clone roots below it, and not
+# because they matter less.  A group-writable clone root does not let anybody
+# replace the built tree; it lets them replace local/.zshrc, which the next build
+# copies and the next apply links into $HOME - arbitrary code in the reader's
+# shell, which is worse rather than smaller.  What decides it is that no note
+# about one could be terminal.  There may be several, 'git clone' and 'mkdir -p'
+# under a 'umask 002' leave every one of them group-writable, and the next fetch
+# of a re-cloned root puts the mode back - so the note would return having been
+# acted on, which is the defect the everyday-state notes were removed for.  This
+# one is cleared by a single chmod that nothing undoes, and that difference is
+# the whole of why one is here and the other is not.
+#
+# The set-group-ID bit is not reported: it grants no write, it decides the group
+# of what is created there, and it is the bit audit_current_mode had to stop
+# comparing.  The sticky bit is reported, because it changes what a writer can
+# do: with it, only the owner of an entry may rename or remove it, so $CUR cannot
+# be swapped - but nothing stops a new name being created beside it, and
+# $DOTFILES/.stowrc is read by stow on every apply, cmd_apply running it from
+# inside this directory.  So it moves the consequence line and not the verdict.
+audit_dotfiles_mode() {
+  local perm group other classes remedy consequence
+  [ -d "$DOTFILES" ] || return 0
+  # '/.' rather than the name itself: ls -ld on a symlink reports the link's own
+  # mode, and that mode is 0777 on Linux and whatever umask made it on BSD - so a
+  # $DOTFILES that is a link to a tree on another volume, a setup people have and
+  # one SHALE_DIR does not have to be used for, would read as world-writable on
+  # every run of the one and answer for the wrong file on the other.  The
+  # trailing component resolves to the directory whether or not the name above it
+  # is a link, and the message still prints the name the reader configured.
+  dir_mode "$DOTFILES/." 2>/dev/null || return 0
+  # 8# because a mode with a set-id or sticky bit has no leading zero and bash
+  # would otherwise read it as decimal.  Both sides of each compare are
+  # arithmetic: '[ x -eq 0030 ]' is a decimal 30 and would answer for no mode at
+  # all.
+  perm=$((8#$DIR_MODE_RAW))
+  group=0
+  other=0
+  [ $((perm & 0030)) -ne $((0030)) ] || group=1
+  [ $((perm & 0003)) -ne $((0003)) ] || other=1
+  # One note for both classes rather than one each: the consequence is the same
+  # and the remedy is a single chmod, so a 0777 that printed it twice would be
+  # doubling one fact.  The remedy names only the class that is open, because a
+  # 'go-w' on a 0757 takes off a bit the reader did not ask about, and a remedy
+  # that does more than it was asked for is one they will not run.
+  if [ "$group" -eq 1 ] && [ "$other" -eq 1 ]; then
+    classes='its group and everyone else on the machine can write to it'
+    remedy='chmod go-w'
+  elif [ "$group" -eq 1 ]; then
+    classes='its group can write to it'
+    remedy='chmod g-w'
+  elif [ "$other" -eq 1 ]; then
+    classes='everyone else on the machine can write to it'
+    remedy='chmod o-w'
+  else
+    return 0
+  fi
+  if [ $((perm & 01000)) -ne 0 ]; then
+    consequence="the sticky bit stops anyone but you renaming the built tree aside, and not a file being written beside it: stow reads $DOTFILES/.stowrc on every apply"
+  else
+    consequence="they can rename the built tree aside and leave one of their own at $CUR, and every symlink an apply made in $HOME then resolves into theirs"
+  fi
+  # The last line is the one a reader pastes, so the path in it is quoted and the
+  # ones above it are not: a $HOME holding a space and an '&' otherwise prints a
+  # command that backgrounds at the '&' and chmods two paths that are not this
+  # one.  Every other prescription shale prints does the same.
+  shell_quote "$DOTFILES"
+  # The raw mode, as audit_current_mode prints it, so a 2775 shows the reader the
+  # digit this is not talking about as well as the ones it is.
+  note "$DOTFILES is mode $DIR_MODE_RAW, and $classes" \
+    "shale builds $CUR with permission bits $OWN_DIR_MODE so nothing else can read what the layers put there, and a directory somebody else can write is where that is undone" \
+    "$consequence" \
+    "shale never sets the mode of $DOTFILES - it was there before shale ran - so no build or apply clears this" \
+    "close it with: $remedy $QUOTED"
+}
+
+
 # The mode of the built tree itself, which is shale's own and not a layer's: it
 # is the one directory in the whole design that every symlink shale makes in
 # $HOME resolves through, so what may be read out of the tree - and, group-write
@@ -5387,8 +5496,15 @@ cmd_doctor() {
         "shale cannot tell whether there is a dotfiles directory at $DOTFILES"
     else
       shell_quote "$DOTFILES"
+      # The chmod is not decoration: mkdir takes the caller's umask, so on the
+      # 'umask 002' that pam_umask gives a user-private group this line alone
+      # creates a 0775 - which audit_dotfiles_mode then reports on the very next
+      # run, doctor having prescribed the state it goes on to complain about.
+      # 0700 written out rather than $OWN_DIR_MODE: that constant is the mode
+      # shale gives the directories it creates itself, and this is one the reader
+      # creates and owns.  The two agreeing is not a coupling to hold.
       blocking_finding "no dotfiles directory at $DOTFILES" \
-        "create it with: mkdir -p $QUOTED"
+        "create it with: mkdir -p $QUOTED && chmod 0700 $QUOTED"
     fi
   fi
 
@@ -5662,9 +5778,12 @@ cmd_doctor() {
     fi
   done
 
-  # Ahead of the walk below it, and of everything that walk says about what is
+  # Ahead of the walk below them, and of everything that walk says about what is
   # inside the built tree: the mode of the tree itself is what decides who else
-  # can see any of it.
+  # can see any of it, and the mode of the directory holding it is what decides
+  # whether that tree is still the one shale built.  Outermost first, so a reader
+  # meeting both notes meets them in the order the exposure runs.
+  audit_dotfiles_mode
   audit_current_mode
 
   # The two walks, in size order: the built tree, then the whole of $HOME.

--- a/tests/run
+++ b/tests/run
@@ -4346,7 +4346,8 @@ test_build_the_commands_it_prints_survive_a_space_and_a_quote_in_the_home_path()
   # Before anything creates it, which is the state doctor's mkdir answers.
   run_shale doctor
   assert_status 1 "$shale_status" 'the doctor'
-  assert_command_reads_as "$shale_out" 'create it with: ' mkdir -p "$dots"
+  assert_command_reads_as "$shale_out" 'create it with: ' \
+    mkdir -p "$dots" chmod 0700 "$dots"
   # A clone fetched and then not renamed, which is kept and named.
   mkrepo personal .zshrc
   conf "base personal $repo_url"
@@ -7015,7 +7016,12 @@ test_doctor_a_missing_dotfiles_directory_is_a_finding() {
   run_shale doctor
   assert_status 1 "$shale_status"
   assert_contains "$shale_out" "shale: no dotfiles directory at $HOME/.dotfiles" 'stdout'
-  assert_contains "$shale_out" "shale:   create it with: mkdir -p '$HOME/.dotfiles'" 'stdout'
+  # The chmod is part of the remedy, not a nicety: mkdir alone takes the caller's
+  # umask, and at 'umask 002' this line would create the 0775 that doctor's own
+  # note about the dotfiles directory's mode then reports.
+  assert_contains "$shale_out" \
+    "shale:   create it with: mkdir -p '$HOME/.dotfiles' && chmod 0700 '$HOME/.dotfiles'" \
+    'stdout'
   # The config check runs anyway rather than being skipped as pointless.
   assert_contains "$shale_out" "shale: no config file at $HOME/.dotfiles/shale.conf" 'stdout'
   assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
@@ -8990,6 +8996,363 @@ test_doctor_compares_only_the_permission_bits_of_the_built_tree() {
   run_shale doctor
   assert_status 0 "$shale_status" 'doctor exit status, sticky'
   assert_eq 'shale: no problems found' "$shale_out" 'the whole report, sticky'
+}
+
+# ------------------------------- doctor's cases about the dotfiles directory
+#
+# The directory above the built tree, which shale was pointed at rather than one
+# it made: the cases above narrow $CUR to 0700 so that nothing else can read what
+# the layers put there, and a dotfiles directory somebody else can write undoes
+# that from one level up - they rename the tree aside, leave their own at the
+# name, and every symlink an apply made in $HOME resolves into it.
+#
+# A note and never a finding, matching the only other mode compare doctor makes:
+# nothing is broken, no build or apply is blocked, and the remedy is the reader's
+# to run because shale never sets the mode of a directory it did not create.
+#
+# No skip_if_root anywhere here, exactly as the built tree's mode cases above
+# carry none: these assert what doctor says about a mode rather than what the
+# kernel does with one, and chmod and ls answer the same for uid 0 as for
+# anybody else.  skip_if_root is for the cases that provoke a permission failure,
+# which none of these does.
+
+test_doctor_names_a_group_writable_dotfiles_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  # Built, so the note counted below is this one: an unbuilt tree is a note of
+  # its own.
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 0775 "$sandbox_dir" || fail 'could not widen the dotfiles directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles is mode 0775, and its group can write to it" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   shale builds $HOME/.dotfiles/current with permission bits 0700 so nothing else can read what the layers put there, and a directory somebody else can write is where that is undone" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   they can rename the built tree aside and leave one of their own at $HOME/.dotfiles/current, and every symlink an apply made in $HOME then resolves into theirs" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   shale never sets the mode of $HOME/.dotfiles - it was there before shale ran - so no build or apply clears this" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   close it with: chmod g-w '$HOME/.dotfiles'" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+}
+
+# The fixture the bootstrap actually leaves, reached by the umask rather than by
+# a chmod.  Shale cannot tell one 0775 from another, so every other case here
+# covers its behaviour perfectly well - what none of them pins is the decision,
+# which is that this note fires on what 'mkdir -p ~/.dotfiles' leaves on an
+# ordinary Debian or Ubuntu box, where pam_umask gives a user-private group a
+# 002.  That is the contested half of the report and a chmod-made mode cannot
+# state it.
+#
+# The suite pins its own umask, so the 002 is set here and put back: without that
+# pin this coverage would be an accident of whoever ran the suite, which is not
+# coverage.
+test_doctor_the_note_fires_on_the_directory_the_bootstrap_umask_leaves() {
+  local saved
+  saved=$(umask)
+  umask 002
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  umask "$saved"
+  assert_mode "$HOME/.dotfiles" 'drwxrwxr-x' 'the fixture the bootstrap umask leaves'
+  run_shale build
+  assert_status 0 "$shale_status"
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles is mode 0775, and its group can write to it" 'stdout'
+}
+
+# The last line of the note is a command, so what a shell reads it back as is the
+# claim, not what it looks like.  A space, a quote, a bracket and an '&': the
+# first three are what a bare path loses to word splitting, quote removal and
+# globbing, and the '&' is the one that makes the loss silent rather than loud -
+# unquoted, the printed line ends there, backgrounds a chmod of paths that are
+# not this one, and leaves the mode exactly as it was.  Spaced home directories
+# are ordinary on macOS.
+#
+# $HOME is moved rather than the case running under the suite's own, because
+# every path shale prints is built from $HOME, so that is the name that has to
+# hold the awkward characters.  The marker is planted because the sandbox guard
+# reads it out of $HOME on every write.
+test_doctor_the_dotfiles_mode_remedy_survives_a_home_that_needs_quoting() {
+  local home_ok
+  sandbox_mkdir "$CASE_DIR/my 'odd' & [home] dir"
+  home_ok=$sandbox_dir
+  sandbox_leaf "$home_ok" .shale-test-sandbox new
+  : >"$sandbox_path" || fail 'could not mark the sandbox home'
+  HOME=$home_ok
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 0775 "$sandbox_dir" || fail 'could not widen the dotfiles directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_command_reads_as "$shale_out" 'close it with: ' chmod g-w "$HOME/.dotfiles"
+  # The lines above it are prose rather than commands and carry the path bare,
+  # which is what makes the quoting a property of the line a reader runs and not
+  # of the report.
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles is mode 0775, and its group can write to it" 'stdout'
+}
+
+# The remedy, run rather than quoted, and the claim that nothing shale does
+# clears it.  Unlike the note on the built tree there is no build that settles
+# this one, so the chmod the last line names is the whole of what does - and a
+# case that never ran it would be pinning a line nobody has checked.
+#
+# This is also where shale is held to changing no mode of its own: a doctor, a
+# build and an apply all run against the widened directory and the mode is read
+# back after each.
+test_doctor_the_dotfiles_mode_note_goes_when_the_chmod_is_run() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 0775 "$sandbox_dir" || fail 'could not widen the dotfiles directory'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" "shale: $HOME/.dotfiles is mode 0775" 'stdout'
+  assert_mode "$HOME/.dotfiles" 'drwxrwxr-x' 'after the doctor'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_mode "$HOME/.dotfiles" 'drwxrwxr-x' 'after the build'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_mode "$HOME/.dotfiles" 'drwxrwxr-x' 'after the apply'
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod g-w "$sandbox_dir" || fail 'could not run the remedy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the chmod'
+  assert_not_contains "$shale_out" "shale: $HOME/.dotfiles is mode" 'stdout'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# World-writable, which is strictly worse and is one note rather than a second
+# one: the consequence is the same and the remedy is one chmod, so a 0777 that
+# printed the whole thing twice would be doubling a single fact.
+test_doctor_names_a_world_writable_dotfiles_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 0777 "$sandbox_dir" || fail 'could not widen the dotfiles directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles is mode 0777, and its group and everyone else on the machine can write to it" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   close it with: chmod go-w '$HOME/.dotfiles'" 'stdout'
+  # One note, not two.
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+}
+
+# The world alone, without the group: the remedy names the class that is open and
+# no other, because a 'go-w' on a directory whose group write bit was deliberate
+# takes off a bit the reader did not ask about.
+test_doctor_names_a_dotfiles_directory_only_the_world_can_write() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 0757 "$sandbox_dir" || fail 'could not widen the dotfiles directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles is mode 0757, and everyone else on the machine can write to it" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   close it with: chmod o-w '$HOME/.dotfiles'" 'stdout'
+}
+
+# The sticky bit, which changes what a writer can do without changing that there
+# is one: it stops anybody but the owner renaming the built tree aside, and stops
+# nothing being created beside it - and $HOME/.dotfiles/.stowrc is a file stow
+# reads on every apply, because apply runs stow from inside that directory.  So
+# the note still fires and its middle line says something else.
+test_doctor_says_what_a_sticky_dotfiles_directory_still_allows() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 1777 "$sandbox_dir" || fail 'could not set the sticky bit'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles is mode 1777, and its group and everyone else on the machine can write to it" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale:   the sticky bit stops anyone but you renaming the built tree aside, and not a file being written beside it: stow reads $HOME/.dotfiles/.stowrc on every apply" \
+    'stdout'
+  assert_not_contains "$shale_out" 'they can rename the built tree aside' 'stdout'
+}
+
+# The modes that must stay silent: 0700 is the closed one, 0750 is the deliberate
+# choice on a machine with a shared group that is meant to read the tree, and the
+# two below them grant a read and no write.  The whole report is compared so that
+# nothing new can appear anywhere in it.
+test_doctor_says_nothing_about_a_dotfiles_directory_nobody_else_can_write() {
+  local mode
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  for mode in 0700 0750 0755 0705; do
+    sandbox_mkdir "$HOME/.dotfiles"
+    chmod "$mode" "$sandbox_dir" || fail "could not set the dotfiles directory to $mode"
+    run_shale doctor
+    assert_status 0 "$shale_status" "doctor exit status at $mode"
+    assert_eq 'shale: no problems found' "$shale_out" "the whole report at $mode"
+  done
+}
+
+# The set-group-ID bit on its own, which is not a permission bit and grants no
+# write: it decides the group of what is created there and nothing else.  A
+# dotfiles directory on a shared volume is the setup that carries it, and it is
+# the one the note on the built tree had to stop firing about - this must not put
+# the same false report back one directory up.
+test_doctor_says_nothing_about_a_setgid_dotfiles_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 2755 "$sandbox_dir" || fail 'could not set the set-group-ID bit'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# Write without search, which grants nothing: an entry has to be looked up before
+# it can be created, renamed or removed, and the lookup is the execute bit.  A
+# 0764 lets the group write to a file it already knows the name of and does not
+# let it put anything at the built tree's name, so the note must not fire.
+test_doctor_says_nothing_about_a_dotfiles_directory_the_group_cannot_search() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 0764 "$sandbox_dir" || fail 'could not set the dotfiles directory mode'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+}
+
+# Both notes at once, in the order the exposure runs: the directory holding the
+# tree decides whether the tree is still the one shale built, so it is named
+# before anything about the tree itself.  Nothing else pins the slot - the case
+# that asserts doctor's overall order has no mode report in its fixture - and a
+# reordering would leave every other case here green.
+test_doctor_names_the_dotfiles_directory_before_the_tree_inside_it() {
+  local line seen
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  chmod 0755 "$sandbox_dir" || fail 'could not widen the built tree'
+  sandbox_mkdir "$HOME/.dotfiles"
+  chmod 0775 "$sandbox_dir" || fail 'could not widen the dotfiles directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  seen=
+  while IFS= read -r line; do
+    case "$line" in
+      "shale: $HOME/.dotfiles is mode"*) seen="$seen dotfiles" ;;
+      "shale: $HOME/.dotfiles/current is mode"*) seen="$seen current" ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq ' dotfiles current' "$seen" 'the order of the two mode notes'
+  # Both counted as notes and neither as a problem, which is the other half of
+  # the claim: two reports, exit 0.
+  assert_contains "$shale_out" 'shale: no problems found, but read the 2 notes above' 'stdout'
+}
+
+# A dotfiles root outside $HOME, which SHALE_DIR is for: the check is about the
+# mode of that directory and nothing about where it sits, so a /opt-style root
+# the user owns is silent at 0700 and named at 0775 exactly as one in $HOME is.
+# The path printed is the resolved root, never $HOME/.dotfiles, which is the
+# spelling that would send the reader to chmod a directory that does not exist.
+test_doctor_names_a_dotfiles_directory_outside_home() {
+  local shale_root
+  shale_dir_fixture
+  run_shale build
+  assert_status 0 "$shale_status"
+  sandbox_mkdir "$shale_root"
+  chmod 0700 "$sandbox_dir" || fail 'could not narrow the dotfiles root'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status at 0700'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report at 0700'
+  chmod 0775 "$sandbox_dir" || fail 'could not widen the dotfiles root'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status at 0775'
+  assert_contains "$shale_out" \
+    "shale: $shale_root is mode 0775, and its group can write to it" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   close it with: chmod g-w '$shale_root'" 'stdout'
+  assert_not_contains "$shale_out" "$HOME/.dotfiles" 'stdout'
+}
+
+# A symlinked dotfiles directory, which is a setup people have - the tree on
+# another volume, the name in $HOME pointing at it.  'ls -ld' on a symlink
+# reports the link's own mode rather than the directory's, and that mode is
+# 0777 on Linux and whatever the umask gave it on BSD - so a check reading the
+# name would call every one of these world-writable on the one platform and
+# answer at random on the other.  The directory behind it is 0700 here, and the
+# report must be the clean one.
+test_doctor_reads_through_a_symlinked_dotfiles_directory() {
+  local link_before link_after
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status"
+  # Moved aside and linked back, so the name in $HOME is a symlink and the tree
+  # behind it is the one every path below still resolves to.
+  sandbox_mkdir "$CASE_DIR/elsewhere"
+  sandbox_leaf "$HOME" .dotfiles
+  mv "$sandbox_path" "$CASE_DIR/elsewhere/store" || fail 'could not move the dotfiles directory'
+  chmod 0700 "$CASE_DIR/elsewhere/store" || fail 'could not narrow the moved directory'
+  ln -s "$CASE_DIR/elsewhere/store" "$sandbox_path" || fail 'could not link the dotfiles directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  # And the mode behind the link is what decides it, not the link's own.
+  chmod 0775 "$CASE_DIR/elsewhere/store" || fail 'could not widen the moved directory'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor exit status, widened'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles is mode 0775, and its group can write to it" 'stdout'
+  # And the remedy it printed names the link, which is the path the reader has:
+  # chmod follows one, so what it narrows is the directory behind it.  A remedy
+  # that had to be rewritten before it worked would be one this note got wrong.
+  assert_command_reads_as "$shale_out" 'close it with: ' chmod g-w "$HOME/.dotfiles"
+  # Read before and compared after, rather than asserted against a literal: a
+  # symlink's own mode is a real one on BSD, taken from the umask when it was
+  # made, and always 0777 on Linux - so 'lrwxrwxrwx' is one platform's spelling
+  # of a claim that is really 'this did not change'.  ls -ld does not follow a
+  # link, so both reads answer for the name in $HOME.
+  link_before=$(ls -ld "$HOME/.dotfiles") || fail 'could not read the link'
+  chmod g-w "$HOME/.dotfiles" || fail 'could not run the remedy'
+  assert_mode "$CASE_DIR/elsewhere/store" 'drwxr-xr-x' 'the directory behind the link'
+  link_after=$(ls -ld "$HOME/.dotfiles") || fail 'could not read the link again'
+  assert_eq "${link_before:0:10}" "${link_after:0:10}" 'the mode of the link itself'
+  assert_symlink_to "$HOME/.dotfiles" "$CASE_DIR/elsewhere/store" 'the link after the chmod'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'doctor after the chmod'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report after the chmod'
 }
 
 # ------------------------------------------ doctor's apply-conflict cases
@@ -16390,6 +16753,20 @@ guard_abort() {
 
 run_case() {
   local name=$1 case_dir=$2 case_home case_out case_err leaf status reason
+  # Pinned for the same reason LC_ALL is: a suite whose result depends on the
+  # login shell it was started from is not answering about the code.  Without
+  # this the mode of every fixture the harness and the case bodies create is
+  # whoever's umask is running, and the cases that assert one are then asserting
+  # that - test_build_composes_no_shale_modes_at_any_depth wants -rw-r--r-- on a
+  # file whose mode is really the developer's, and fails on any machine at
+  # 'umask 002', which is what pam_umask gives a user-private group on Debian and
+  # Ubuntu.  022 rather than any other value because it is what the container and
+  # both CI runners already have, so this changes nothing there and only removes
+  # the variance elsewhere.  Here rather than at the top of the script so that it
+  # is re-established before every case: the ones that exercise a umask of their
+  # own set and restore it inside their own body, and this puts the floor back
+  # for the next one either way.
+  umask 022
   # Nothing is created until the path for it has been proven, the case directory
   # included: run_all names it after the case, so anything already there was put
   # there by an earlier case.  mkdir without -p is the write and the second half


### PR DESCRIPTION
Closes #127.

doctor now notes a dotfiles root writable by group or other — the state Debian/Ubuntu's default umask leaves after the README's own bootstrap — with the exact chmod that clears it; 0700/0750/setgid stay silent, and shale never changes the mode itself (a case pins that across doctor, build and apply). The note aligns with #124's current-mode report and prints immediately before it. Clone roots are deliberately not covered (a re-clone restores the mode, so that note would recur — the #133 nagging class); the decline is stated in the README where the 775 clone modes are already documented. The suite's umask is pinned, which also fixes a pre-existing red at umask 002. Both bootstrap paths in the docs now create the root at 0700, matching doctor's prescription byte for byte.

Gates run: code review and functional verification by execution — full mode matrix on both interpreters, remedy round-trips, second-uid confirmation of every factual claim in the note's wording, a root-user suite run proving the 13 new cases pass legitimately without skip_if_root, and the full suite green under umask 022, 002 and 077. 517 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)