### PR TITLE
Count the links a build orphans, from the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,13 +224,15 @@ pointing at it until stow makes the link, and one deleted from every layer leave
 until stow prunes it. Apply when unsure: it builds first, so it is never less than a build.
 [docs/layers.md](docs/layers.md) has the boundary case by case.
 
-Builds are quiet. A build that finds `current` holding a copy older than the layer file replacing it
-keeps the previous tree at `~/.dotfiles/current.old` and says nothing, because an edited layer leaves
-exactly that state and a message there would be a message on every edit. `shale doctor` is what
-reports the mismatch, as a note rather than a problem, and only until the build that overwrites it.
-After that build nothing reports it: what was there sits at `~/.dotfiles/current.old` until the next
-build removes it, and `doctor` names it again only where a problem it found means no build is coming
-— see [docs/layers.md](docs/layers.md).
+Builds are quiet, bar one line: a build that takes a path out of the tree and leaves a link in
+`$HOME` pointing at nothing counts those links and says so, which is *Links left behind after layers
+change* in [docs/migrating.md](docs/migrating.md). A build that finds `current` holding a copy older
+than the layer file replacing it keeps the previous tree at `~/.dotfiles/current.old` and says
+nothing, because an edited layer leaves exactly that state and a message there would be a message on
+every edit. `shale doctor` is what reports the mismatch, as a note rather than a problem, and only
+until the build that overwrites it. After that build nothing reports it: what was there sits at
+`~/.dotfiles/current.old` until the next build removes it, and `doctor` names it again only where a
+problem it found means no build is coming — see [docs/layers.md](docs/layers.md).
 
 Shale chooses between three exit codes, and no others:
 
@@ -490,9 +492,10 @@ overwrites, and how to carry on from a block that stopped.
   400-directory tree, five lines were not measurable, twenty added 13 milliseconds to the build and
   72 to the apply, and four hundred added 0.9 seconds and 2.4.
 - When a whole directory leaves every layer, stow does not visit it and the links inside it are left
-  dangling by an apply that still exits 0. That apply counts them and says so in one line; `shale
-  doctor` names them and prints what to do about them, and goes on finding them on every later run,
-  which `apply` does not — it speaks only for the apply you just ran.
+  dangling by an apply that still exits 0. The run that took those paths out of the tree counts them
+  and says so in one line — the `build` where you ran it on its own, the `apply` otherwise, never
+  both; `shale doctor` names them and prints what to do about them, and goes on finding them on every
+  later run, which neither does — each speaks only for the run you just made.
   [docs/migrating.md](docs/migrating.md) covers the case in full.
 - A shale that is killed outright — `kill -9`, or the machine losing power — leaves a
   `~/.dotfiles/current.new` behind if it died mid-build. `doctor` notes it, and any `current.old`

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -345,7 +345,18 @@ The apply says so, in one line and no more:
 shale: 3 links in /home/you point at paths the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names them
 ```
 
-It counts the links that apply itself left behind — the paths its own build took out of the tree —
+Where you run `shale build` on its own, the build is what says it, naming itself as what took the
+paths out, and the apply after it does not say it again:
+
+```
+shale: 3 links in /home/you point at paths the built tree no longer provides: this build took those paths out of the tree, and 'shale doctor' names them
+```
+
+Either way you are told once. A build says nothing about a file that left a directory the tree still
+holds: that link dangles until the next apply and the apply prunes it, so there is nothing there to
+act on.
+
+It counts the links the run itself left behind — the paths its own build took out of the tree —
 and stops there. An apply that stow then refuses says it too, as the last line under what stow
 reported, because the build has already taken those paths out of the tree; the apply after your fix
 will not mention them again. Run `shale doctor` for the rest: which links they are, that `current`

--- a/shale
+++ b/shale
@@ -335,8 +335,9 @@ OLD=$DOTFILES/current.old
 # $DOTFILES spelled relative to $HOME, and empty where the root is not under the
 # home at all - which is a layout SHALE_DIR makes reachable and the default never
 # was.  The one place a $HOME-relative path has to be compared against the root,
-# in cmd_apply's count, reads it: written as the literal '.dotfiles' it excluded
-# a path that is not the root under a SHALE_DIR, and excluded nothing that is.
+# in the dangling-link count build and apply share, reads it: written as the
+# literal '.dotfiles' it excluded a path that is not the root under a SHALE_DIR,
+# and excluded nothing that is.
 DOTFILES_REL=
 case "$DOTFILES" in
   "$HOME_PREFIX"/*) DOTFILES_REL=${DOTFILES#"$HOME_PREFIX"/} ;;
@@ -3885,6 +3886,29 @@ audit_declared_modes() {
   note ${lines[@]+"${lines[@]}"}
 }
 
+# Whether the built tree still holds the directory that a link at $1 - a path
+# relative to $HOME - sits in, which is what stow's unstow phase walks; what
+# that was measured against is under apply_prunes_link below.  A directory the
+# ignore list covers is the exception both versions make - they skip it before
+# recursing, so nothing inside one is swept - and no apply links into one of
+# those either, so no link this counts is in one.
+#
+# Two readers, asking the same question from opposite ends: doctor of a link
+# chkstow handed it, and the dangling-link count of a path a build's own
+# composition took out of the tree.  Written once so that no answer about one
+# link can differ between the two reports.
+tree_holds_the_directory_of() {
+  local rel=$1 dir
+  case "$rel" in
+    */*) dir=$CUR/${rel%/*} ;;
+    # A link directly in $HOME, whose directory is the built tree itself.
+    *) dir=$CUR ;;
+  esac
+  # A symlink to a directory is a leaf to stow as it is to the composer, so it
+  # is not a directory the unstow phase walks into.
+  [ -d "$dir" ] && [ ! -L "$dir" ]
+}
+
 # Non-zero unless the next apply removes the orphaned link $1 by itself, so that
 # the remedy printed for it is the one that works: $1 is the link's path
 # normalised, $2 is $HOME normalised, and $3 is 'relative' or 'absolute' for the
@@ -3899,7 +3923,7 @@ audit_declared_modes() {
 # one 'shale apply' and no rm at all; a directory that left every layer is the
 # case rm is for.
 apply_prunes_link() {
-  local nlink=$1 nhome=$2 spelling=$3 prefix rel dir
+  local nlink=$1 nhome=$2 spelling=$3 prefix rel
   [ "$spelling" = relative ] || return 1
   # A home of '/' is the one whose join would come out doubled, and the one
   # whose prefix is empty.
@@ -3908,14 +3932,7 @@ apply_prunes_link() {
     "$prefix"/*) rel=${nlink#"$prefix"/} ;;
     *) return 1 ;;
   esac
-  case "$rel" in
-    */*) dir=$CUR/${rel%/*} ;;
-    # A link directly in $HOME, whose directory is the built tree itself.
-    *) dir=$CUR ;;
-  esac
-  # A symlink to a directory is a leaf to stow as it is to the composer, so it
-  # is not a directory the unstow phase walks into.
-  [ -d "$dir" ] && [ ! -L "$dir" ]
+  tree_holds_the_directory_of "$rel"
 }
 
 # Every link under $HOME that points into the built tree at a path the built
@@ -4670,6 +4687,11 @@ check_layers() {
   return 0
 }
 
+# Whether cmd_build reports the links its own removals left dangling in $HOME.
+# Cleared by cmd_apply, which runs the build itself and counts again after stow:
+# one line from the pair, whichever way round the two commands are run.
+BUILD_REPORTS_ORPHANS=1
+
 cmd_build() {
   local i dir n had_current qcur qold rel file lineno bits errors
 
@@ -4978,17 +5000,21 @@ cmd_build() {
   # current.old holds a replaced file with it - the next build reaps current.old
   # and cannot re-detect either divergence, this build having left every copy in
   # $CUR the same age as the layer file it came from.
+  #
+  # And before the walk below, for the same reason and against the same signal:
+  # the walk takes about a tenth of a second over a two-thousand-path tree, and
+  # every millisecond of it spent ahead of these lines is a window in which an
+  # interrupt loses them for good.
   n=${#DIVERGED_PATHS[@]}
-  if [ "$n" -eq 0 ] && [ "$OLDER_COUNT" -eq 0 ]; then
-    rm -rf "$OLD" || warn "could not remove $OLD"
-  else
+  if [ "$n" -gt 0 ] || [ "$OLDER_COUNT" -gt 0 ]; then
     # The one directory of shale's own that no mkdir here made: it is the whole
     # of the last build's $CUR, arrived by rename with the mode that build gave
     # it.  A no-op on every build but the first after an upgrade, where the tree
     # it renames was made at 0777 against a umask and would sit group-writable
     # for the one build this keeps it - holding a copy of every file in every
     # layer, which is the whole of what $OWN_DIR_MODE is for.  Set only where
-    # the tree is kept, because the arm above deletes it unread.
+    # the tree is kept: everywhere else the reap below removes it moments later,
+    # and a mode on a directory that is about to go is work for nothing.
     #
     # A warning rather than a die: the build is done and correct, and this is a
     # mode on a tree the next build removes.
@@ -5013,6 +5039,50 @@ cmd_build() {
     done
   fi
 
+  # The paths this build took out of the tree, read off the tree it replaced.
+  # Between the report above and the reap below because it has to be: it is the
+  # rename to current.old that leaves those paths readable at all, and the rm
+  # under the arm that keeps nothing is what takes them away again.  Which of
+  # them $HOME has a link at is settled further down; this is only the walk, and
+  # apply reads the same list again once stow has run.
+  PREVIOUS_PATHS=()
+  if [ "$had_current" -eq 1 ] && [ -d "$OLD" ] && [ ! -L "$OLD" ]; then
+    scan_previous_tree "$OLD" ''
+  fi
+
+  # The tree the walk above has just read, where there was nothing to keep it
+  # for.  A divergence keeps it instead, and says so in the lines above.
+  if [ "$n" -eq 0 ] && [ "$OLDER_COUNT" -eq 0 ]; then
+    rm -rf "$OLD" || warn "could not remove $OLD"
+  fi
+
+  # The links in $HOME this build has just left pointing at nothing.  A path
+  # that leaves the tree is a path whose link dangles, and no apply run
+  # afterwards can say so - it reads the tree those paths have already left - so
+  # a build that said nothing here left the state that made #132 worth fixing
+  # intact for everyone the docs send to 'shale build' on its own.
+  #
+  # Only the links no apply will take back, which is what keeps this off the
+  # ordinary build: a file leaving a directory the tree still holds leaves a link
+  # the next apply prunes, and a line about it would send a reader to doctor over
+  # something that goes on its own.
+  #
+  # One line, whatever the count, and the detail is doctor's - the same split as
+  # apply's.  The line itself is orphan_line's, which apply prints too where
+  # stow refused; apply's success line is its own literal and says stow declined
+  # to remove them, which is the one thing a build cannot say, no stow having
+  # run.  What both spell the same way is the count, the subject and the remedy,
+  # which is the whole of what a reader acts on.
+  #
+  # A warning rather than a failure, and the status stays 0: the tree is built
+  # and correct, and what is left over is a link in $HOME that nothing has
+  # removed.
+  if [ "$BUILD_REPORTS_ORPHANS" -eq 1 ]; then
+    count_dangling_links kept
+    orphan_line
+    [ -z "$ORPHAN_LINE" ] || warn "$ORPHAN_LINE"
+  fi
+
   if [ -n "$DEFERRED" ]; then
     warn "interrupted, but $CUR had already been rebuilt" \
       'the layers are composed and in place; nothing was left half-swapped'
@@ -5020,26 +5090,29 @@ cmd_build() {
   fi
 }
 
-# Every path the built tree holds below $CUR/$1, relative to $CUR, appended to
-# PREVIOUS_PATHS.  Apply calls it once on the tree a build is about to replace,
-# which is the only moment the paths that build removes can still be read: a
-# build reaps current.old unless it has a divergence to point at, so after one
-# there is nothing left holding them, and no walk of $HOME afterwards can tell a
-# link this apply orphaned from one an apply last year did.
+# Every path the tree at $1 holds below $1/$2, relative to $1, appended to
+# PREVIOUS_PATHS.  A build calls it once on current.old, in the moment after the
+# swap has renamed the tree it replaced there, which is the only moment the
+# paths that build removed can still be read: the same build reaps current.old
+# unless it has a divergence to point at, so afterwards there is nothing left
+# holding them, and no walk of $HOME can tell a link this build orphaned from
+# one an apply last year did.
 #
-# Neither dotglob nor nullglob is set here - cmd_build sets both, and this runs
-# before it - so both patterns are wanted and an unmatched one arrives as
-# itself, exactly as in doctor's walks.  '.' and '..' are dropped by name,
-# whatever the glob options say about them.
+# dotglob and nullglob are both set by the time this runs - cmd_build sets them
+# and never puts them back - so '*' is the whole listing and a '.*' beside it
+# would be a second copy of half of it.  '.' and '..' are dropped by name all
+# the same, whatever the glob options say about them, and the arm below that
+# tells an unmatched pattern from a file of that name is kept for the same
+# reason: nullglob makes it unreachable here rather than wrong.
 scan_previous_tree() {
-  local rel=$1 here e base srel
-  here=$CUR${rel:+/$rel}
+  local root=$1 rel=$2 here e base srel
+  here=$root${rel:+/$rel}
   # A directory that cannot be listed answers every glob with nothing, exactly
   # as an empty one does.  Nothing is said about it: what this feeds is a count
-  # of the links one apply left behind, and a subtree shale cannot read is one
+  # of the links one build left behind, and a subtree shale cannot read is one
   # it can say nothing about - doctor walks $HOME itself and does.
   { [ -r "$here" ] && [ -x "$here" ]; } || return 0
-  list_dir "$here" 1
+  list_dir "$here" 0
   for e in ${DIR_ENTRIES[@]+"${DIR_ENTRIES[@]}"}; do
     base=${e##*/}
     case "$base" in
@@ -5051,21 +5124,32 @@ scan_previous_tree() {
     srel=${rel:+$rel/}$base
     PREVIOUS_PATHS+=("$srel")
     # A symlink to a directory is a leaf here as it is in the composer, and
-    # descending one would walk out of the built tree.
+    # descending one would walk out of the tree being read.
     if [ -d "$e" ] && [ ! -L "$e" ]; then
-      scan_previous_tree "$srel"
+      scan_previous_tree "$root" "$srel"
     fi
   done
 }
 
-# How many links in $HOME this apply has just left pointing at nothing, in
-# DANGLING.  Run after stow, and every answer is the filesystem's as it stands
-# rather than a prediction: a path counts only where the built tree has stopped
-# providing it, $HOME still holds a symlink at it, and that link resolves to
-# exactly the path the tree dropped.  So a link stow pruned a moment ago is not
-# counted - the ordinary case of a file leaving its layer, where the directory
-# holding it stays and stow walks in - and neither is a dangling link of the
-# user's own that happens to sit at one of these paths.
+# How many links in $HOME the paths this run took out of the built tree have
+# left pointing at nothing, in DANGLING.  A path counts only where the built
+# tree has stopped providing it, $HOME still holds a symlink at it, and that
+# link resolves to exactly the path the tree dropped - so a dangling link of the
+# user's own that happens to sit at one of these paths is not counted.
+#
+# $1 says which command is asking, and the difference between the two answers is
+# stow.  'all' is apply's, taken after stow has run, and every answer in it is
+# the filesystem's as it stands rather than a prediction: a link stow pruned a
+# moment ago is not counted because it is no longer there - the ordinary case of
+# a file leaving its layer, where the directory holding it stays and stow walks
+# in and takes the link back.
+#
+# 'kept' is build's, taken where no stow has run.  A link an apply will take
+# back is passed over there, on the same test doctor's report reads, so that a
+# build says what the apply after it would have said and neither says it twice.
+# Without that, every build that dropped a file from a directory the tree still
+# holds would report a link that the next apply removes - #75's rule, and a
+# reader sent to doctor over a link that is about to go on its own.
 #
 # What this is not is an audit of $HOME, which is doctor's and costs a walk of
 # it.  Measured on the container: chkstow takes 0.10s over a 20k-entry home and
@@ -5086,7 +5170,7 @@ scan_previous_tree() {
 # still answers for itself - it says chkstow is missing and what that costs, in
 # its own words, and chkstow ships with stow, which an apply needed to run at all.
 count_dangling_links() {
-  local i n rel target link dest
+  local scope=$1 i n rel target link dest spelling
   DANGLING=0
   # The substitution below swallows a missing readlink - every link would arrive
   # with an empty target and be passed over, and the count would be a 0 meaning
@@ -5133,9 +5217,12 @@ count_dangling_links() {
     dest=$(readlink "$link") || continue
     [ -n "$dest" ] || continue
     # A relative target is what stow writes, and it is relative to the directory
-    # holding the link rather than to anywhere shale is.
+    # holding the link rather than to anywhere shale is.  Which of the two it is
+    # decides whether an apply removes this link, so it is read before the join
+    # takes the difference away - doctor's report reads it the same way.
+    spelling=relative
     case "$dest" in
-      /*) ;;
+      /*) spelling=absolute ;;
       *) dest=${link%/*}/$dest ;;
     esac
     normalise_path "$dest"
@@ -5144,8 +5231,31 @@ count_dangling_links() {
     # strings as they arrived: $HOME itself may hold a '.' or a '..'.
     normalise_path "$target"
     [ "$dest" = "$NORMALISED" ] || continue
+    # The links the next apply takes back, which are not a build's to report.
+    # An absolutely spelled one is not among them however ordinary its directory
+    # is: stow leaves it in place, so it is counted here, and it is what apply's
+    # own count finds after stow.  2.4.1 says nothing about one; 2.3.1 prints a
+    # 'BUG in find_stowed_path?' line for a link directly in $HOME and nothing
+    # for one further down, measured on both.
+    if [ "$scope" = kept ] && [ "$spelling" = relative ] &&
+      tree_holds_the_directory_of "$rel"; then
+      continue
+    fi
     DANGLING=$((DANGLING + 1))
   done
+}
+
+# The one line either command says about those links, in ORPHAN_LINE, and empty
+# where there are none.  Written once because both say the same thing about the
+# same links: the build is what took the paths out of the tree, whichever
+# command the reader ran, and doctor is what names them.
+orphan_line() {
+  ORPHAN_LINE=
+  if [ "$DANGLING" -eq 1 ]; then
+    ORPHAN_LINE="1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it"
+  elif [ "$DANGLING" -gt 0 ]; then
+    ORPHAN_LINE="$DANGLING links in $HOME point at paths the built tree no longer provides: this build took those paths out of the tree, and 'shale doctor' names them"
+  fi
 }
 
 cmd_apply() {
@@ -5157,14 +5267,12 @@ cmd_apply() {
     die 'stow is not installed, and apply links the built tree with it' \
       'install it with your system package manager: shale installs nothing'
 
-  # Before the build, which is what takes paths out of the tree being read.  A
-  # tree that is not a directory is left to the build to refuse, and a missing
-  # one - the state before the first build - leaves nothing to have orphaned.
-  PREVIOUS_PATHS=()
-  if [ -d "$CUR" ] && [ ! -L "$CUR" ]; then
-    scan_previous_tree ''
-  fi
-
+  # The build walks the tree it replaces and would report the links that leaves
+  # dangling, which is right where it is run on its own and wrong here: this
+  # apply counts again once stow has run, and stow takes back the links from
+  # every directory the tree still holds.  Build's number is taken before that
+  # and would name links that are gone by the time the line is read.
+  BUILD_REPORTS_ORPHANS=0
   cmd_build || exit 1
 
   # -t "$HOME" is mandatory even though stow's default target - the parent of
@@ -5258,13 +5366,10 @@ cmd_apply() {
   # providing, including the ones an apply that had run would have pruned - so
   # what is said is that the build took the paths out, which is true of all of
   # them, rather than that stow declined to remove them, which is true of some.
-  count_dangling_links
+  count_dangling_links all
+  orphan_line
   lines=()
-  if [ "$DANGLING" -eq 1 ]; then
-    lines=("1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it")
-  elif [ "$DANGLING" -gt 0 ]; then
-    lines=("$DANGLING links in $HOME point at paths the built tree no longer provides: this build took those paths out of the tree, and 'shale doctor' names them")
-  fi
+  [ -z "$ORPHAN_LINE" ] || lines=("$ORPHAN_LINE")
 
   if [ "$status" -eq 125 ]; then
     die "could not enter $DOTFILES to run stow" \

--- a/tests/run
+++ b/tests/run
@@ -4880,6 +4880,334 @@ test_build_a_dot_lock_in_dotfiles_is_nothing_to_any_command() {
   assert_real_dir "$HOME/.dotfiles/.lock" 'the planted directory'
 }
 
+# Issue #137's transcript, read from the command that leaves the links.  A
+# directory leaves every layer, and the build composing the tree without it is
+# what takes those paths out - so the build is what counts them, and the apply
+# after it has nothing to add: the tree it reads is the one those paths have
+# already left.  Before this, running the documented 'shale build' first bought
+# silence from both commands.
+#
+# The count is what makes the line worth having: three links from two
+# directories is a number neither a per-link report nor a per-directory one
+# would print.
+test_build_names_how_many_links_it_orphaned() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  mklayer local .config/git/config
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that made the links'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_eq \
+    "shale: 3 links in $HOME point at paths the built tree no longer provides: this build took those paths out of the tree, and 'shale doctor' names them" \
+    "$shale_err" 'the build stderr'
+  # One line and no more: which links they are and which remedy applies are
+  # doctor's, and a block of them here would be a block on every build that
+  # drops a directory.
+  assert_eq 1 "$(printf '%s\n' "$shale_err" | grep -c '^shale: ')" \
+    'lines the build printed'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  assert_dangling_symlink "$HOME/.config/nvim/spell.add" 'the leftover link'
+  assert_dangling_symlink "$HOME/.config/git/config" 'the leftover link'
+  # The apply after it says nothing, which is the whole of what 'once' means
+  # here: the same three links, already named by the command that made them.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the build'
+  assert_empty "$shale_err" 'the apply after the build'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc"
+  # And doctor, which none of this changes, still holds the detail.
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/nvim/init.lua points at $HOME/.dotfiles/current/.config/nvim/init.lua, which the built tree no longer provides" \
+    'doctor stdout'
+  assert_contains "$shale_out" 'shale: 3 problems found' 'doctor stdout'
+}
+
+# The other half of that claim, and what decides whether the line above is ever
+# read: a build that orphans nothing says nothing, which is every ordinary
+# build.  Four shapes of one - a first build with no tree to replace, a repeat
+# of it, a file leaving a directory the tree still holds, and a file leaving the
+# top of the tree.
+#
+# The last two are why the count is not 'whatever dangles now'.  Both leave a
+# link that dangles the moment the build ends and both are taken back by the
+# next apply, so a build that reported them would send a reader to doctor over
+# links that go on their own - and would do it on the commonest edit there is.
+#
+# assert_empty is the anchor: a substring test for the message would pass on any
+# message that merely differs from the needle, and what is asserted here is that
+# there is no message at all.
+test_build_says_nothing_when_it_orphans_nothing() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .vimrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the first build'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the second build'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply'
+  sandbox_leaf "$HOME/.dotfiles/personal/base" .vimrc
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  sandbox_leaf "$HOME/.dotfiles/personal/base/.config/nvim" spell.add
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  run_shale build
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the build that took two files out'
+  # Both links dangle while they wait for the apply, and both are gone after it.
+  # That is what the silence above is a claim about.
+  assert_dangling_symlink "$HOME/.vimrc" 'the link waiting for the apply'
+  assert_dangling_symlink "$HOME/.config/nvim/spell.add" \
+    'the link waiting for the apply'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that pruned two links'
+  assert_missing "$HOME/.vimrc" 'the pruned link'
+  assert_missing "$HOME/.config/nvim/spell.add" 'the pruned link'
+}
+
+# The claim #137 turns on, asserted as a comparison: a build followed by an
+# apply says what a bare apply says, once.  The same shape of path leaves the
+# tree by each route - a directory that left every layer - and the same one link
+# is counted either way.
+#
+# What differs is the cause each names, and it has to: no stow has run when the
+# build speaks, so a build saying stow had declined to remove anything would be
+# describing something that never happened.  The count, the paths and the remedy
+# are the same words in both, which is what a reader acts on.
+test_build_then_apply_says_what_a_bare_apply_says() {
+  local by_build by_apply line
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .local/share/pass/one.gpg
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that made the links'
+  # The build's route.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  by_build=$shale_err
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the build'
+  assert_empty "$shale_err" 'the apply after the build'
+  # The apply's route: a second directory leaves, and nothing is built first.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.local"
+  rm -rf "$sandbox_dir/share" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the bare apply'
+  by_apply=$shale_err
+  assert_eq \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it" \
+    "$by_build" 'the build stderr'
+  assert_eq \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names it" \
+    "$by_apply" 'the bare apply stderr'
+  # Stated over both rather than read off the two literals above, so that a
+  # change to either wording that dropped the count or the remedy fails here.
+  for line in "$by_build" "$by_apply"; do
+    assert_eq 1 "$(printf '%s\n' "$line" | grep -c '^shale: ')" 'lines one route printed'
+    assert_contains "$line" \
+      "shale: 1 link in $HOME points at a path the built tree no longer provides" \
+      'the count both routes print'
+    assert_contains "$line" "'shale doctor' names it" 'the remedy both routes print'
+  done
+}
+
+# The count belongs to the run that made it, in both directions.  A build that
+# orphans a link and an apply after it that orphans none: the number is the
+# build's and the apply is silent.  Then a build that orphans none and an apply
+# that orphans one of its own: the number is the apply's, and it is 1 rather
+# than the 2 dangling in $HOME by then, the first belonging to the build that
+# named it.
+#
+# Which is the same scope apply has always had, now shared: neither command
+# audits $HOME - that costs a walk of the whole of it and is doctor's - and both
+# answer for the paths their own run took out of the tree.
+test_build_and_apply_each_count_the_links_their_own_run_left() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .local/share/pass/one.gpg
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that made the links'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that orphaned one'
+  assert_eq \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it" \
+    "$shale_err" 'the build that orphaned one'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that orphaned none'
+  assert_empty "$shale_err" 'the apply that orphaned none'
+  # The other direction: a build with nothing to take out, and then an apply
+  # doing the whole of it.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that orphaned none'
+  assert_empty "$shale_err" 'the build that orphaned none'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.local"
+  rm -rf "$sandbox_dir/share" || fail 'could not remove the layer directory'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that orphaned one'
+  # An equality rather than a substring test, because the number is the whole
+  # claim: a line counting both orphans would satisfy any needle this one is a
+  # prefix of.
+  assert_eq \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names it" \
+    "$shale_err" 'the apply that orphaned one'
+  # Both links are in $HOME, and doctor - which answers for $HOME rather than
+  # for a run - names both.
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the link the build left'
+  assert_dangling_symlink "$HOME/.local/share/pass/one.gpg" 'the link the apply left'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_eq 2 \
+    "$(printf '%s\n' "$shale_out" | grep -c 'which the built tree no longer provides')" \
+    'the orphans doctor names'
+}
+
+# The same line under a root outside $HOME, which is the layout where the two
+# halves of the count are different directories: the links are in $HOME and what
+# they point at is under SHALE_DIR.  A count that read the root for the links,
+# or the home for the tree, finds nothing here and reports a clean build.
+test_build_names_the_links_it_orphaned_under_a_root_outside_the_home() {
+  local shale_root
+  shale_dir_fixture
+  sandbox_write "$shale_root/personal/base/.config/nvim" init.lua 'elsewhere/init.lua'
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that made the links'
+  assert_symlink_to "$HOME/.config/nvim/init.lua" \
+    "$shale_root/current/.config/nvim/init.lua"
+  sandbox_mkdir "$shale_root/personal/base"
+  rm -rf "$sandbox_dir/.config" || fail 'could not remove the layer directory'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_eq \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it" \
+    "$shale_err" 'the build stderr'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the leftover link'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the build'
+  assert_empty "$shale_err" 'the apply after the build'
+  assert_symlink_to "$HOME/.zshrc" "$shale_root/current/.zshrc"
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/nvim/init.lua points at $shale_root/current/.config/nvim/init.lua, which the built tree no longer provides" \
+    'doctor stdout'
+}
+
+# The guard that no other case reaches: a link spelled as an absolute path is
+# not one the next apply takes back, however ordinary the directory holding it
+# is, so a build counts it even where the built tree still holds that directory.
+# Removing the spelling test from the count leaves every case above green while
+# this state - two absolute links at paths that have left the tree, in a
+# directory that has not - goes from two lines to one silent build and one apply
+# saying 2, which is the very split #137 exists to close.
+#
+# Both routes, because it is the agreement between them that is the claim.  The
+# links are one level down on purpose: 2.3.1 writes a 'BUG in find_stowed_path?'
+# line about an absolute link directly in $HOME and nothing at all about one
+# below it, 2.4.1 is silent about either, and asserting shale's own silence here
+# would otherwise be asserting a stow version.
+test_build_counts_an_absolute_link_a_still_held_directory_will_keep() {
+  local by_build by_apply f dir
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  mklayer personal/base .config/nvim/plugins.lua
+  mklayer personal/base .local/share/pass/one.gpg
+  mklayer personal/base .local/share/pass/two.gpg
+  mklayer personal/base .local/share/pass/three.gpg
+  run_shale apply
+  assert_status 0 "$shale_status"
+  assert_empty "$shale_err" 'the apply that made the links'
+  # The build's route: the user's own spelling of two links, and then the two
+  # paths under them leaving the tree while the directory holding them stays.
+  #
+  # In that order, and never the reverse: an absolute link at a path the tree
+  # still provides is a conflict stow refuses outright - 'existing target is not
+  # owned by stow' - so the layer file has to go in the same breath.
+  for f in .config/nvim/spell.add .config/nvim/plugins.lua; do
+    sandbox_mkdir "$HOME/${f%/*}"
+    dir=$sandbox_dir
+    # The link the apply made goes by path rather than through a leaf proof, for
+    # the reason every case that replaces one does: the proof refuses a symlink
+    # at the name, and a symlink at the name is what this is here to replace.
+    rm -f "$dir/${f##*/}" || fail "could not remove the link the apply made at $f"
+    sandbox_leaf "$dir" "${f##*/}" new
+    ln -s "$HOME/.dotfiles/current/$f" "$sandbox_path" ||
+      fail "could not plant the absolute link at $f"
+    sandbox_leaf "$HOME/.dotfiles/personal/base/${f%/*}" "${f##*/}"
+    rm -f "$sandbox_path" || fail "could not remove the layer file at $f"
+  done
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  by_build=$shale_err
+  assert_real_dir "$HOME/.dotfiles/current/.config/nvim" \
+    'the directory the tree still holds'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the build'
+  assert_empty "$shale_err" 'the apply after the build'
+  assert_dangling_symlink "$HOME/.config/nvim/spell.add" 'the link stow kept'
+  assert_dangling_symlink "$HOME/.config/nvim/plugins.lua" 'the link stow kept'
+  # The apply's route, in the other directory and with nothing built first.
+  for f in .local/share/pass/two.gpg .local/share/pass/three.gpg; do
+    sandbox_mkdir "$HOME/${f%/*}"
+    dir=$sandbox_dir
+    rm -f "$dir/${f##*/}" || fail "could not remove the link the apply made at $f"
+    sandbox_leaf "$dir" "${f##*/}" new
+    ln -s "$HOME/.dotfiles/current/$f" "$sandbox_path" ||
+      fail "could not plant the absolute link at $f"
+    sandbox_leaf "$HOME/.dotfiles/personal/base/${f%/*}" "${f##*/}"
+    rm -f "$sandbox_path" || fail "could not remove the layer file at $f"
+  done
+  run_shale apply
+  assert_status 0 "$shale_status" 'the bare apply'
+  by_apply=$shale_err
+  assert_real_dir "$HOME/.dotfiles/current/.local/share/pass" \
+    'the directory the tree still holds'
+  assert_dangling_symlink "$HOME/.local/share/pass/two.gpg" 'the link stow kept'
+  assert_dangling_symlink "$HOME/.local/share/pass/three.gpg" 'the link stow kept'
+  # The same nonzero count from both, which is what the guard buys: without it
+  # the build says nothing here and the apply still says two.
+  assert_eq \
+    "shale: 2 links in $HOME point at paths the built tree no longer provides: this build took those paths out of the tree, and 'shale doctor' names them" \
+    "$by_build" 'the build stderr'
+  assert_eq \
+    "shale: 2 links in $HOME point at paths the built tree no longer provides: stow does not remove a link from a directory that left the tree; 'shale doctor' names them" \
+    "$by_apply" 'the bare apply stderr'
+  # And doctor, which reads the spelling the same way, names all four and offers
+  # no apply for any of them.
+  run_shale doctor
+  assert_status 1 "$shale_status" 'doctor'
+  assert_eq 4 \
+    "$(printf '%s\n' "$shale_out" | grep -c 'which the built tree no longer provides')" \
+    'the orphans doctor names'
+  assert_contains "$shale_out" \
+    'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
+    'doctor stdout'
+}
+
 # ---------------------------------------------------------------- clone cases
 #
 # Every url here is a path to a repository the case created; no case names a
@@ -9905,10 +10233,12 @@ test_doctor_the_apply_remedy_reads_for_more_than_one_link() {
 }
 
 # The discriminator's other half, which no directory can stand for: a link
-# spelled as an absolute path is one no stow prunes, wherever it sits.  2.3.1
-# says 'BUG in find_stowed_path?' on its stderr and carries on; 2.4.1 says
-# nothing; both leave the link.  So the link here is in a directory the built
-# tree still holds, and the remedy is still the delete.
+# spelled as an absolute path is one no stow prunes, wherever it sits.  Both
+# versions leave it.  2.4.1 says nothing about one; 2.3.1 says 'BUG in
+# find_stowed_path?' on its stderr and carries on, and only for a link directly
+# in $HOME - one further down, as here, it passes over in silence.  So the link
+# here is in a directory the built tree still holds, and the remedy is still the
+# delete.
 test_doctor_an_absolute_link_is_not_one_an_apply_clears() {
   conf 'base personal/base'
   mklayer personal/base .config/nvim/init.lua


### PR DESCRIPTION
Closes #137.

`build` now prints one stderr line, exit 0, counting the `$HOME` links its tree replacement orphaned — only those the next apply would not prune, so the ordinary edit stays silent and build's number equals what a bare apply reports. An apply that ran the build internally says it once, from its own post-stow report, unchanged byte-for-byte from #132. Doctor unchanged. The docs' build-first route now reports what the bare-apply route always did.

Gates run: code review (logic confirmed clean including a from-source trace of stow's unstow phase on 2.3.1 and 2.4.1; one load-bearing guard found unenforced and now pinned by a mutation-checked case) and functional verification by execution — build's count matched stow 2.3.1's actual prune behavior exactly in every link class and both directions, and bare apply is byte-identical to main across seven scenarios. 523 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)