### PR TITLE
Give doctor's unprunable remedy the clause that is true of both kept-link classes

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -373,7 +373,7 @@ is correct, and which remedy fits. Doctor is also what still reports them afterw
 ```
 shale: /home/you/.config/foo/a.conf points at /home/you/.dotfiles/current/.config/foo/a.conf, which the built tree no longer provides
 shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying
-shale:   stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links
+shale:   stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds, so none of these is one of them
 shale:   stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:
 shale:     stow -D -p --no-folding -d '/home/you/.dotfiles' -t '/home/you' current && shale apply
 shale:   earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory

--- a/shale
+++ b/shale
@@ -4152,7 +4152,8 @@ EOF
   # one of them.  A file that left its only layer leaves a link the next apply
   # removes on its own, and telling the reader to rm it - and that reapplying
   # will not help - is both more work than the state needs and false about it.
-  # A directory that left every layer is the case that needs the rm, and the
+  # A directory that left every layer, or a link spelled as an absolute path in
+  # a directory the tree still holds, is the case that needs the rm, and the
   # sweep under it is the alternative to doing that by hand.  Where the two are
   # mixed, the rm is what covers all of them and the apply is named for what it
   # takes off the list.
@@ -4200,7 +4201,7 @@ EOF
       remedy+=("an apply would clear $prunable of them and leave the rest: stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds" \
         'no apply will finish until the problems above are fixed')
     else
-      remedy+=('stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links')
+      remedy+=('stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds, so none of these is one of them')
     fi
     # The sweep goes with the apply rather than standing without it.  Its '&&'
     # is on stow's exit status and not on the apply's, so where the apply cannot

--- a/tests/run
+++ b/tests/run
@@ -10143,7 +10143,7 @@ test_doctor_a_link_into_the_built_tree_it_no_longer_provides_is_a_finding() {
     'shale: remove the links named above; the built tree is correct, and nothing needs rebuilding or reapplying' \
     'stdout'
   assert_contains "$shale_out" \
-    'shale:   stow prunes a link only from a directory the built tree still holds, so a directory that left every layer keeps its links' \
+    'shale:   stow prunes only the links an apply wrote — relative, and in a directory the built tree still holds, so none of these is one of them' \
     'stdout'
   assert_contains "$shale_out" \
     'shale:   stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \


### PR DESCRIPTION
Closes #164.

Wording-only, three lines: doctor's `prunable -eq 0` remedy clause becomes the sentence #162 settled — true of departed-directory links, absolutely-spelled links, and mixtures — plus the one asserting test and a docs transcript that would otherwise misquote real output. Gate: combined code review and functional check by execution (both states reproduced, one-line diff against main, doc transcript byte-identical, no lookalike dash anywhere). 524 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)