### PR TITLE
Treat a directory the tree holds through a symlink as one stow cleans

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -294,6 +294,14 @@ A symlink is copied as a symlink, target text unchanged, and it is a leaf: shale
 one, so a layer's symlink to a directory collides with a lower layer's real directory rather than
 merging into it.
 
+Stow does follow one, which is where it parts company with the composer. Where `$HOME` already holds
+a real directory at that path, an apply links the contents of the link's directory into it and
+leaves your own files there untouched — measured on stow 2.3.1 and 2.4.1. `doctor` reports that path
+all the same, as one holding something no apply put there: what a build will put at the far end of a
+link is not something it can read off the link, and one file of yours at a name that directory
+provides is a refusal stow abandons the whole apply over. Move your directory aside if you want the
+link, or leave it and read what the apply says.
+
 The target is resolved from where the link ends up inside `current/`, not from `$HOME`. A link to a
 sibling works — `.exrc -> .vimrc` resolves inside `current/` and reading `~/.exrc` gets the file.
 A link written as though it started in `$HOME`, such as `.exrc -> .dotfiles/current/.vimrc`, dangles

--- a/shale
+++ b/shale
@@ -3886,12 +3886,68 @@ audit_declared_modes() {
   note ${lines[@]+"${lines[@]}"}
 }
 
-# Whether the built tree still holds the directory that a link at $1 - a path
-# relative to $HOME - sits in, which is what stow's unstow phase walks; what
-# that was measured against is under apply_prunes_link below.  A directory the
-# ignore list covers is the exception both versions make - they skip it before
-# recursing, so nothing inside one is swept - and no apply links into one of
-# those either, so no link this counts is in one.
+# Whether stow walks into the built tree's path $1, $1 being absolute: it is one
+# question for both phases of a restow, because an apply that walks a directory
+# walks it in each of them and an apply that refuses does neither.  Written
+# apart from its one reader below because what it answers is a fact about stow
+# rather than about the link being asked after.
+#
+# A symlink to a directory is one stow walks into, which is where this parts
+# company with the composer: a link is a leaf to the composer, and stow follows
+# it.  unstow_node hands any target that is a real directory to unstow_contents,
+# and stow_node any that is, to stow_contents; each asks -d of the package's
+# path, which follows the link, and walks what is at the end of it.  Measured
+# both ways round on 2.3.1 and against 2.4.1's source, with the tree's
+# '.config/nvim' a symlink and $HOME's a real directory: the contents were
+# linked into it and the apply exited 0, and a dangling link inside it was
+# pruned, for a link into the tree and one out of it alike.
+#
+# An absolutely spelled link is the one shape the versions disagree about, and
+# it answers no on both.  2.4.1 refuses the whole apply over it - 'source is an
+# absolute symlink ... All operations aborted' - and touches nothing anywhere;
+# 2.3.1 walks it as above, because the test it makes for that is against a path
+# relative to the wrong directory below the top level, so it catches only a
+# top-level one.  2.3.1's tolerance is the bug rather than the contract, and no
+# is the answer that is true of the apply a reader is about to run on either.
+#
+# A dangling link and a link to a file answer no through -d, and both are a
+# state stow dies in - 'unstow_contents() called with non-directory path' on
+# both versions, an apply that exits non-zero having relinked nothing.
+stow_walks_into() {
+  local dir=$1 dest
+  # -d as stow's own test is -d: it follows a link, and a dangling one or one to
+  # a file is out on the same line as a path holding nothing at all.
+  [ -d "$dir" ] || return 1
+  # The readlink is spent only where the answer turns on it, an ordinary
+  # directory being done above.  A missing readlink answers no, which is the
+  # conservative half: a link left to be removed by hand rather than an apply
+  # promised for it that then leaves it where it was.
+  [ -L "$dir" ] || return 0
+  # Defence for a caller that does not exist yet: both of today's return before
+  # they reach this - audit_broken_links on the tool, count_dangling_links on its
+  # own readlink a few lines earlier - so nothing here can reach the
+  # substitution without it.  A third caller that skipped that check would
+  # otherwise have the shell report the missing command on its own stderr, which
+  # is a line shale did not write.
+  command -v readlink >/dev/null 2>&1 || return 1
+  dest=$(readlink "$dir") || return 1
+  case "$dest" in
+    /*) return 1 ;;
+  esac
+  return 0
+}
+
+# Whether stow's unstow phase runs its cleanup in the directory that a link at
+# $1 - a path relative to $HOME - sits in, that sweep being what takes a link
+# out of $HOME without a hand; what the answer is used for is under
+# apply_prunes_link below.  The path asked about is the built tree's, because
+# the walk is of the built tree: a directory it no longer holds is never
+# visited, whatever $HOME still has there.  Which directories stow walks into is
+# stow_walks_into's question, measured there.
+#
+# A directory the ignore list covers is the exception both versions make - they
+# skip it before recursing, so nothing inside one is swept - and no apply links
+# into one of those either, so no link this counts is in one.
 #
 # Two readers, asking the same question from opposite ends: doctor of a link
 # chkstow handed it, and the dangling-link count of a path a build's own
@@ -3904,9 +3960,7 @@ tree_holds_the_directory_of() {
     # A link directly in $HOME, whose directory is the built tree itself.
     *) dir=$CUR ;;
   esac
-  # A symlink to a directory is a leaf to stow as it is to the composer, so it
-  # is not a directory the unstow phase walks into.
-  [ -d "$dir" ] && [ ! -L "$dir" ]
+  stow_walks_into "$dir"
 }
 
 # Non-zero unless the next apply removes the orphaned link $1 by itself, so that

--- a/tests/run
+++ b/tests/run
@@ -5267,6 +5267,132 @@ test_apply_counts_both_kinds_of_kept_link_in_one_run() {
     "$HOME/.dotfiles/current/.local/share/pass/one.gpg"
 }
 
+# The class neither of the two above is: a directory the built tree holds
+# through a symlink.  A symlink is a leaf to the composer and not one to stow -
+# unstow_contents asks -d of the package's path, which follows the link, walks
+# what is at the end of it and sweeps the target directory on the way out - so
+# the links inside it are pruned exactly as a real directory's are.  Measured on
+# 2.3.1 and against 2.4.1's source, both of which prune below and exit 0.
+#
+# The state is a layer swapping a directory for a symlink to one it keeps
+# elsewhere, which is the everyday shape of it: '.config/nvim' pointing at
+# '.vim'.  The file that does not come across is what leaves a link behind, and
+# the file that does is the control - a build that reported this pair would have
+# to say 1, and the apply after it takes that one back.
+test_build_says_nothing_about_a_link_stow_prunes_from_a_symlinked_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the links'
+  assert_empty "$shale_err" 'the apply that made the links'
+  mklayer personal/base .vim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/nvim" || fail 'could not remove the layer directory'
+  sandbox_leaf "$sandbox_dir" nvim new
+  ln -s ../.vim "$sandbox_path" || fail 'could not plant the layer symlink'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_empty "$shale_err" 'the build'
+  assert_dangling_symlink "$HOME/.config/nvim/spell.add" \
+    'the link waiting for the apply'
+  # The claim is stow's rather than this suite's: the apply the build said
+  # nothing about is run, and the link is gone after it.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply'
+  assert_missing "$HOME/.config/nvim/spell.add" 'the pruned link'
+  assert_symlink_to "$HOME/.config/nvim/init.lua" \
+    "$HOME/.dotfiles/current/.config/nvim/init.lua" 'the link the tree still answers for'
+}
+
+# Apply's own count, on the same state and with no build of its own before it:
+# it is taken once stow has run, so the link stow has just pruned is not there
+# to be counted and the run says nothing.  That was true before the tree ever
+# held a directory through a symlink and this is what pins it, the count being
+# the one of the three readers this class of directory never reached.
+test_apply_counts_nothing_where_stow_pruned_a_link_from_a_symlinked_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the links'
+  mklayer personal/base .vim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/nvim" || fail 'could not remove the layer directory'
+  sandbox_leaf "$sandbox_dir" nvim new
+  ln -s ../.vim "$sandbox_path" || fail 'could not plant the layer symlink'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_empty "$shale_err" 'the apply'
+  assert_missing "$HOME/.config/nvim/spell.add" 'the pruned link'
+}
+
+# The spelling of the tree's own symlink, which is the one shape the two
+# versions disagree about and so the one that answers no on both.  2.4.1 refuses
+# the whole apply over an absolutely spelled source - 'source is an absolute
+# symlink' - and prunes nothing anywhere; 2.3.1 makes that test against a path
+# relative to the wrong directory below the top level, so it stows this one and
+# sweeps below it.  Measured, both.
+#
+# So the link is counted, and the remedy the reader gets for it is the rm that
+# works on either.  No apply is run here for the same reason the answer is no:
+# its status is the version, not the behaviour under test.
+test_build_counts_a_link_under_an_absolutely_spelled_symlink_to_a_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the links'
+  mklayer personal/base .vim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/nvim" || fail 'could not remove the layer directory'
+  sandbox_leaf "$sandbox_dir" nvim new
+  # Where it points makes no difference; how it is spelled is the whole of it.
+  ln -s "$HOME/.dotfiles/personal/base/.vim" "$sandbox_path" ||
+    fail 'could not plant the layer symlink'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_eq \
+    "shale: 1 link in $HOME points at a path the built tree no longer provides: this build took that path out of the tree, and 'shale doctor' names it" \
+    "$shale_err" 'the build stderr'
+  assert_dangling_symlink "$HOME/.config/nvim/spell.add" 'the link the build counted'
+}
+
+# The other shape -d turns away, and this one both versions agree on: a symlink
+# with nothing at the end of it is not a directory stow walks into, it is a
+# directory stow dies in.  'unstow_contents() called with non-directory path' on
+# 2.3.1 and on 2.4.1's source alike, an apply that exits non-zero, and both
+# links still in $HOME afterwards - so a build that had passed over them on the
+# grounds that an apply takes them back would have been wrong about an apply
+# that does not run at all.
+test_build_counts_the_links_a_dangling_symlink_in_the_built_tree_left() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the links'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/nvim" || fail 'could not remove the layer directory'
+  sandbox_leaf "$sandbox_dir" nvim new
+  ln -s ../.vim "$sandbox_path" || fail 'could not plant the layer symlink'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_eq \
+    "shale: 2 links in $HOME point at paths the built tree no longer provides: this build took those paths out of the tree, and 'shale doctor' names them" \
+    "$shale_err" 'the build stderr'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+  # A fragment of shale's own line rather than stow's: what stow prints there is
+  # its internal error text, and only the shape of the failure - a die rather
+  # than the planned refusal that exits 1 - is the same on both versions.
+  assert_contains "$shale_err" "shale: stow failed part-way: $HOME may be partly relinked" \
+    'the apply stderr'
+  assert_dangling_symlink "$HOME/.config/nvim/init.lua" 'the link the apply left'
+  assert_dangling_symlink "$HOME/.config/nvim/spell.add" 'the link the apply left'
+}
+
 # ---------------------------------------------------------------- clone cases
 #
 # Every url here is a path to a repository the case created; no case names a
@@ -10320,6 +10446,123 @@ test_doctor_an_absolute_link_is_not_one_an_apply_clears() {
   assert_dangling_symlink "$HOME/.config/nvim/gone.lua" 'the link the apply left'
 }
 
+# A link in a directory the built tree holds through a symlink, which is the
+# class this issue is about: stow follows the link, walks what is at the end of
+# it and sweeps on the way out, so the link is one the next apply clears and not
+# one to send a reader to remove by hand.  Measured on 2.3.1 and against 2.4.1's
+# source, and the apply is run below so the claim is stow's rather than this
+# suite's.
+#
+# The remedy asserted is the sentence about which links stow prunes, not 'clear
+# it with: shale apply'.  Doctor has a finding of its own about this state - a
+# layer providing a symlink where $HOME has a real directory is a path it calls
+# one holding something no apply put there - and while that stands, no line in
+# the report names a command, which is the rule for every line that does.  That
+# finding is the conservative half of a trade doctor makes deliberately: the
+# apply below finishes and exits 0, so the finding costs a reader a look at a
+# path that was not in anybody's way, and the alternative is a report that
+# passes states an apply refuses.  What the classification below fixes is the
+# other line: the link inside that directory is one an apply takes back, and the
+# remedy no longer prescribes an rm for it.
+test_doctor_a_link_in_a_symlinked_directory_is_one_an_apply_clears() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/spell.add
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the links'
+  # The layer swaps the directory for a symlink to one it keeps elsewhere, and
+  # '.vim' has the one file: the other link is left pointing at a path the tree
+  # no longer provides.
+  mklayer personal/base .vim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/nvim" || fail 'could not remove the layer directory'
+  sandbox_leaf "$sandbox_dir" nvim new
+  ln -s ../.vim "$sandbox_path" || fail 'could not plant the layer symlink'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.config/nvim/spell.add points at $HOME/.dotfiles/current/.config/nvim/spell.add, which the built tree no longer provides" \
+    'stdout'
+  assert_contains "$shale_out" \
+    'shale:   stow prunes the links an apply wrote — relative, and in a directory the built tree still holds — and this is one of them' \
+    'stdout'
+  # What ships while the conflict finding stands, and it is about this link
+  # rather than about the directory the finding names.
+  assert_contains "$shale_out" \
+    'shale: no apply will finish until the problems above are fixed, so this link stays' \
+    'stdout'
+  # The remedy this must never be: it prescribes an rm for a link the apply
+  # below takes back on its own, and 'nothing needs reapplying' is false of it.
+  assert_not_contains "$shale_out" 'remove the links named above' 'stdout'
+  assert_not_contains "$shale_out" 'nothing needs rebuilding or reapplying' 'stdout'
+  assert_not_contains "$shale_out" 'stow -D -p' 'stdout'
+  # And the apply that classification speaks for, which is the whole of the
+  # claim: the link goes, and the report stops naming it.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_missing "$HOME/.config/nvim/spell.add" 'the link the apply cleared'
+  assert_symlink_to "$HOME/.config/nvim/init.lua" \
+    "$HOME/.dotfiles/current/.config/nvim/init.lua" 'the link the tree still answers for'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor after the apply'
+  assert_not_contains "$shale_out" 'which the built tree no longer provides' \
+    'the stdout after the apply'
+}
+
+# A layer's symlink to a directory where $HOME has a real directory of the
+# reader's own: stow walks into the link and links what is at the end of it into
+# that directory, so an apply over the settled state finishes and exits 0 -
+# measured on 2.3.1 and against 2.4.1's source.  Doctor names the path all the
+# same, and this pins that it does.
+#
+# The finding is conservative and deliberately so.  What is at the far end is
+# not the built tree's to answer for - the next apply builds before it stows, so
+# the layers decide it, and a link's target text can leave the tree, cross
+# another link or name a path no build composes.  Doctor cannot resolve that
+# exactly, so it says the one thing that is always true: it cannot promise this
+# apply.  The second half below is the state that makes the choice worth its
+# cost - the layer grows a file at the far end and the reader has one of their
+# own at that name, with no build in between - where the apply refuses and a
+# report that had passed the first half on the strength of the built tree would
+# have passed this one too.
+test_doctor_names_a_layer_symlink_over_a_real_directory_in_home() {
+  conf 'base personal/base'
+  mklayer personal/base .vim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  sandbox_leaf "$sandbox_dir" nvim new
+  ln -s ../.vim "$sandbox_path" || fail 'could not plant the layer symlink'
+  sandbox_mkdir "$HOME/.config/nvim"
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor on the settled state'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" \
+    'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.config/nvim" 'stdout'
+  # The cost of that answer, stated rather than wished away: this apply works.
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply doctor would not promise'
+  assert_symlink_to "$HOME/.config/nvim/init.lua" \
+    "$HOME/.dotfiles/current/.config/nvim/init.lua" 'the link stow made through the symlink'
+  # And what it buys: the layer grows a file at the far end, the reader has one
+  # of their own at that name, and no build has run.  Doctor says the same
+  # thing, and the apply refuses.
+  mklayer personal/base .vim/newthing
+  sandbox_write "$HOME/.config/nvim" newthing 'mine, and not a link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor with no build in between'
+  assert_contains "$shale_out" "shale:   $HOME/.config/nvim" 'the second stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply'
+  assert_contains "$shale_err" "shale: stow failed; nothing in $HOME was relinked" \
+    'the apply stderr'
+  assert_eq 'mine, and not a link' "$(cat "$HOME/.config/nvim/newthing")" \
+    'the file of the reader own'
+}
+
 # Both causes at once, which is the shape neither remedy alone is right for: the
 # rm covers all of them and is what leads, and the apply is named for the ones it
 # takes off the list rather than left out.
@@ -10789,6 +11032,38 @@ test_doctor_a_missing_readlink_warns_without_failing() {
 $shale_out
 EOF
   assert_eq 1 "$notes" 'the number of readlink notes'
+}
+
+# The same missing tool where a layer provides a symlink to a directory, which
+# is the shape whose answer turns on a link's own target text.  Doctor stops
+# before it reads one - it says the tool is missing and returns - so the path
+# stays the finding it was, and the run says that in its own words on stdout.
+#
+# stderr, because a shell reporting a command it could not find is the failure
+# this pins, and a doctor run has nothing of its own to put there.  What holds
+# it is the early return rather than the guard inside stow_walks_into, which no
+# caller can reach without readlink; the case is why a caller that changed that
+# would be noticed here.
+test_doctor_a_missing_readlink_says_nothing_of_its_own_on_stderr() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .vim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  sandbox_leaf "$sandbox_dir" nvim new
+  ln -s ../.vim "$sandbox_path" || fail 'could not plant the layer symlink'
+  sandbox_write "$HOME/.config/nvim" mine.lua 'mine, and not a link'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  stub_path_without readlink
+  saved=$PATH
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_empty "$shale_err" 'the doctor stderr'
+  assert_contains "$shale_out" \
+    'shale: readlink is not installed, and shale reads what a link points at with it' 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.config/nvim" 'stdout'
 }
 
 # The shape the audit's own check could never report: no build has run, so the


### PR DESCRIPTION
Closes #166, at the scope recorded in its final comment.

`tree_holds_the_directory_of` assumed stow treats a symlinked directory in the built tree as a leaf; measured on 2.3.1 and against 2.4.1 source, stow follows it and runs its cleanup inside. The helper now delegates to `stow_walks_into`, which encodes the measured truth (relative targets walked; absolute refused — 2.4.1 aborts the whole apply over one, 2.3.1's below-top-level tolerance is its bug; dangling and to-a-file refused). Consequences: doctor's orphan classification, its remedy sentence, and build's kept-scope count are now right for links inside symlinked directories — doctor no longer prescribes hand-removing links the next apply prunes itself. The conservative home-conflict finding for a layer symlink over a real `$HOME` directory is deliberately retained (doctor may exit 1 where the apply succeeds — never the reverse); a suppression was attempted, failed three adversarial gate rounds on measured doctor-green/apply-fails states, and is withdrawn per the issue comment, with a case now guarding against unsafe reintroduction.

Gates run: four full rounds of code review and functional verification, including fuzzing (~430 generated states), stow source reading on both versions, and a final combined gate confirming no doctor-green/apply-fails state is constructible on the shipped diff. 531 passed, 0 failed, 0 skipped under bash 5.2.21, bash 3.2.57, and a stow 2.4.1 source shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)