### PR TITLE
Name current.old while it holds what layers cannot produce again

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,15 +224,21 @@ pointing at it until stow makes the link, and one deleted from every layer leave
 until stow prunes it. Apply when unsure: it builds first, so it is never less than a build.
 [docs/layers.md](docs/layers.md) has the boundary case by case.
 
-Builds are quiet, bar one line: a build that takes a path out of the tree and leaves a link in
-`$HOME` pointing at nothing counts those links and says so, which is *Links left behind after layers
-change* in [docs/migrating.md](docs/migrating.md). A build that finds `current` holding a copy older
-than the layer file replacing it keeps the previous tree at `~/.dotfiles/current.old` and says
-nothing, because an edited layer leaves exactly that state and a message there would be a message on
-every edit. `shale doctor` is what reports the mismatch, as a note rather than a problem, and only
-until the build that overwrites it. After that build nothing reports it: what was there sits at
-`~/.dotfiles/current.old` until the next build removes it, and `doctor` names it again only where a
-problem it found means no build is coming — see [docs/layers.md](docs/layers.md).
+Builds are quiet. Three things make one say anything beyond the `composed layer` line it prints per
+layer, and nothing else does. A build that takes a path out of the tree and leaves a link in `$HOME`
+pointing at nothing counts those links and reports them, which is *Links left behind after layers
+change* in [docs/migrating.md](docs/migrating.md). A build that finds `current` holding a copy
+*newer* than the layer file replacing it reports that per file, naming where it kept what it
+replaced. And a build about to remove a `~/.dotfiles/current.old` reports that removal where the
+tree holds something the layers cannot produce again — a file newer than its layer copy, one whose
+kind the layers have changed, or one at a path no layer provides — where anything that is not a tree
+shale composed is sitting at the name, or where the state is one an interrupted build leaves. A
+build that finds `current` holding a copy *older* than the layer file replacing it keeps the
+previous tree and says nothing, because an edited layer leaves exactly that state and a message
+there would be a message on every edit; `shale doctor` is what reports that mismatch, as a note
+rather than a problem, and only until the build that overwrites it. `doctor` names a `current.old`
+on the same conditions the removal is announced on, and also where a problem it found means no build
+is coming — see [docs/layers.md](docs/layers.md).
 
 Shale chooses between three exit codes, and no others:
 
@@ -258,7 +264,8 @@ one at a time.
 and building again — and it should never be edited or versioned. Edit the layer, not the result. A
 build that finds a regular file in `current` differing in age from the layer's copy keeps the tree it
 replaced at `~/.dotfiles/current.old`, so what was there is recoverable until the next build, which
-removes it. Newer means either that something wrote or moved a file into the built tree — which is
+removes it — and says so as it goes, where that tree holds anything the layers cannot produce again,
+or is not a tree shale composed at all. Newer means either that something wrote or moved a file into the built tree — which is
 what `stow --adopt` does with a file newer than the layer's copy — or that a different layer now
 provides the path with an older copy; the build says so per file, stating both. Older means
 either that something moved a file into it, which is what `stow --adopt` does, or that a layer has
@@ -361,8 +368,8 @@ directory, or a link of your own, none of which stow will write over — that no
 `.stow-local-ignore`, which shale writes itself, or shale itself, that `~/.dotfiles/current` is a
 directory rather than a file or a link to one, that a build could create the tree it composes into,
 that nothing in `~/.dotfiles` whose name does not begin with a dot is a stray, that no `current.new`
-has been left beside `current` and no `current.old` that no build is coming to remove, and that no
-link in `$HOME` points into the built tree at a path it no longer provides. Where a `.stowrc` exists
+has been left beside `current` and no `current.old` holding anything the layers cannot produce again,
+and that no link in `$HOME` points into the built tree at a path it no longer provides. Where a `.stowrc` exists
 it says so, because stow appends its `--ignore` patterns to the ones shale passes and one of them can
 drop a file from an apply without a word. It reads nothing out of that file, and changes nothing
 itself.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -741,7 +741,8 @@ shale:   the layer copy wins; what was there is kept at /home/you/.dotfiles/curr
 
 Read the kept copy before you act on it, because the message covers two things and shale cannot tell
 them apart. If it is your own file — an edit through the `~/.zshrc` link, or something `stow --adopt`
-moved in — copy it into a layer, and do it before the next build, which reaps `current.old`. If it is
+moved in — copy it into a layer, and do it before the next build, which reaps `current.old` and says
+so on stderr while that tree still holds anything the layers cannot produce again. If it is
 the copy the layer that used to win this path was providing, there is nothing to do: remove an
 override, drop a layer from `shale.conf`, or reorder precedence, and the copy that wins the path in
 its place is often the older file, which is the same comparison with nobody having touched
@@ -784,11 +785,16 @@ are still named; what changes is that nothing promises you a `current.old` that 
 never creates.
 
 `doctor` names the files only in the window between one arriving and the next build. Afterwards the
-built copy is the layer's again, the mismatch is gone, and `doctor` says nothing at all — the copy
-is still in `current.old` and still one build from gone, but that tree is what every rebuild leaves
-and naming it after each one would be naming it after every edit. `doctor` names `current.old`
-where a problem it found means no build is coming to clear it, and there only. So the window is the
-one before the build: if you use `stow --adopt` against `current/`, run `shale doctor` first.
+built copy is the layer's again and the mismatch is gone, so nothing names your file any more — this
+direction of the comparison, the one an adopted older file lands in, is the one where the window
+closes quietly. The other direction it does not: where `current.old` holds a file *newer* than the
+layer copy that replaced it, one whose *kind* the layers have changed since — a path that is a
+directory or a symlink in a layer now, where the kept tree has a file, or a whole kept directory at
+a path a layer now provides as a symlink — or one at a path no layer provides at all, `doctor` says so in a note giving the directory's path and saying the next build
+removes it. That is a note about a directory
+and not about your file — the walk that decides it stops at the first path it cannot account for and
+reports no path at all, so which file it was is not in the note. So the window before the build is
+still the one worth having: if you use `stow --adopt` against `current/`, run `shale doctor` first.
 
 ## The everyday loop: build, and when to apply
 
@@ -801,9 +807,11 @@ each layer. It keeps `current.old` — the built copy your edit replaced was old
 the layer copy, which is the state a file moved into the tree also leaves, and shale keeps the
 previous tree either way — but it prints no message about it, because a message there is a message
 on every edit. `shale doctor` is where a built tree its layers have moved past is reported, and
-after a build the mismatch is gone. Doctor is silent about the `current.old` that build left as
-well, for the reason the build is: the next build removes it, and a line about it after every
-rebuild is a line after every edit.
+after a build the mismatch is gone. It says nothing about the `current.old` that build left either,
+and the reason is what is in it: every copy in that tree is a layer's own file from the build before,
+older than the layer copy that replaced it, so the layers still have all of it. A tree holding
+something they do not — a file newer than its layer copy, one the layers have since made a directory
+or a symlink, or one at a path no layer provides — is the case doctor does report, below.
 
 `shale apply` is what you need when a **path** appears or disappears, since making and unmaking links
 is stow's job and nothing else does it:
@@ -837,6 +845,7 @@ shale apply
 ```
 
 The first build after anything changes a layer — a pull, or your own edit a moment ago — keeps
-`current.old` without saying so, and the build after it removes it. Every build is quiet; what a
-`shale doctor` in between the pull and the build reports is the built tree not yet matching the
-layers, which is what that pull just did. There is no `shale sync`.
+`current.old` without saying so, and the build after it removes it without saying so either: what
+goes is the layers' own files at the layers' own age. Builds are quiet through the whole of that
+loop; what a `shale doctor` in between the pull and the build reports is the built tree not yet
+matching the layers, which is what that pull just did. There is no `shale sync`.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -25,8 +25,9 @@ it replaces gets three lines on stderr naming it and naming its copy in `current
 — which is what `--adopt` leaves when the file in `$HOME` predates the layer's — gets nothing,
 because an edited layer leaves that same state and the message would be on the loop you run all day.
 `shale doctor` is what covers the silent direction, and the time to run it is before you build,
-while it still names the file: after the build the copy is in `current.old` and doctor says nothing
-about it either, that tree being what every rebuild leaves. Or copy the file into a layer instead,
+while it still names the file: after the build the copy is in `current.old`, older than the layer
+copy that replaced it, which is the shape an ordinary rebuild leaves as well — so doctor says
+nothing about it, and the file is one build from gone. Or copy the file into a layer instead,
 and there is nothing to recover. The refusals themselves are covered below, each with what to do
 about it.
 
@@ -328,9 +329,12 @@ same note from a `doctor` run any time after pulling a layer and before building
 to act on there —
 which is why it is a note and `doctor` still exits 0. Either way the previous tree is at
 `current.old` and your file is in it, until the next clean build removes it. The note above is the
-last warning you get: after that build `doctor` cannot see the mismatch any more, because the built
-copy matches the layer again, and it says nothing about `current.old` either — every rebuild leaves
-one, so a line about it would be a line after every edit. Copy the file into a layer instead and
+last thing that names your file: after that build `doctor` cannot see the mismatch any more, because
+the built copy matches the layer again, and it says nothing about `current.old` either — an adopted
+file that predates the layer copy leaves a tree shaped exactly like the one every rebuild leaves,
+and a line about that would be a line after every edit. A file adopted *newer* than the layer copy
+is the other case: the build names it as it replaces it, `doctor` reports the tree for as long as it
+stands, and the build that removes it says so. Copy the file into a layer instead and
 there is nothing to recover.
 
 ## Links left behind after layers change

--- a/shale
+++ b/shale
@@ -3165,6 +3165,134 @@ winning_layer() {
   return 1
 }
 
+# Zero when the tree at $1, walked from the relative path $2 - empty for the
+# whole of it - holds an entry the layers as configured now do not account for.
+# $3 is list_dir's dots flag, 1 for a caller without dotglob and 0 for build,
+# which sets it: passing 1 there lists every dotfile twice and doubles the walk
+# again at each level below.  $4 is 1 where a path no layer provides is to be
+# counted, and 0 where that verdict cannot be trusted.  Asked by build and by
+# doctor, of a current.old and of nothing else.
+#
+# What it is for: current.old is left by two histories that leave the same
+# directory behind, and shale remembers neither.  A build keeps it because
+# something in the tree it replaced did not match the layer copy - which an
+# edited layer does to every path that layer provides, so most of them hold a
+# copy of files every layer still has - and a kill after the swap leaves one
+# holding whatever the tree held.  Nothing on disk says which; but the evidence
+# each would leave can be looked for, and this is that look.
+#
+# Newer than the layer copy, which is build's own divergence test asked one
+# build later, of the tree that was kept rather than the tree being composed.
+# An edit written through a link and a file moved into the built tree both land
+# there with a timestamp of their own, ahead of the layer copy that superseded
+# them; a copy the everyday loop keeps is the layer's own file from the build
+# before, older than the layer copy that has since been edited and never newer
+# than it.  So the everyday tree answers no and stays unmentioned, and #133's
+# quiet is what a reader gets for editing a layer.
+#
+# Or a different kind from the layer copy, which no age comparison reaches at
+# all: a layer that turned .zshrc into a directory of its own, or one that ships
+# a symlink where the kept tree holds a file, replaces that file with something
+# that is not a version of it, and the copy going away is the only one there is.
+# A kept symlink where the layer has a file is the same thing from the other
+# side, and is the shape a hand-made link in the built tree leaves.  Two
+# symlinks are the one pair left alone: there is no portable way to read the age
+# of a link rather than of what it points at, and a layer retargeting its own
+# link is an everyday change.
+#
+# Or provided by no layer at all, which is the same answer arrived at from the
+# other side: a path the layers have dropped since the kept build, or one
+# nothing ever provided, has no copy anywhere but here.  That verdict is $4's,
+# because it is only as good as the layers being all here - with a clone still
+# to be fetched, every path the missing layer provides looks dropped, and a walk
+# that counted them would call every tree evidence until the fetch.
+#
+# The current config decides the counterpart, not the config the kept build ran
+# under - the question is what is recoverable from somewhere else *now*, and a
+# layer dropped from shale.conf in between is a layer that no longer answers for
+# anything.
+#
+# One direction of the age comparison only, and the reason is the one that keeps
+# this quiet: a file moved into the built tree *older* than the layer copy -
+# which is what stow --adopt leaves for a file in $HOME that predates the
+# layer's - is shaped exactly like the everyday tree and cannot be told from it
+# here.  audit_built_tree is where that file is named, in the window before the
+# build that replaces it, and this cannot reopen a window that has closed.
+holds_unaccounted() {
+  local root=$1 rel=$2 dots=$3 unprovided=$4 here e base srel
+  here=$root${rel:+/$rel}
+  # A directory that cannot be listed answers every glob with nothing, exactly
+  # as an empty one does, so a subtree that could not be read would otherwise
+  # come back accounted for - which is the answer that keeps the line off the
+  # screen, and the wrong one to give from a walk that did not happen.
+  { [ -r "$here" ] && [ -x "$here" ]; } || return 0
+  # '.' and '..' are dropped by name, whatever the glob options say about them,
+  # and an unmatched pattern arrives as itself wherever nullglob is unset.  The
+  # list is expanded once, before the body runs, so the recursion below may
+  # write DIR_ENTRIES again.
+  list_dir "$here" "$dots"
+  for e in ${DIR_ENTRIES[@]+"${DIR_ENTRIES[@]}"}; do
+    base=${e##*/}
+    case "$base" in
+      . | ..) continue ;;
+      '*' | '.*')
+        { [ -e "$e" ] || [ -L "$e" ]; } || continue
+        ;;
+    esac
+    # The two names no layer ever accounts for and neither may be read as
+    # evidence: shale writes .stow-local-ignore into the top of every tree it
+    # composes and refuses any layer that ships one, and a build copies no .git
+    # at any depth.  Without the first, every tree shale has ever composed
+    # answers yes and the whole check is a line on every run.
+    [ "$base" = .git ] && continue
+    if [ -z "$rel" ] && [ "$base" = .stow-local-ignore ]; then
+      continue
+    fi
+    srel=${rel:+$rel/}$base
+    # A symlink to a directory is a leaf here as it is in the composer, and
+    # descending one would walk out of the tree being asked about.
+    if [ -d "$e" ] && [ ! -L "$e" ]; then
+      # The kind question again, asked of the directory before anything inside
+      # it is: a build composes a layer's symlink as a leaf, so a layer
+      # providing this path as anything but a real directory replaces the whole
+      # of what is kept here rather than merging into it, and every file below
+      # is going with it.  Asking only per file would answer through the layer's
+      # link - winning_layer's -e resolves it - so a target that happens to hold
+      # the same names reads as though the layers still had all of this, and the
+      # subtree goes in silence.  The everyday shape is a real directory on both
+      # sides, which this leaves alone.
+      #
+      # A path no layer provides at all is not answered here: the files below
+      # are what carry that verdict, and $unprovided is what decides whether it
+      # counts - deciding it for the directory would take the pending clone's
+      # suppression away from everything under it.
+      if winning_layer "$srel" -1 &&
+        { [ ! -d "$WINNER" ] || [ -L "$WINNER" ]; }; then
+        return 0
+      fi
+      holds_unaccounted "$root" "$srel" "$dots" "$unprovided" && return 0
+      continue
+    fi
+    if ! winning_layer "$srel" -1; then
+      [ "$unprovided" -eq 1 ] && return 0
+      continue
+    fi
+    # Kind before age, because a difference in kind is what no age can express:
+    # the two sides are not two versions of one file, and the layer's is not a
+    # copy of what is going away.
+    if [ -d "$WINNER" ] && [ ! -L "$WINNER" ]; then
+      return 0
+    fi
+    if [ -L "$e" ]; then
+      [ -L "$WINNER" ] || return 0
+      continue
+    fi
+    [ -L "$WINNER" ] && return 0
+    [ "$e" -nt "$WINNER" ] && return 0
+  done
+  return 1
+}
+
 # The built tree under $1, relative to $CUR and '' for the whole of it, walked
 # for files older than the layer copy that provides them.  Counts them into
 # MISMATCH_COUNT, keeps the first $2 in MISMATCH_PATHS and folds each into
@@ -4748,7 +4876,7 @@ check_layers() {
 BUILD_REPORTS_ORPHANS=1
 
 cmd_build() {
-  local i dir n had_current qcur qold rel file lineno bits errors
+  local i dir n had_current had_scratch qcur qold rel file lineno bits errors
 
   parse_config || exit 1
 
@@ -4785,6 +4913,14 @@ cmd_build() {
       'shale builds into it' \
       'remove it, or move it aside'
   fi
+
+  # Recorded before the reap below and read at the announcement further down: a
+  # tree standing here is the shape doctor calls an interrupted build, and this
+  # build removes it along with the current.old that shape leaves beside it -
+  # the one doctor has been telling the reader to copy out of.  After this rm
+  # nothing can tell that state from an ordinary run.
+  had_scratch=0
+  { [ ! -e "$NEW" ] && [ ! -L "$NEW" ]; } || had_scratch=1
 
   # Reaping whatever a killed run left behind.
   rm -rf "$NEW" || die "could not remove $NEW"
@@ -4988,6 +5124,41 @@ cmd_build() {
       die "could not write $NEW/.stow-local-ignore"
   fi
 
+  # Announced where what is going holds something the layers do not account for.
+  # The build that left it here named a file in it recoverable 'until the next
+  # build', and this is that build, so the deadline expiring is a thing that
+  # happens rather than a silence: one line, on stderr with build's other
+  # advisories, the build carrying on and exiting 0.  It is not a fault.
+  #
+  # Gated on holds_unaccounted rather than on the name being there, because the
+  # everyday loop leaves a current.old after every edit and #75 is what a build
+  # sounds like.  A tree holding the layers' own files from the build before is
+  # nothing to announce the removal of; one holding an edit written through a
+  # link, or a path no layer provides any more, is.
+  #
+  # The other three arms are doctor's, spelt the same way round: whatever that
+  # report names here, this line answers for.  Doctor tells a reader to copy
+  # what they want out of this tree before the next build, and a build that then
+  # removed it in silence would be the same asymmetry #168 was about, one state
+  # along.  So anything at the name that is not a directory is announced
+  # unlooked-at - no build composed it, and nothing accounts for it - and so is
+  # a removal made from either shape doctor calls an interrupted build, which
+  # are a $CUR that was not there when this build started and a $NEW that was.
+  #
+  # Only what was already here when this build started, either way.  The
+  # current.old this build is about to make is reaped further down instead.
+  #
+  # 'removing' rather than 'removed': the rm below can fail, and it dies naming
+  # the path when it does, so this line is what that message is about rather
+  # than a claim contradicting it.
+  if { [ -e "$OLD" ] || [ -L "$OLD" ]; } &&
+    { [ ! -d "$OLD" ] || [ -L "$OLD" ] ||
+      [ "$had_scratch" -eq 1 ] ||
+      { [ ! -e "$CUR" ] && [ ! -L "$CUR" ]; } ||
+      holds_unaccounted "$OLD" '' 0 1; }; then
+    warn "removing $OLD, where a build leaves the tree it replaced"
+  fi
+
   # current.old must be gone, not merely attempted: mv a b where b is an
   # existing directory moves a *into* b, so a failed rm -rf that went unnoticed
   # would yield a stale current.old/current and a build that reported success.
@@ -5107,6 +5278,11 @@ cmd_build() {
 
   # The tree the walk above has just read, where there was nothing to keep it
   # for.  A divergence keeps it instead, and says so in the lines above.
+  #
+  # Silent, and deliberately: what goes here is the tree this same run replaced,
+  # for which the run has just composed the replacement, and a line about it
+  # would be a line on every build that ever replaced anything - which is the
+  # everyday-noise problem the announcement above is gated to avoid.
   if [ "$n" -eq 0 ] && [ "$OLDER_COUNT" -eq 0 ]; then
     rm -rf "$OLD" || warn "could not remove $OLD"
   fi
@@ -5613,7 +5789,7 @@ cmd_apply() {
 # before it found, and only the finding count decides the exit status.
 cmd_doctor() {
   local tool i n name path root dir entry leaf known lines layers
-  local pending removed covers
+  local pending removed covers kept
 
   FINDINGS=0
   NOTES=0
@@ -6057,44 +6233,68 @@ cmd_doctor() {
       note "$OLD is at the path a build moves $CUR aside to" \
         'shale clears that path before it swaps' \
         "$removed"
-    elif [ -d "$CUR" ] && [ ! -L "$CUR" ]; then
-      # Only where the build that reaps it is not going to run.  Either
-      # direction of the comparison keeps this tree, and an edited layer is one
-      # of them - it leaves every path that layer provides newer than the copy
-      # in the tree - so the everyday loop keeps one on every rebuild, and a
-      # line about it on every run is a line nobody reads.  Neither direction is
-      # named, for the reason the build names neither: what is in the tree is
-      # not doctor's to say, and a cause guessed at sends a reader looking for
-      # the wrong file.  What is left is the one thing the build that kept it
-      # could not know, which is that nothing is coming to clear it.
-      #
-      # What the path is for, never what is in it: nothing here has looked, and
-      # a build that kept it because one file differed leaves a whole tree, while
-      # an empty one told that it holds the last copy of something is a lie in
-      # the direction that costs a reader time.
-      if [ "$BUILD_BLOCKED" -gt 0 ]; then
-        note "$OLD is where a build leaves the tree it replaced" \
-          'the last build kept it because the copies it replaced were not the ones the layers now provide' \
-          "$removed" \
-          'copy anything in it you want to keep into a layer first'
-      fi
     else
-      # The shape a kill between the two renames leaves, and the one a hand that
-      # removed $CUR leaves too.  Only what is on disk is stated: the composed
-      # tree still standing at $NEW is what distinguishes the interrupted build
-      # from the removal, and without it no cause is named.  $CUR is spoken for
-      # only where there is nothing at it at all - every other shape it can be
-      # in is a finding above, in the words build refuses it with.
-      lines=("$OLD is where a build leaves the tree it replaced")
-      { [ -e "$CUR" ] || [ -L "$CUR" ]; } ||
-        lines[${#lines[@]}]="there is nothing at $CUR"
-      if [ -e "$NEW" ] || [ -L "$NEW" ]; then
-        lines[${#lines[@]}]="a build was interrupted between moving it there and moving the tree it had composed into place, which is still at $NEW"
+      # One note for every shape a real directory here can be, because nothing
+      # on disk tells them apart: a divergence keeps this tree deliberately and
+      # a kill after the swap leaves the same directory behind, and doctor
+      # cannot say which build it is looking at the leavings of.  So no cause is
+      # named - a cause guessed at sends a reader looking for the wrong file -
+      # and every line below is true of both.
+      #
+      # What the path is for, never what is in it: the walk below asks one
+      # question and keeps no answer, and a whole tree told that it holds the
+      # last copy of something is a lie in the direction that costs a reader
+      # time.
+      #
+      # $CUR is spoken for only where there is nothing at it at all - every
+      # other shape it can be in is a finding above, in the words build refuses
+      # it with - and the composed tree still standing at $NEW is the only thing
+      # that separates a build killed between the two renames from a hand that
+      # removed $CUR.
+      #
+      # Printed on the everyday shape only where the tree holds something the
+      # layers do not account for.  A rebuild after an edit keeps one of these
+      # every time, so a note on the name being there is a note after every
+      # edit, which is what #133 took out; and a note on nothing at all is what
+      # let an apply reap a hand-edited file seconds after 'no problems found'.
+      # holds_unaccounted is the question that separates them, and it is asked
+      # only in that shape: a kill leaves a tree $HOME is linked against, an
+      # empty one included, and no build is between the reader and it.  Nor
+      # where a finding has stopped the build that would clear this, which the
+      # last line of the note is about and nothing in the tree can answer.
+      #
+      # A pending clone takes the 'no layer provides it' half of the question
+      # away rather than the whole of it: every path the layer being fetched
+      # provides looks dropped until it arrives, and a walk that counted those
+      # would name this tree on every run between the config and the clone.
+      # What survives the wait is the age comparison, which is about the layers
+      # that are here.
+      kept=1
+      if [ -d "$CUR" ] && [ ! -L "$CUR" ] &&
+        [ ! -e "$NEW" ] && [ ! -L "$NEW" ] &&
+        [ "$BUILD_BLOCKED" -eq 0 ]; then
+        kept=0
+        ! holds_unaccounted "$OLD" '' 1 "$((1 - pending))" || kept=1
       fi
-      lines[${#lines[@]}]='it may hold the only copy of anything that was moved into the built tree rather than composed from a layer'
-      lines[${#lines[@]}]=$removed
-      lines[${#lines[@]}]='copy anything in it you want to keep into a layer first'
-      note ${lines[@]+"${lines[@]}"}
+      if [ "$kept" -eq 1 ]; then
+        lines=("$OLD is where a build leaves the tree it replaced")
+        { [ -e "$CUR" ] || [ -L "$CUR" ]; } ||
+          lines[${#lines[@]}]="there is nothing at $CUR"
+        # Only where the swap did not finish, which is what a $CUR that is not a
+        # directory is and what a healthy one rules out: a tree standing there
+        # is a rename that completed, whatever else is beside it, so a scratch
+        # tree left by some earlier killed compose says nothing about how this
+        # current.old got here.  The line above it is the other half of the same
+        # reading - together they are the state, and neither is a guess.
+        if { [ ! -d "$CUR" ] || [ -L "$CUR" ]; } &&
+          { [ -e "$NEW" ] || [ -L "$NEW" ]; }; then
+          lines[${#lines[@]}]="a build was interrupted between moving it there and moving the tree it had composed into place, which is still at $NEW"
+        fi
+        lines[${#lines[@]}]='it may hold the only copy of a file a divergence replaced, of one that was moved into the built tree rather than composed from a layer, or of one at a path no layer provides any more'
+        lines[${#lines[@]}]=$removed
+        lines[${#lines[@]}]='copy anything in it you want to keep into a layer first'
+        note ${lines[@]+"${lines[@]}"}
+      fi
     fi
   fi
 

--- a/tests/run
+++ b/tests/run
@@ -3759,6 +3759,362 @@ test_build_warns_when_the_built_tree_was_edited() {
   assert_missing "$HOME/.dotfiles/current.old/junk"
 }
 
+# The whole recovery, driven by nothing but what shale printed.  Every path the
+# case copies is read back out of build's stderr and doctor's stdout rather than
+# written here, so a message that stops naming a path fails this case instead of
+# a user's afternoon: this is the walk #168 came out of, where the only line
+# that ever named the file was the first one, and the two commands a reader runs
+# next closed the window without a word.
+#
+# Two files are edited and one is copied out, which is what makes the last build
+# still worth a line: the tree it removes holds the one that was not, and the
+# announcement is about a tree holding something the layers cannot produce
+# again.  It is also the honest end of the walk - the file nobody copied out is
+# gone, and the messages are what decided which.
+test_build_a_diverged_file_is_recovered_by_following_the_messages() {
+  local line kept layer tree named
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .vimrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  # Dated, so that the edits below are newer than the built copies by more than
+  # a filesystem's timestamp resolution, whatever that resolution is.
+  touch -t 200001010000 "$sandbox_dir/.zshrc" "$sandbox_dir/.vimrc" ||
+    fail 'could not date the layer files'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  # A build with nothing at current.old says nothing new: the line below is
+  # about a tree that was already there.
+  assert_empty "$shale_err" 'the first apply stderr'
+  # The writes an editor makes through ~/.zshrc and ~/.vimrc, which are links
+  # into the tree.
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  # '>|': the apply above put these files here, and editing them is the point.
+  printf 'HAND EDITED\n' >|"$sandbox_path" || fail 'could not edit the built tree'
+  sandbox_leaf "$sandbox_dir" .vimrc
+  printf 'ALSO EDITED\n' >|"$sandbox_path" || fail 'could not edit the built tree'
+  assert_eq 'HAND EDITED' "$(cat "$HOME/.zshrc")" 'through the link'
+
+  # One: the build that replaces the edits says where it put what it replaced,
+  # once per file.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that keeps the tree'
+  kept=
+  layer=
+  named=
+  while IFS= read -r line; do
+    case "$line" in
+      *'/.zshrc was newer than '*) layer=${line##* was newer than } ;;
+      *'what was there is kept at '*)
+        named="$named${named:+ }${line##*what was there is kept at }"
+        case "$line" in
+          *'/.zshrc until the next build'*)
+            kept=${line#*what was there is kept at }
+            kept=${kept%% until the next build*}
+            ;;
+        esac
+        ;;
+    esac
+  done <<EOF
+$shale_err
+EOF
+  assert_eq "$HOME/.dotfiles/current.old/.zshrc" "$kept" 'the path the build named'
+  assert_eq "$HOME/.dotfiles/personal/base/.zshrc" "$layer" 'the layer the build named'
+  assert_eq 'HAND EDITED' "$(cat "$kept")" 'the kept copy'
+  # Both files, so the one left behind below was offered too.
+  assert_contains "$named" '/.vimrc until the next build' 'the paths the build named'
+
+  # Two: doctor, which is what a reader runs before touching anything, says the
+  # window is still open and names the directory the files above are in.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  tree=
+  while IFS= read -r line; do
+    case "$line" in
+      'shale: '*' is where a build leaves the tree it replaced')
+        tree=${line#shale: }
+        tree=${tree% is where a build leaves the tree it replaced}
+        ;;
+    esac
+  done <<EOF
+$shale_out
+EOF
+  assert_eq "$HOME/.dotfiles/current.old" "$tree" 'the directory doctor named'
+  # The two messages have to agree about where the file is, or following them
+  # both lands nowhere.
+  case "$kept" in
+    "$tree"/*) ;;
+    *) fail "the build named $kept, which is not under the $tree doctor named" ;;
+  esac
+  assert_contains "$shale_out" \
+    'shale:   copy anything in it you want to keep into a layer first' 'stdout'
+
+  # Three: that line, carried out with the two paths above and no others.
+  cp "$kept" "$layer" || fail "could not copy $kept to $layer"
+
+  # Four: the build that closes the window says so before it does it - the tree
+  # going away still holds the .vimrc nobody copied out - and the .zshrc is in a
+  # layer by then rather than in that tree.
+  run_shale build
+  assert_status 0 "$shale_status" 'the reaping build'
+  assert_contains "$shale_err" \
+    "shale: removing $tree, where a build leaves the tree it replaced" \
+    'the reaping build stderr'
+  assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
+  assert_eq 'HAND EDITED' "$(cat "$HOME/.zshrc")" 'through the link'
+  # The one that was not copied out is gone, which is what the messages were
+  # for: 'ALSO EDITED' existed nowhere else.
+  assert_eq 'personal/base/.vimrc' "$(cat "$HOME/.vimrc")" 'the file nobody kept'
+
+  # And the report is clean again: what stands at the name now is this build's
+  # own, holding the copies the recovered file replaced - the layers account for
+  # every one of them, so there is nothing left to say.
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the reap'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report after the reap'
+}
+
+# The announcement is about what was at the name when the build started and
+# about nothing else.  A build that found nothing there says nothing new,
+# whatever it does with the name afterwards - and it does: this same build makes
+# a current.old of its own in the swap and reaps that one without a word, the
+# tree going away then being the one it has just composed a replacement for.
+#
+# Both shapes that are nobody's build, because the two are answered by different
+# halves of the check.  Anything at the name that is not a directory is not a
+# tree shale composed, so nothing walks it and nothing accounts for it; a
+# directory is walked, and a file in it at a path no layer provides is the same
+# answer arrived at the long way.
+test_build_announces_only_a_current_old_it_did_not_make() {
+  local reaped
+  reaped="shale: removing $HOME/.dotfiles/current.old, where a build leaves the tree it replaced"
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the first build'
+  assert_empty "$shale_err" 'the first build stderr'
+  assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
+  sandbox_write "$HOME/.dotfiles" current.old 'left behind by an older build'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps the stray file'
+  assert_eq "$reaped" "$shale_err" 'the stderr of the build that reaps the file'
+  # Nothing kept it: this build's own current.old went in the reap below the
+  # swap, where the tree replaced was the one it composed the replacement for.
+  assert_missing "$HOME/.dotfiles/current.old" 'after the build that reaps the file'
+  sandbox_write "$HOME/.dotfiles/current.old" notes 'the only copy of something'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps the stray tree'
+  assert_eq "$reaped" "$shale_err" 'the stderr of the build that reaps the tree'
+  assert_missing "$HOME/.dotfiles/current.old" 'after the build that reaps the tree'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build after'
+  assert_empty "$shale_err" 'the build after stderr'
+}
+
+# What doctor names, the build that removes it answers for.  In both shapes
+# doctor calls an interrupted build, its note tells the reader to copy anything
+# they want out of this tree first; a build that then took it away without a
+# word would be the asymmetry #168 was about, one state along.  Neither tree
+# here holds anything the layers cannot produce again, which is what makes these
+# two arms about the shape rather than about the contents.
+test_build_announces_the_reap_of_a_tree_an_interrupted_build_left() {
+  local reaped
+  reaped="shale: removing $HOME/.dotfiles/current.old, where a build leaves the tree it replaced"
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale build
+  assert_status 0 "$shale_status" 'the first build'
+  assert_empty "$shale_err" 'the first build stderr'
+  # Shape one: nothing at current, which is what a kill between the two renames
+  # leaves and what a hand that removed current leaves too.
+  sandbox_mkdir "$HOME/.dotfiles"
+  sandbox_leaf "$sandbox_dir" current.old new
+  mv "$HOME/.dotfiles/current" "$sandbox_path" || fail 'could not move the tree aside'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor before the reap'
+  assert_contains "$shale_out" \
+    'shale:   copy anything in it you want to keep into a layer first' 'doctor stdout'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps it'
+  assert_eq "$reaped" "$shale_err" 'the stderr of the build after the removal'
+  assert_missing "$HOME/.dotfiles/current.old" 'after that build'
+  # Shape two: current is a tree again, and the scratch tree a killed compose
+  # left is still beside it.
+  cp -RPp "$HOME/.dotfiles/current" "$HOME/.dotfiles/current.old" ||
+    fail 'could not copy the tree aside'
+  sandbox_write "$HOME/.dotfiles/current.new" .zshrc 'half of a composed tree'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor before the second reap'
+  assert_contains "$shale_out" \
+    'shale:   copy anything in it you want to keep into a layer first' 'doctor stdout'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps both'
+  assert_eq "$reaped" "$shale_err" 'the stderr of the build after the scratch tree'
+  assert_missing "$HOME/.dotfiles/current.new" 'after that build'
+  # And with neither shape in play, the same tree is reaped in silence: what
+  # was different was the state, not what the tree held.
+  cp -RPp "$HOME/.dotfiles/current" "$HOME/.dotfiles/current.old" ||
+    fail 'could not copy the tree aside'
+  run_shale build
+  assert_status 0 "$shale_status" 'the ordinary build'
+  assert_empty "$shale_err" 'the ordinary build stderr'
+}
+
+# A symlink in the kept tree is a leaf, and two symlinks are the one pair with
+# no answer here: there is no portable way to read the age of a link rather than
+# of what it points at, and a layer retargeting its own link is an everyday
+# change.  Every other pairing is a difference in kind, and a difference in kind
+# is not two versions of one file - what the next build puts there is not a copy
+# of what is going away, whatever the two timestamps say.
+test_build_a_kept_symlink_counts_unless_the_layer_ships_one_too() {
+  local reaped
+  reaped="shale: removing $HOME/.dotfiles/current.old, where a build leaves the tree it replaced"
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  ln -s .zshrc "$sandbox_dir/.zprofile" || fail 'could not make the layer link'
+  run_shale build
+  assert_status 0 "$shale_status" 'the first build'
+  assert_empty "$shale_err" 'the first build stderr'
+  # A link where the layer ships a link: nothing to compare, and nothing to say.
+  sandbox_mkdir "$HOME/.dotfiles/current.old"
+  sandbox_leaf "$sandbox_dir" .zprofile new
+  ln -s elsewhere "$sandbox_path" || fail 'could not make the kept link'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps the retargeted link'
+  assert_empty "$shale_err" 'the stderr of the build that reaps the link'
+  # A link where the layer ships a file, which is the shape a hand-made link in
+  # the built tree leaves: where it pointed is recorded nowhere else.
+  sandbox_mkdir "$HOME/.dotfiles/current.old"
+  sandbox_leaf "$sandbox_dir" .zshrc new
+  ln -s elsewhere "$sandbox_path" || fail 'could not make the kept link'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps the link over a file'
+  assert_eq "$reaped" "$shale_err" \
+    'the stderr of the build that reaps the link over a file'
+  # And a link at a path no layer provides at all.
+  sandbox_mkdir "$HOME/.dotfiles/current.old"
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s elsewhere "$sandbox_path" || fail 'could not make the orphaned link'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that reaps the orphaned link'
+  assert_eq "$reaped" "$shale_err" 'the stderr of the build that reaps the orphan'
+}
+
+# The data-loss shape one kind along from the one #168 was reported for, and why
+# kind is asked before age: the edit is kept, the layer then turns that path into
+# a directory of its own - a .zshrc becoming a .zshrc/ of fragments is the
+# ordinary way that happens - and there is no age comparison left to reach.  Read
+# as accounted for, the kept copy went in silence, with 'no problems found' in
+# between.
+test_doctor_and_build_name_a_kept_file_the_layer_turned_into_a_directory() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  # Dated, so that the edit below is newer than the built copy by more than a
+  # filesystem's timestamp resolution, whatever that resolution is.
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  # '>|': the apply above put this file here, and editing it is the point.
+  printf 'HAND EDITED\n' >|"$sandbox_path" || fail 'could not edit the built tree'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that keeps the tree'
+  assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
+  # The refactor, which is what takes the comparison away: the path the kept copy
+  # is at is a directory in the layer now.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  mklayer personal/base .zshrc/00-path
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  run_shale build
+  assert_status 0 "$shale_status" 'the reaping build'
+  assert_contains "$shale_err" \
+    "shale: removing $HOME/.dotfiles/current.old, where a build leaves the tree it replaced" \
+    'the reaping build stderr'
+  assert_eq 'personal/base/.zshrc/00-path' \
+    "$(cat "$HOME/.dotfiles/current/.zshrc/00-path")" 'the rebuilt tree'
+}
+
+# The same, the other way about: the kept tree holds a file and the layer ships a
+# symlink at that path now.  What lands is a link, and the file it replaces is
+# the last copy of its own contents.
+test_build_names_a_kept_file_the_layer_turned_into_a_symlink() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .zprofile
+  run_shale build
+  assert_status 0 "$shale_status" 'the first build'
+  assert_empty "$shale_err" 'the first build stderr'
+  # Every other path in the kept tree is the built tree's own copy at the built
+  # tree's own age, so the one change below is the only thing being measured.
+  sandbox_write "$HOME/.dotfiles/current.old" .zprofile 'the only copy'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zprofile
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  ln -s .zshrc "$sandbox_path" || fail 'could not make the layer link'
+  run_shale build
+  assert_status 0 "$shale_status" 'the reaping build'
+  assert_eq \
+    "shale: removing $HOME/.dotfiles/current.old, where a build leaves the tree it replaced" \
+    "$shale_err" 'the reaping build stderr'
+}
+
+# And the kind question asked of a directory, which is the one a per-file walk
+# cannot reach.  A build composes a layer's symlink as a leaf, so a layer that
+# provides this path as a link replaces the whole kept subtree rather than
+# merging into it - and where what the link points at happens to hold the same
+# names, every file below reads as though the layers still had all of it.  The
+# decoy is dated to the built copy's own age on purpose: if this case ever
+# passes on the timestamps it has stopped measuring the kind.
+test_doctor_and_build_name_a_kept_directory_the_layer_turned_into_a_symlink() {
+  conf 'base personal/base'
+  mklayer personal/base .config/foo
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  touch -t 200001010000 "$sandbox_dir/foo" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the first build'
+  assert_empty "$shale_err" 'the first build stderr'
+  # The built tree copied aside, and the only copy of something put inside the
+  # directory that is about to stop being one.
+  cp -RPp "$HOME/.dotfiles/current" "$HOME/.dotfiles/current.old" ||
+    fail 'could not copy the tree aside'
+  sandbox_write "$HOME/.dotfiles/current.old/.config" foo 'the only copy'
+  touch -t 200001010000 "$sandbox_path" || fail 'could not date the kept copy'
+  # What the layer link points at, holding a foo of its own at the same age as
+  # the copy in the built tree, so no age comparison anywhere has anything to
+  # say and every child of the kept directory resolves through the link.
+  mklayer personal/base elsewhere/foo
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/elsewhere"
+  touch -t 200001010000 "$sandbox_dir/foo" || fail 'could not date the decoy'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .config
+  rm -rf "$sandbox_path" || fail 'could not remove the layer directory'
+  ln -s elsewhere "$sandbox_path" || fail 'could not make the layer link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  run_shale build
+  assert_status 0 "$shale_status" 'the reaping build'
+  assert_contains "$shale_err" \
+    "shale: removing $HOME/.dotfiles/current.old, where a build leaves the tree it replaced" \
+    'the reaping build stderr'
+  # What the build put there, which is the link and not a directory: the kept
+  # subtree was replaced whole, exactly as the note said it would be.
+  assert_symlink_to "$HOME/.dotfiles/current/.config" \
+    "$HOME/.dotfiles/current/elsewhere"
+}
+
 # The same state, reached with nothing edited anywhere.  Removing an override is
 # an everyday act, and the copy that wins the path in its place can be older than
 # the built copy it replaces - two clone roots pulled minutes apart is enough.
@@ -3772,6 +4128,10 @@ test_build_warns_when_the_built_tree_was_edited() {
 test_build_does_not_blame_an_edit_when_the_winning_layer_changes() {
   local older newer message
   message='shale:   either something wrote or moved a file into the built tree, or a different layer now provides this path and its copy is older'
+  # Every build below but the first reaps the tree the build before it kept, and
+  # none of them says so: what is in each of those trees is a layer's own copy
+  # of the one path, at the age that layer's file still has, so there is nothing
+  # in one that the layers do not account for.
   conf 'personal personal/base' 'work work/base'
   mklayer personal/base .zshrc
   mklayer work/base .zshrc
@@ -3924,6 +4284,10 @@ test_build_keeps_every_older_file_and_forgets_them_next_build() {
   assert_eq 'local/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the rebuilt file'
   run_shale build
   assert_status 0 "$shale_status"
+  # Silent, and the honest limit of the announcement: the files going away here
+  # are the ones moved into the tree, and they are *older* than the layer copies
+  # that replaced them - which is the shape an ordinary rebuild leaves too, and
+  # is why doctor names them in the window before the build rather than after.
   assert_empty "$shale_err" 'the next build stderr'
   assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
 }
@@ -11287,11 +11651,14 @@ test_doctor_says_when_there_is_no_built_tree_to_check_links_against() {
 
 # ------------------------------------------------- doctor's leftover-tree cases
 #
-# The two names a build works under, both of which only a build that did not
-# finish leaves behind - and current.old also every build that replaced a file
-# not matching its layer copy.  Notes, not findings: neither stops a build, and
-# the next build removes both, which is also why nothing else in the report
-# mentions them - the stray scan skips both names because shale owns them.
+# The two names a build works under.  current.new is left only by a build that
+# did not finish; current.old also by every build that replaced a file not
+# matching its layer copy, which is one of the everyday ones.  Notes, not
+# findings: neither stops a build, and the next build removes both - and that
+# removal is exactly why current.old is worth a line, since the build that kept
+# it called what is in it recoverable 'until the next build' and doctor is the
+# command a reader runs in between.  Nothing else in the report mentions either
+# name: the stray scan skips both, shale owning them.
 
 test_doctor_notes_a_leftover_scratch_tree() {
   conf 'base personal/base'
@@ -11325,19 +11692,21 @@ test_doctor_notes_a_leftover_scratch_tree() {
   assert_eq 'shale: no problems found' "$shale_out" 'the whole report after the build'
 }
 
-# The tree a build keeps deliberately, and the state that made 'no problems
-# found' unreachable: editing a layer is what keeps it, so a report that named
-# it said something on every run for two builds after every edit.  The build
-# that kept it is what names the file it kept - here, the hand-edited copy - and
-# the next build reaps the tree, so doctor has nothing of its own to add.
-test_doctor_says_nothing_about_the_tree_the_last_build_kept() {
+# The tree a build keeps deliberately, which is the window the build that kept
+# it called recoverable 'until the next build'.  Doctor is the command a reader
+# runs in that window - and answering 'no problems found' there is what let the
+# next apply take the hand-edited copy with nothing having said it was going.
+#
+# The note goes when the tree does, which is what makes it a note about what is
+# on disk rather than a line about the setup.
+test_doctor_names_the_tree_a_divergence_kept_until_a_build_reaps_it() {
   conf 'base personal/base' 'local local'
   mklayer personal/base .zshrc
   mklayer local .zshrc
   sandbox_mkdir "$HOME/.dotfiles/local"
   touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
-  # Applied, so that a clean report here is the bare verdict: an unbuilt tree is
-  # a note of its own.
+  # Applied, so that the report below is this note and nothing else: an unbuilt
+  # tree is a note of its own.
   run_shale apply
   assert_status 0 "$shale_status" 'the first apply'
   assert_missing "$HOME/.dotfiles/current.old" 'after a clean build'
@@ -11348,21 +11717,55 @@ test_doctor_says_nothing_about_the_tree_the_last_build_kept() {
   run_shale build
   assert_status 0 "$shale_status" 'the build that keeps the tree'
   assert_eq 'HAND EDITED' "$(cat "$HOME/.dotfiles/current.old/.zshrc")" 'the kept copy'
-  # The signal that survives this silence, and the one that names the path: the
-  # build itself, at the moment it keeps the tree.
+  # The message the note has to still be true of: the build names the file, and
+  # names the deadline this note is about.
   assert_contains "$shale_err" \
     "shale:   the layer copy wins; what was there is kept at $HOME/.dotfiles/current.old/.zshrc until the next build, to copy into a layer if it was your edit" \
     'the build stderr'
   run_shale doctor
   assert_status 0 "$shale_status"
-  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   it may hold the only copy of a file a divergence replaced, of one that was moved into the built tree rather than composed from a layer, or of one at a path no layer provides any more' \
+    'stdout'
+  assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   copy anything in it you want to keep into a layer first' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
   assert_empty "$shale_err" 'stderr'
+  # A note and not a finding, and no cause guessed at: an edited layer leaves
+  # the same tree, and a reader told their build replaced a file that did not
+  # match goes looking for damage that is not there.
+  assert_not_contains "$shale_out" 'did not match the layer copy' 'stdout'
+  assert_not_contains "$shale_out" 'do not match the layer copies' 'stdout'
+  assert_not_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # And silent again once there is nothing to be silent about - after a build
+  # that says what it is taking away, this tree being one nothing else holds a
+  # copy of.
+  run_shale build
+  assert_status 0 "$shale_status" 'the reaping build'
+  assert_eq \
+    "shale: removing $HOME/.dotfiles/current.old, where a build leaves the tree it replaced" \
+    "$shale_err" 'the reaping build stderr'
+  assert_missing "$HOME/.dotfiles/current.old" 'after the reaping build'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the reap'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report after the reap'
+  assert_empty "$shale_err" 'stderr after the reap'
 }
 
-# The everyday loop the report has to stay quiet through: edit one line of one
-# layer file, rebuild, and every path that layer provides is newer than the copy
-# the build replaces, so the build keeps current.old.  Doing what README
-# recommends may not cost a reader their clean report.
+# The everyday loop both of them have to stay quiet through: edit one line of
+# one layer file, rebuild, and every path that layer provides is newer than the
+# copy the build replaces, so the build keeps current.old.  Doing what README
+# recommends may not cost a reader their clean report, and the build that clears
+# it a fortnight of edits later may not start talking either.
+#
+# It is the shape of the tree that buys that silence rather than its name: every
+# copy in it is the layer's own file from the build before, so it is older than
+# the layer copy that replaced it and never newer, and nothing in it is at a
+# path the layers have dropped.  The two cases below this one are the same tree
+# with something in it that is not, and they are the ones that speak.
 test_doctor_says_nothing_about_the_tree_an_ordinary_rebuild_kept() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
@@ -11382,13 +11785,27 @@ test_doctor_says_nothing_about_the_tree_an_ordinary_rebuild_kept() {
   assert_status 0 "$shale_status"
   assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
   assert_empty "$shale_err" 'stderr'
+  # And the build that reaps it says nothing either: what is going away is the
+  # layers' own files, which the layers still have.
+  run_shale build
+  assert_status 0 "$shale_status" 'the reaping build'
+  assert_empty "$shale_err" 'the reaping build stderr'
+  assert_missing "$HOME/.dotfiles/current.old" 'after the reaping build'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the reap'
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report after the reap'
 }
 
-# And where that silence would be wrong: the tree is reaped by the next build,
-# so it is worth a line exactly where there is not going to be one.  The note
-# says what happened rather than reporting a fault - an edited layer is the
-# ordinary cause, and a reader told their build 'replaced a file that did not
-# match' goes looking for damage that is not there.
+# The one line of the note that is not the same in every state: no build is
+# going to run, so the deadline the rest of it names is not coming, and a reader
+# told 'the next build removes it' would be told to fix the findings above by a
+# report that had just promised the fix reaps their file.  The tree here is
+# empty, so it holds nothing unaccounted for and an ordinary report would say
+# nothing about it: what is not coming is the build, and no walk can see that.
+# The rest is the same words as after any other build, because nothing on disk
+# says what put the tree there - an edited layer is the ordinary cause, and a
+# reader told their build 'replaced a file that did not match' goes looking for
+# damage that is not there.
 test_doctor_names_the_kept_tree_no_build_will_clear() {
   local line first
   conf 'base personal/base'
@@ -11403,14 +11820,17 @@ test_doctor_names_the_kept_tree_no_build_will_clear() {
   assert_contains "$shale_out" \
     "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
   assert_contains "$shale_out" \
-    'shale:   the last build kept it because the copies it replaced were not the ones the layers now provide' \
+    'shale:   it may hold the only copy of a file a divergence replaced, of one that was moved into the built tree rather than composed from a layer, or of one at a path no layer provides any more' \
     'stdout'
-  # Neither direction of the comparison is named: an edited layer keeps this
-  # tree and so does a file moved into the built tree, and the line under this
-  # one is only worth reading if the cause was the second.
+  # Neither direction of the comparison is named, and neither origin: an edited
+  # layer keeps this tree, a file moved into the built tree keeps it, and a kill
+  # after the swap leaves the same directory behind.
   assert_not_contains "$shale_out" 'which is what editing a layer does' 'stdout'
+  assert_not_contains "$shale_out" 'the last build kept it because' 'stdout'
   assert_contains "$shale_out" \
     'shale:   no build will run until the problems above are fixed, so it stays where it is' 'stdout'
+  # And not both: the deadline and its absence are the same line of the note.
+  assert_not_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
   assert_contains "$shale_out" \
     'shale:   copy anything in it you want to keep into a layer first' 'stdout'
   assert_not_contains "$shale_out" 'did not match the layer copy' 'stdout'
@@ -11439,6 +11859,11 @@ EOF
 # The composed tree still standing at current.new is what says a build was
 # interrupted rather than that a hand removed current, and it is the only thing
 # that does; the case below is the same shape without it.
+#
+# The tree here is a current moved aside whole, so every copy in it is the
+# layers' own at the layers' own age and nothing in it is unaccounted for.  That
+# is deliberate: this shape is named whatever it holds, because $HOME is linked
+# against it and no build stands between the reader and the loss.
 test_doctor_names_the_tree_left_at_current_old_when_current_is_gone() {
   local line seen
   conf 'base personal/base'
@@ -11460,7 +11885,7 @@ test_doctor_names_the_tree_left_at_current_old_when_current_is_gone() {
     "shale:   a build was interrupted between moving it there and moving the tree it had composed into place, which is still at $HOME/.dotfiles/current.new" \
     'stdout'
   assert_contains "$shale_out" \
-    'shale:   it may hold the only copy of anything that was moved into the built tree rather than composed from a layer' \
+    'shale:   it may hold the only copy of a file a divergence replaced, of one that was moved into the built tree rather than composed from a layer, or of one at a path no layer provides any more' \
     'stdout'
   assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
   assert_contains "$shale_out" \
@@ -11513,17 +11938,101 @@ test_doctor_names_no_interrupted_build_where_there_cannot_have_been_one() {
     "shale:   there is nothing at $HOME/.dotfiles/current" 'stdout'
   assert_not_contains "$shale_out" 'a build was interrupted' 'stdout'
   assert_contains "$shale_out" \
-    'shale:   it may hold the only copy of anything that was moved into the built tree rather than composed from a layer' \
+    'shale:   it may hold the only copy of a file a divergence replaced, of one that was moved into the built tree rather than composed from a layer, or of one at a path no layer provides any more' \
     'stdout'
   assert_contains "$shale_out" 'shale:   the next build removes it' 'stdout'
   assert_contains "$shale_out" 'shale: no problems found, but read the 2 notes above' 'stdout'
 }
 
-# Nothing has looked inside either tree, so nothing may say what is in one.  An
-# empty current.old is the state a build that composed no file at all leaves,
-# and 'copy anything in it you want to keep' is the whole of what a report that
-# did not walk it can offer.  The blocked build is what makes the note print at
-# all: with one to reap the tree there is nothing to say about it.
+# And the line that may not be reached from a healthy current: a tree standing
+# there is a rename that finished, whatever else is beside it, so a current.new
+# left by some earlier killed compose says nothing about how this current.old
+# got here.  The scratch tree is named by its own note above; claiming a build
+# was interrupted between the two renames would be doctor reading one state off
+# another.
+test_doctor_names_no_interrupted_build_beside_a_tree_that_is_there() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.dotfiles/current"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  # '>|': the apply above put this file here, and editing it is what keeps the
+  # tree below - the note has to be printed for this case to measure its lines.
+  printf 'HAND EDITED\n' >|"$sandbox_path" || fail 'could not edit the built tree'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build that keeps the tree'
+  assert_exists "$HOME/.dotfiles/current/.zshrc" 'the built tree'
+  sandbox_write "$HOME/.dotfiles/current.new" .zshrc 'half of a composed tree'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_not_contains "$shale_out" 'a build was interrupted' 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale:   there is nothing at $HOME/.dotfiles/current" 'stdout'
+  # The scratch tree is still reported, in the words that are true of it.
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.new is left over from a build that did not finish" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the 2 notes above' 'stdout'
+}
+
+# The other half of 'no layer provides it', which is only as good as the layers
+# being all here.  While a clone is pending every path the layer being fetched
+# provides looks dropped, and the pending clone is a note rather than a finding -
+# so nothing stops doctor reaching this walk, and a walk that counted them would
+# name this tree on every run between writing the config line and fetching it.
+# What survives the wait is the age comparison, which is about the layers that
+# are here.
+test_doctor_says_nothing_about_a_dropped_path_while_a_clone_is_pending() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  # Dated, so that the touch below is newer than the kept copy by more than a
+  # filesystem's timestamp resolution, whatever that resolution is.
+  touch -t 200001010000 "$sandbox_dir/.zshrc" || fail 'could not date the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  # The built tree copied aside, so every path in it is accounted for, and one
+  # path added that no layer provides.
+  cp -RPp "$HOME/.dotfiles/current" "$HOME/.dotfiles/current.old" ||
+    fail 'could not copy the tree aside'
+  sandbox_write "$HOME/.dotfiles/current.old" .vimrc 'the only copy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor with every layer here'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  # The same tree, with a layer still to be fetched.
+  conf 'base personal/base' 'work work git@example.invalid:me/work.git'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor with a clone pending'
+  assert_contains "$shale_out" \
+    "shale: layer 'work' has no directory at $HOME/.dotfiles/work yet" 'stdout'
+  assert_not_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the note above' 'stdout'
+  # And what the wait does not take away: a copy newer than the layer file that
+  # replaced it is about a layer that is here.
+  sandbox_mkdir "$HOME/.dotfiles/current.old"
+  sandbox_leaf "$sandbox_dir" .zshrc
+  touch "$sandbox_path" || fail 'could not date the kept copy'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the kept copy was touched'
+  assert_contains "$shale_out" \
+    "shale: $HOME/.dotfiles/current.old is where a build leaves the tree it replaced" 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found, but read the 2 notes above' 'stdout'
+}
+
+# The walk answers one question and keeps no answer, so the note may not say what
+# is in the tree.  An empty current.old is the state a build that composed no
+# file at all leaves, and 'copy anything in it you want to keep' is the whole of
+# what a report holding one bit about it can offer - 'may hold' is the strongest
+# thing the note says.  The blocked build is what makes the note print at all
+# here: an empty tree holds nothing the layers cannot produce again, so with a
+# build coming to reap it there is nothing to say about it.
 test_doctor_claims_no_contents_for_a_tree_it_has_not_walked() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
@@ -15894,6 +16403,9 @@ test_meta_noclobber_overrides_are_allow_listed() {
     # shale's own build put this file there, and editing it is what the case is
     # about.
     'HAND EDITED'
+    # The second of the two files the recovery walkthrough edits, which is the
+    # one nobody copies back out.
+    'ALSO EDITED'
     # The same, for the file an adopt would have put there in its place.
     'FIVE YEARS OF ZSH'
     # And for the several of them one build has to keep at once.


### PR DESCRIPTION
Closes #168, at the criterion amended in its final comment.

The usability trial's one data loss: divergence keeps your edit in `current.old`, doctor never mentioned it, and the README-recommended apply reaped it silently. Now doctor names `current.old` — and the removing build announces it on stderr — exactly when the directory holds something the layers cannot produce again: an entry newer than its layer counterpart, at a path no layer provides, or of a different kind than the layers now hold (file→directory, file→symlink, directory→symlink, each a measured silent-loss shape). Interrupted-build shapes are named unconditionally. The everyday edit-then-rebuild loop is byte-identical to before, verified by stream-level comparison against main across seven flows — #133's quiet doctor and #75's quiet build stand. Two limits recorded honestly in the commit: the adopted-older direction (content comparison, out of scope) and bash 3.2's whole-second `-nt` (inherited).

Gates run: two full review+verification rounds plus a final combined gate — the evidence test's truth table traced per entry class, 110+ flake-hunt runs under bash 3.2.57, the recovery walkthrough driven only by message output, and the trial's exact sequence re-run. 540 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)