### PR TITLE
Point the bootstrap at .shale-modes before the first apply ships an .ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,34 @@ mkdir -p ~/.dotfiles && chmod 0700 ~/.dotfiles
 cp examples/wsl-work.conf ~/.dotfiles/shale.conf
 $EDITOR ~/.dotfiles/shale.conf     # list this machine's layers
 mkdir -p ~/.dotfiles/local         # a layer with no url is yours to create
+```
+
+Declare any mode that matters before that first apply. Git records no permission bits for a
+directory and only the executable bit for a file, so an `.ssh`, a credentials file or anything else
+private is composed and linked at the cloning machine's umask — typically `755` and `644` — with
+every command exiting 0, `doctor` included: a mode nobody declared is not a fault shale can see.
+Declarations go in a `.shale-modes` at the top of the clone root, which for a url-less layer is the
+layer directory itself, and which a layer from a repository carries committed with it:
+
+```
+# ~/.dotfiles/local/.shale-modes
+700  .ssh
+600  .ssh/config
+```
+
+```sh
 shale apply                        # clones what is missing, builds, links
 ```
 
+[Declaring the mode of a path](#declaring-the-mode-of-a-path) is the whole of the format.
+
 Shale clones a layer that has a url and creates no layer that has not, so every url-less layer has
 to exist before the first apply — `local`, in both shipped examples. `examples/minimal.conf` is the
-smaller starting point: one repository layer and that same local directory.
+smaller starting point: one repository layer and that same local directory. A repository layer's
+clone root does not exist until that apply creates it, so a mode not already committed with the
+layer cannot be declared ahead of it: apply once, put the `.shale-modes` in the clone now on disk,
+commit it, and apply again. The second apply narrows what you declared and widens nothing, so the
+first apply's open mode does not stay open.
 
 Dotfiles already in `$HOME`? Whether they are ordinary files or stow packages you stow by hand, they
 have to stop being files at those paths before the first apply, and anything of yours worth keeping

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -13,6 +13,12 @@ Fragment directories, numeric prefixes and shared helper files are conventions f
 expressed in the config formats themselves and implemented by the files you write. Shale has no
 knowledge of any of them and treats every one as an ordinary file.
 
+The one thing a layer cannot carry in the tree itself is a mode. Git records no permission bits for
+a directory and only the executable bit for a file, so an `.ssh`, a credentials file or anything
+else private arrives on the next machine at that clone's umask — typically `755` and `644` — and no
+command says so. Declare those modes in a `.shale-modes` at the top of the clone root before the
+layer's first apply; [Permissions](#permissions) below is the whole of it.
+
 ## Where a layer lives
 
 Give a layer a subdirectory of its repository rather than the repository root:


### PR DESCRIPTION
Closes #169.

Docs-only: the README bootstrap now says — before the first apply — that git records only the executable bit, so a mode that matters must be declared in `.shale-modes` first, with the example and, for repository layers whose clone root doesn't exist yet, the apply-declare-commit-apply repair sequence (verified: the second apply narrows and widens nothing). docs/layers.md gains the matching pointer in its opening. The design question of doctor guessing at mode-sensitive names is declined with the reasoning in the commit body: a name heuristic is interpretation, unbounded, and fires on correctly-configured machines forever.

Gate run: every factual claim executed in sandboxes (four cases plus the repair round-trip); suite unchanged at 540 passed, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)