### PR TITLE
Smooth the first hour's papercuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ exercised rather than assumed. WSL is Linux for shale's purposes. No other platf
 
 ## Install
 
-Copy the script to any directory on your `PATH`:
+Clone this repository, and copy the script from the clone to any directory on your `PATH`. These
+commands and the bootstrap below run from the clone's root, which is where `shale` and the example
+configs are:
 
 ```sh
 mkdir -p ~/.local/bin
@@ -49,9 +51,9 @@ command: shale is one file, and the copy you have is whatever the repository hel
 
 ```sh
 mkdir -p ~/.dotfiles && chmod 0700 ~/.dotfiles
-cp examples/wsl-work.conf ~/.dotfiles/shale.conf
-$EDITOR ~/.dotfiles/shale.conf     # list this machine's layers
-mkdir -p ~/.dotfiles/local         # a layer with no url is yours to create
+cp examples/wsl-work.conf ~/.dotfiles/shale.conf   # examples/ is in this repository
+$EDITOR ~/.dotfiles/shale.conf                     # list this machine's layers
+mkdir -p ~/.dotfiles/local                         # a layer with no url is yours to create
 ```
 
 Declare any mode that matters before that first apply. Git records no permission bits for a

--- a/shale
+++ b/shale
@@ -396,10 +396,15 @@ usage() {
     'A .shale-modes file there declares modes, one "700  .ssh" per line.'
 }
 
+# Every wrong invocation: an unknown command, an unknown option, and the wrong
+# number of arguments to one of the four.  What is wrong, then where the whole
+# text is - rather than the text itself, which was twenty lines of stderr
+# answering a mistyped word, with the one line naming it scrolled off the top of
+# a small terminal.  The usage text is still exactly one command away, and both
+# ways of asking for it deliberately - 'shale' bare and 'shale help' - print it
+# on stdout and exit 0.
 usage_error() {
-  emit "$@"
-  printf '\n' >&2
-  usage >&2
+  emit "$@" "run 'shale help' for usage"
   exit 2
 }
 
@@ -2109,9 +2114,12 @@ clone_missing_roots() {
     # The leading dot keeps this name out of the layer namespace: a configured
     # path component must start with a letter, digit or '_'.  git names it in
     # its own 'Cloning into' line, which is a path nobody wrote and which is
-    # gone by the time it is looked for; that stays as it is.  Redirecting git's
-    # stderr to hide it would take the network error, the bad host key and the
-    # wrong url with it, which is every reason a clone fails.
+    # gone by the time it is looked for; that line stays exactly as git writes
+    # it.  Redirecting git's stderr to hide it would take the network error, the
+    # bad host key and the wrong url with it, which is every reason a clone
+    # fails, and reading or rewriting that stream is shale interpreting another
+    # program's output.  So the path is named here instead, ahead of git saying
+    # it - which is the whole of what makes git's line legible.
     tmp=$DOTFILES/.$root.cloning
     # Named before anything touches it, reaping included: a signal delivered
     # partway through the rm would otherwise run cleanup with CLONING still
@@ -2119,7 +2127,8 @@ clone_missing_roots() {
     CLONING=$tmp
     rm -rf "$tmp" || die "could not remove $tmp"
     { [ ! -e "$tmp" ] && [ ! -L "$tmp" ]; } || die "$tmp still exists"
-    report "cloning '$root' from $url into $dir"
+    report "cloning '$root' from $url into $dir" \
+      "git clones into $tmp and shale renames it, so git's own output names that path"
     # Into the temporary name and renamed after: an interrupted or failed clone
     # must not leave a half-populated directory that looks like a layer.
     git clone -- "$url" "$tmp" || die "could not clone $url into $dir"

--- a/tests/run
+++ b/tests/run
@@ -1344,8 +1344,8 @@ test_usage_readme_quotes_the_usage_text_verbatim() {
 # The usage text went through cat, so on a machine without one the first command
 # anyone runs printed nothing and exited 0 - the silent success shape, on the one
 # output that is meant to explain the tool.  Nothing in usage runs a tool now,
-# and both paths to it are here: the bare invocation, and the usage a wrong one
-# prints on stderr.
+# and neither does the diagnostic that sends a reader to it: the bare invocation
+# prints the text, and a wrong one prints the two lines pointing at it.
 #
 # run_shale reads shale's output back with cat, under the case's PATH, so this
 # case runs shale itself and reads the captures with PATH restored.
@@ -1383,14 +1383,18 @@ test_usage_prints_without_cat() {
   assert_status 2 "$status" 'the wrong invocation without cat'
   assert_empty "$(cat "$bad_out")" 'the wrong invocation stdout'
   assert_contains "$(cat "$bad_err")" "shale: unknown command 'buld'" 'stderr'
-  assert_contains "$(cat "$bad_err")" 'usage:' 'stderr'
+  assert_contains "$(cat "$bad_err")" "shale:   run 'shale help' for usage" 'stderr'
 }
 
+# Two lines and no more: what was wrong, and where the usage text is.  Asserted
+# whole rather than by fragment, because the thing this pins is the absence of
+# the other twenty lines - a mistyped word used to answer with the entire usage
+# block, which put the one line naming the word off the top of a short terminal.
 test_usage_unknown_command_exits_2() {
   run_shale buld
   assert_status 2 "$shale_status"
-  assert_contains "$shale_err" "shale: unknown command 'buld'" 'stderr'
-  assert_contains "$shale_err" 'usage:' 'stderr'
+  assert_eq "shale: unknown command 'buld'
+shale:   run 'shale help' for usage" "$shale_err" 'stderr'
   assert_empty "$shale_out" 'stdout'
 }
 
@@ -1400,7 +1404,7 @@ test_usage_empty_command_exits_2() {
   run_shale ''
   assert_status 2 "$shale_status"
   assert_contains "$shale_err" "shale: unknown command ''" 'stderr'
-  assert_contains "$shale_err" 'usage:' 'stderr'
+  assert_contains "$shale_err" "shale:   run 'shale help' for usage" 'stderr'
   assert_empty "$shale_out" 'stdout'
 }
 
@@ -1409,7 +1413,7 @@ test_usage_unknown_option_exits_2() {
   assert_status 2 "$shale_status"
   assert_contains "$shale_err" 'shale: unknown option -n' 'stderr'
   assert_contains "$shale_err" 'shale has no options' 'stderr'
-  assert_contains "$shale_err" 'usage:' 'stderr'
+  assert_contains "$shale_err" "shale:   run 'shale help' for usage" 'stderr'
   assert_empty "$shale_out" 'stdout'
 }
 
@@ -1417,7 +1421,7 @@ test_usage_extra_argument_exits_2() {
   run_shale build extra
   assert_status 2 "$shale_status"
   assert_contains "$shale_err" 'shale: build takes no arguments' 'stderr'
-  assert_contains "$shale_err" 'usage:' 'stderr'
+  assert_contains "$shale_err" "shale:   run 'shale help' for usage" 'stderr'
   assert_empty "$shale_out" 'stdout'
 }
 
@@ -1425,7 +1429,30 @@ test_usage_which_without_a_path_exits_2() {
   run_shale which
   assert_status 2 "$shale_status"
   assert_contains "$shale_err" 'shale: which takes exactly one PATH' 'stderr'
+  assert_contains "$shale_err" "shale:   run 'shale help' for usage" 'stderr'
   assert_empty "$shale_out" 'stdout'
+}
+
+# The usage text has one home and it is stdout: 'shale' bare and 'shale help'
+# print it and exit 0, and no wrong invocation prints any of it.  Every arm of
+# usage_error is here, because the reason for each is the same one and a reader
+# reaching for the text after any of them types the same command.  The needles
+# are whole lines of the block, so nothing passes by matching a word the
+# diagnostic itself uses.
+test_usage_a_wrong_invocation_does_not_print_the_usage_text() {
+  local invocation
+  for invocation in 'buld' '-n' 'build extra' 'which'; do
+    # Deliberately unquoted: each entry is the whole argument list.
+    # shellcheck disable=SC2086
+    run_shale $invocation
+    assert_status 2 "$shale_status" "'shale $invocation' exit status"
+    assert_not_contains "$shale_err" 'shale - layered dotfiles builder' \
+      "'shale $invocation' stderr"
+    assert_not_contains "$shale_err" 'usage:' "'shale $invocation' stderr"
+    assert_not_contains "$shale_err" '  shale which PATH     show which layer provides PATH' \
+      "'shale $invocation' stderr"
+    assert_empty "$shale_out" "'shale $invocation' stdout"
+  done
 }
 
 # 'shale which -odd-name' must work without a '--' separator, so nothing may
@@ -5789,6 +5816,12 @@ stub_git() {
 # The assertion on stderr is git's own 'Cloning into' line, which pins both that
 # the clone runs into the temporary name and that nothing passes --quiet; the
 # path is asserted rather than the sentence, which git translates.
+#
+# Shale's own line names that same path first, which is the whole of what makes
+# git's readable: the line git writes carries a '.personal.cloning' nobody
+# configured, on a stream shale neither reads nor rewrites, and until this ran
+# ahead of it the first thing a bootstrap printed was a path found in no config
+# and gone by the time anyone looked for it.
 test_clone_a_missing_root_is_cloned_and_composed() {
   mkrepo personal .zshrc .config/git/config
   conf "base personal $repo_url"
@@ -5796,6 +5829,9 @@ test_clone_a_missing_root_is_cloned_and_composed() {
   assert_status 0 "$shale_status"
   assert_contains "$shale_out" \
     "shale: cloning 'personal' from $repo_url into $HOME/.dotfiles/personal" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   git clones into $HOME/.dotfiles/.personal.cloning and shale renames it, so git's own output names that path" \
+    'stdout'
   assert_contains "$shale_err" "$HOME/.dotfiles/.personal.cloning" 'stderr'
   assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/personal/.zshrc")" 'the clone'
   assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
@@ -5822,6 +5858,7 @@ test_clone_one_clone_serves_every_layer_under_its_root() {
   clones=$(grep -c '^clone ' "$git_log")
   assert_eq 1 "$clones" 'git clone invocations'
   assert_eq "shale: cloning 'personal' from $repo_url into $HOME/.dotfiles/personal
+shale:   git clones into $HOME/.dotfiles/.personal.cloning and shale renames it, so git's own output names that path
 shale: composed layer 'base' from $HOME/.dotfiles/personal/base
 shale: composed layer 'wsl' from $HOME/.dotfiles/personal/wsl
 shale: composed layer 'work' from $HOME/.dotfiles/personal/work" "$shale_out" 'stdout'
@@ -5839,7 +5876,9 @@ test_clone_every_missing_root_with_a_url_is_cloned() {
   run_shale build
   assert_status 0 "$shale_status"
   assert_eq "shale: cloning 'personal' from $personal_url into $HOME/.dotfiles/personal
+shale:   git clones into $HOME/.dotfiles/.personal.cloning and shale renames it, so git's own output names that path
 shale: cloning 'work' from $repo_url into $HOME/.dotfiles/work
+shale:   git clones into $HOME/.dotfiles/.work.cloning and shale renames it, so git's own output names that path
 shale: composed layer 'base' from $HOME/.dotfiles/personal
 shale: composed layer 'work' from $HOME/.dotfiles/work" "$shale_out" 'stdout'
   assert_eq 'personal/.zshrc' "$(cat "$HOME/.dotfiles/current/.zshrc")" 'the built tree'
@@ -6212,6 +6251,32 @@ test_apply_links_every_file_of_the_built_tree_into_home() {
     "$HOME/.dotfiles/current/.config/git/config"
   assert_eq 'personal/base/.zshrc' "$(cat "$HOME/.zshrc")" 'the linked file'
   assert_eq 'local/.netrc' "$(cat "$HOME/.netrc")" 'the linked file'
+}
+
+# An apply over layers nothing has touched prints the same layer lines as the
+# one before it, and that is the intended output rather than an oversight.  The
+# lines are true of every run: this apply did compose each layer, whatever the
+# result turned out to equal.  Saying nothing instead would mean deciding the
+# tree just composed matches the one it replaced, and nothing decides that
+# without comparing the two trees file by file, contents included - which is the
+# one thing shale never does with a file it copies.  A guess from mtimes is not
+# the same claim: a checkout, a 'cp -p' or an untarred backup restores a file's
+# old timestamp with new bytes under it, and the wrong guess suppresses the only
+# line saying which layers this apply used and where they came from.
+test_apply_repeats_the_layer_lines_on_an_unchanged_rerun() {
+  local first
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .netrc
+  run_shale apply
+  assert_status 0 "$shale_status"
+  first=$shale_out
+  assert_eq "shale: composed layer 'base' from $HOME/.dotfiles/personal/base
+shale: composed layer 'local' from $HOME/.dotfiles/local" "$first" 'the first apply stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the second apply'
+  assert_eq "$first" "$shale_out" 'the second apply stdout'
+  assert_empty "$shale_err" 'the second apply stderr'
 }
 
 # What --no-folding buys, and the only assertion that can tell it took effect:


### PR DESCRIPTION
Closes #171.

Four trial papercuts: the README now says to clone the repository before the bootstrap references `examples/`; every wrong invocation prints its one-line diagnostic plus `run 'shale help' for usage` instead of the 20-line dump (all `usage_error` arms treated consistently, recorded); the clone report explains the `.NAME.cloning` temp path git's output names; and apply's no-op reprint is deliberately KEPT — no sound cheap change-detection exists without the content comparison shale must never do — with the decision pinned by a case so it cannot drift silently.

Gate run: the nine-invocation matrix executed (two stderr lines, empty stdout, exit 2 each; help paths byte-identical to main), the README walked literally from a bare sandbox, the clone claims verified against the code and a real clone. 544 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)