### PR TITLE
Let the devcontainer reach the host's Docker daemon

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,14 @@
 		"dockerfile": "Dockerfile"
 	},
 
+	// The host's Docker Desktop daemon, over its mounted socket, so trials and
+	// version tests can run pristine images from inside this container.  The
+	// daemon is the host's: containers started here outlive this container's
+	// rebuilds and share the host's image cache.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+	},
+
 	// tests/run skips five cases under root, because root ignores the mode bits
 	// they depend on, and the CI gate fails on any skip.  A root container
 	// cannot pass the suite's own acceptance criterion.


### PR DESCRIPTION
One feature line: docker-outside-of-docker, mounting the host daemon's socket so pristine-image trials and stow-version tests can run from inside the container. Takes effect on the next rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)