### PR TITLE
Report a layer's absolutely-spelled symlink before stow refuses the whole apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,18 +385,19 @@ build.
 ## Checking the setup
 
 `shale doctor` checks that every tool shale runs is installed, that the config parses, that every
-configured layer directory is there and that nothing in one is a directory it cannot search or a file
-it cannot open, that no two layers disagree about whether a path is a file or a directory, that
+configured layer directory is there and that nothing in one is a directory it cannot search or a
+file it cannot open, that no two layers disagree about whether a path is a file or a directory, that
+no layer ships a symlink whose target is spelled from the root, which stow will not link, that
 nothing in `$HOME` at a path the layers provide is something no apply put there — a file, a
 directory, or a link of your own, none of which stow will write over — that no layer ships
 `.stow-local-ignore`, which shale writes itself, or shale itself, that `~/.dotfiles/current` is a
 directory rather than a file or a link to one, that a build could create the tree it composes into,
 that nothing in `~/.dotfiles` whose name does not begin with a dot is a stray, that no `current.new`
-has been left beside `current` and no `current.old` holding anything the layers cannot produce again,
-and that no link in `$HOME` points into the built tree at a path it no longer provides. Where a `.stowrc` exists
-it says so, because stow appends its `--ignore` patterns to the ones shale passes and one of them can
-drop a file from an apply without a word. It reads nothing out of that file, and changes nothing
-itself.
+has been left beside `current` and no `current.old` holding anything the layers cannot produce
+again, and that no link in `$HOME` points into the built tree at a path it no longer provides. Where
+a `.stowrc` exists it says so, because stow appends its `--ignore` patterns to the ones shale passes
+and one of them can drop a file from an apply without a word. It reads nothing out of that file, and
+changes nothing itself.
 
 ```
 $ shale doctor
@@ -407,12 +408,9 @@ Doctor reports two kinds of line. A *problem* is a defect in the setup: it count
 and makes doctor exit 1. Everything else is a note about something worth knowing, and neither counts
 nor changes the exit code. Every state doctor can see that stops a build or an apply outright is a
 problem, so `no problems found` is a strong signal that both will run rather than a guarantee that
-they must. What it does not see: an absolute symlink in a layer, which stow refuses at apply time
-and the two stow versions disagree about — so shale asserts nothing about it, and
-[docs/layers.md](docs/layers.md) covers it — nor whether `$HOME` is writable, which fails an apply
-rather than a build, nor whether a leftover `current.old` can be removed, nor an *absolute* link in
-`$HOME` pointing at the built tree's own copy of that same path, which stow refuses and which only
-a hand ever makes.
+they must. What it does not see: whether `$HOME` is writable, which fails an apply rather than a
+build, nor whether a leftover `current.old` can be removed, nor an absolute link in `$HOME` pointing
+at the built tree's own copy of that same path, which stow refuses and which only a hand ever makes.
 
 That verdict is about the checks that ran. The audit of `$HOME` for broken links is the only one that
 looks outside `~/.dotfiles`, and it needs a built tree, `chkstow`, `readlink` and a `$HOME` to walk.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -323,10 +323,15 @@ WARNING! stowing current would cause conflicts:
 All operations aborted.
 ```
 
-`shale doctor` does not report this one, and deliberately: the two stow versions disagree about
-which absolute links they refuse and where, so any finding shale wrote would be right on one of them
-and wrong on the other. Nothing but the apply itself can tell you, which is the reason for the rule
-rather than an exception to it.
+Only the spelling decides it. Whether the target exists, whether it is a directory, and whether it
+points inside `current/` or somewhere else entirely make no difference on either version — stow
+reads the text and never follows it.
+
+`shale doctor` reports every one of them before the apply does, naming the layer, the link and its
+target, and telling you to respell it relative to the directory the link sits in. It reports the
+link that lands in the composed tree: one a higher layer shadows with a file of its own never
+reaches `current/`, so nothing says anything about it. A link at a path the ignore list covers is
+not reported either, because stow never looks there.
 
 ## A layer, or a guard inside a file
 

--- a/shale
+++ b/shale
@@ -2528,18 +2528,29 @@ UNCHECKED_LINKS=0
 # saying what an apply is for states a mechanism, and stays true whether or not
 # one can run today.
 #
-# Three inputs, each sufficient on its own.  An apply builds before it stows, so
+# Four inputs, each sufficient on its own.  An apply builds before it stows, so
 # everything that stops a build stops it.  stow will not write over what it did
 # not create, so a path in $HOME that a layer provides stops the stow half; that
 # is APPLY_CONFLICTS, which blocks no build and so is not counted in
-# BUILD_BLOCKED.  And stow is the one tool an apply needs that a build does not,
-# so a machine without it composes every layer and links none of them.
+# BUILD_BLOCKED.  stow will not link an absolutely spelled symlink either, and
+# on 2.4.1 abandons the whole apply over one anywhere in the tree; that is
+# ABS_LINK_COUNT, which blocks no build for the same reason.  And stow is the
+# one tool an apply needs that a build does not, so a machine without it
+# composes every layer and links none of them.
 #
-# Read where the line is printed rather than answered once: BUILD_BLOCKED and
-# APPLY_CONFLICTS go on rising until the last check has run.
+# ABS_LINK_COUNT is the one input whose answer is version-dependent: 2.3.1
+# applies a link below the top of the tree that 2.4.1 refuses, so on 2.3.1 this
+# can withhold an apply that would have run.  Withheld is the right direction of
+# error - the remedy is to respell the link, which is wanted on both versions -
+# where offering it puts 'shale apply' in a report whose own finding says that
+# apply aborts.
+#
+# Read where the line is printed rather than answered once: BUILD_BLOCKED,
+# APPLY_CONFLICTS and ABS_LINK_COUNT go on rising until the last check has run.
 apply_offerable() {
   [ "$BUILD_BLOCKED" -eq 0 ] &&
     [ "$APPLY_CONFLICTS" -eq 0 ] &&
+    [ "$ABS_LINK_COUNT" -eq 0 ] &&
     [ "$APPLY_TOOL_MISSING" -eq 0 ]
 }
 
@@ -2701,6 +2712,48 @@ APPLY_CONFLICT_PATHS=()
 # The subtree below a path already answered for, empty when there is none.
 HOME_CONFLICT_SKIP=
 
+# Non-zero unless stow never looks at the composed path $1, which is the one
+# question two checks below share: a path stow passes over is a path no apply
+# can be refused at, whatever the layers put there and whatever is in $HOME.
+#
+# One function rather than an arm in each of them, for the reason the ignore
+# table above is derived rather than written out twice: the copy in home_conflict
+# had never been given the newline rules until #108, and doctor passed a setup
+# apply then refused.
+stow_skips_path() {
+  local srel=$1
+  # The one entry stow adds to whatever the file holds rather than reading out
+  # of it, which is why STOW_IGNORE_LIST has no row for it and why this arm
+  # stands on its own.  Anchored at the top of the tree, and a literal, so the
+  # trailing-newline trim stow's '$' allows is the whole of the reading.
+  #
+  # Both spellings, and the second is the reachable one: no build accepts a
+  # layer providing '.stow-local-ignore', and every build composes one called
+  # '.stow-local-ignore\n' without a word.  Stow covers it and links nothing
+  # there, so a finding at that path would be about a file no apply can reach.
+  case "${srel%%/*}" in
+    .stow-local-ignore | ".stow-local-ignore$NL") return 0 ;;
+  esac
+  # The rest of the list cmd_build writes, read as stow reads it, and it has to
+  # stay that list in both directions: a name missing is a finding on a working
+  # setup for ever - a ~/.gitignore of the reader's own beside a layer that has
+  # one - and a name that is not in the list is a refusal doctor goes quiet
+  # about.
+  #
+  # Given the whole path rather than the last component: an ancestor on the list
+  # is a directory stow goes nowhere below, and the newline rules are about the
+  # ancestors a path passed through without matching.
+  ! stow_default_covers "$srel" || return 0
+  # The ignore files' patterns, which cmd_build appends to that same file:
+  # stow never looks at a path they match either.  Guarded on the count rather
+  # than left to the loop inside, because this runs once per composed path and
+  # the ordinary config has no ignore line at all.
+  if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$srel"; then
+    return 0
+  fi
+  return 1
+}
+
 # Records $HOME/$1 when what stands there is not the built tree's own copy of
 # the path and a build would provide that path as a $2 - 'file' or 'directory'.
 # stow refuses every one of them, verified against 2.3.1 and 2.4.1, which word
@@ -2740,43 +2793,9 @@ home_conflict() {
       "$HOME_CONFLICT_SKIP"/*) return 0 ;;
     esac
   fi
-  # The one entry stow adds to whatever the file holds rather than reading out
-  # of it, which is why STOW_IGNORE_LIST has no row for it and why this arm
-  # stands on its own.  Anchored at the top of the tree, and a literal, so the
-  # trailing-newline trim stow's '$' allows is the whole of the reading.
-  #
-  # Both spellings, and the second is the reachable one: no build accepts a
-  # layer providing '.stow-local-ignore', and every build composes one called
-  # '.stow-local-ignore\n' without a word.  Stow covers it and links nothing
-  # there, so a finding at that path would be about a file no apply can reach.
-  case "${srel%%/*}" in
-    .stow-local-ignore | ".stow-local-ignore$NL")
-      [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
-      return 0
-      ;;
-  esac
-  # The rest of the list cmd_build writes, read as stow reads it, and it has to
-  # stay that list in both directions: a name missing is a finding on a working
-  # setup for ever - a ~/.gitignore of the reader's own beside a layer that has
-  # one - and a name that is not in the list is a refusal doctor goes quiet
-  # about.  This stood as a hand-written 'case' until #108 and had never been
-  # given the three newline rules, so doctor passed a setup apply then refused.
-  # There is one matcher now, and it reads the one list.
-  #
-  # stow_default_covers is given the whole path rather than the last component:
-  # the skip above means an ancestor on the list has already returned, but the
-  # newline rules are about ancestors this walk passed through without matching,
-  # and only the path carries them.
-  if stow_default_covers "$srel"; then
-    [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
-    return 0
-  fi
-  # The ignore files' patterns, which cmd_build appends to that same file:
-  # stow never looks at a path they match, so nothing standing in $HOME there is
-  # a refusal any apply can meet.  Guarded on the count rather than left to the
-  # loop inside, because this runs once per composed path and the ordinary
-  # config has no ignore line at all.
-  if [ "${#IGNORE_PATTERNS[@]}" -gt 0 ] && path_is_ignored "$srel"; then
+  # A path stow passes over is a path nothing standing in $HOME there is a
+  # refusal at, so the whole subtree below a directory it skips goes with it.
+  if stow_skips_path "$srel"; then
     [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
     return 0
   fi
@@ -2878,6 +2897,125 @@ report_home_conflicts() {
   finding ${lines[@]+"${lines[@]}"}
 }
 
+# The symlinks a layer spells with an absolute target, collected by the same
+# walk.  Capped like every other list doctor keeps: the cap changes what is
+# printed and never what is counted.
+#
+# Two lists, because the report and the deduplication ask different questions:
+# the line names the layer and what the link points at, and one file is one
+# thing to edit however many composed paths it lands at.
+ABS_LINK_CAP=10
+ABS_LINK_COUNT=0
+ABS_LINK_PATHS=()
+ABS_LINK_LINES=()
+
+# Records the entry $2, from layer $1 and landing at composed path $3, when it is
+# a symlink whose target text starts with '/'.  Measured on both versions, and
+# the two do not agree: 2.4.1 refuses one wherever it is in the tree and
+# abandons the whole apply, and 2.3.1 refuses one at the top of the tree and
+# stows a deeper one without a word.
+#
+# 2.3.1 is the accident rather than the design.  Both versions run the same test
+# in stow_node - readlink the source, refuse a target starting '/' - but 2.3.1
+# runs it against the link text it is about to write, which resolves from the
+# target directory rather than from the directory the link goes in, so below the
+# top of the tree the -l finds nothing and the test is skipped.  2.4.1 runs it
+# against the path of the package node itself.  So the deeper link is not
+# supported on 2.3.1; it is unexamined, and the first stow upgrade refuses the
+# whole apply over a layer that has been applying for months.
+#
+# Called for the layer that wins the path and no other, and not at all where two
+# layers disagree about the kind there - which together are what make this an
+# answer about the tree the next build composes: a link a higher layer shadows
+# with a file never lands in it, and a path that stops every build lands nothing
+# at all.  Both call sites carry the reasoning for their own half.
+#
+# $3 rather than $2 for the skip test, and the composed path is the only one
+# that can answer it: what stow reads is current/, and a layer's own directory
+# name is nowhere in the paths its list is matched against.
+#
+# Deduplicated on the layer entry, which is the file somebody has to edit: with
+# 'local' and 'local/sub' both configured, one link inside 'sub' is met by that
+# layer's own listing and again by the walk down from 'local', landing at two
+# composed paths - and reporting it twice would inflate the count as well as the
+# report, for one respelling that fixes both.  The names differ between the two
+# sightings, so the whole line is not the thing to compare.  Above the cap the
+# dedup stops working, which is why the line that replaces the names says only
+# 'and more' - the same bargain the stray list makes.
+#
+# The skip test is asked before it, and per sighting: the two land at different
+# composed paths, and an ignore pattern covering one of them says nothing about
+# the other.
+#
+# 'Cannot say' answers the same as 'not absolute', which is the answer that
+# reports nothing: a missing readlink is a note doctor has already printed, and
+# a finding raised on a guess is worse than the silence it replaces.  The
+# readlink is the one fork here and it is spent only on a symlink stow would
+# look at, once per file however many layers reach it - a tree with no links in
+# it pays one lstat per entry and nothing else.
+layer_absolute_link() {
+  local name=$1 path=$2 srel=$3 dest k
+  [ -L "$path" ] || return 0
+  ! stow_skips_path "$srel" || return 0
+  k=0
+  while [ "$k" -lt "${#ABS_LINK_PATHS[@]}" ]; do
+    [ "${ABS_LINK_PATHS[$k]}" != "$path" ] || return 0
+    k=$((k + 1))
+  done
+  command -v readlink >/dev/null 2>&1 || return 0
+  dest=$(readlink "$path") || return 0
+  case "$dest" in
+    /*) ;;
+    *) return 0 ;;
+  esac
+  ABS_LINK_COUNT=$((ABS_LINK_COUNT + 1))
+  if [ "$ABS_LINK_COUNT" -le "$ABS_LINK_CAP" ]; then
+    ABS_LINK_PATHS+=("$path")
+    ABS_LINK_LINES+=("layer '$name': $path -> $dest")
+  fi
+  return 0
+}
+
+# One finding however many links, on report_home_conflicts' reasoning: what they
+# add up to on 2.4.1 is one apply that will not run, and one line of remedy
+# covers every one of them.
+#
+# A finding rather than a note, and the wording has to be true on both versions
+# because shale never asks which one is installed - so it says what each does.
+# The reading that decides it is 2.4.1's, the version Homebrew ships and the one
+# the macOS half of CI runs: there, one such link anywhere aborts the apply
+# outright, which is the doctor-green/apply-fails state this exists to close.
+# Where 2.3.1 links the deeper one instead, the finding is still about a defect -
+# a layer that stops applying at the next stow upgrade - rather than about
+# today's exit status.
+#
+# It stops no build, so BUILD_BLOCKED is left alone: the composer copies a link
+# without reading it, and the built tree is correct either way.
+report_absolute_links() {
+  local n=$ABS_LINK_COUNT i lines links respell rest
+  [ "$n" -gt 0 ] || return 0
+  links="$n symlinks in the layers have absolute targets"
+  respell='respell each target relative to the directory its link is in'
+  if [ "$n" -eq 1 ]; then
+    links='1 symlink in the layers has an absolute target'
+    respell='respell the target relative to the directory the link is in'
+  fi
+  lines=("$links"
+    "apply gives the composed tree to stow, and stow will not link a symlink whose target starts with a '/': stow 2.4.1 refuses one wherever it is in the tree, and abandons the whole apply"
+    'stow 2.3.1 refuses one at the top of the tree and links a deeper one instead, so a layer that applies here today can stop applying the day stow is upgraded'
+    "$respell")
+  i=0
+  while [ "$i" -lt "${#ABS_LINK_LINES[@]}" ]; do
+    lines[${#lines[@]}]=${ABS_LINK_LINES[$i]}
+    i=$((i + 1))
+  done
+  if [ "$n" -gt "$ABS_LINK_CAP" ]; then
+    rest=$((n - ABS_LINK_CAP))
+    lines[${#lines[@]}]="and $rest more, not named here"
+  fi
+  finding ${lines[@]+"${lines[@]}"}
+}
+
 # Every path two layers disagree about the kind of, and every layer path this
 # walk cannot read: the states build refuses that nothing else in doctor sees.
 # The walk is build's own minus the copying - one listing per layer directory
@@ -2904,6 +3042,7 @@ report_home_conflicts() {
 scan_layer_trees() {
   local rel=$1 layers=$2 i k here e base srel path alone lines
   local kind first first_kind last other other_kind other_prev providers children
+  local win
   # One layer cannot disagree with anything, so below such a directory the whole
   # of the comparison is skipped and the walk is only looking for a directory it
   # cannot enter.  Worth its own arm because it is the ordinary shape: most of a
@@ -2995,6 +3134,7 @@ scan_layer_trees() {
         # One layer holds this subtree, so this listing is the only one that
         # reaches this path and the kind here is the kind that lands.
         home_conflict "$srel" "$kind"
+        layer_absolute_link "${LAYER_NAMES[$i]}" "$e" "$srel"
         [ "$kind" = directory ] || continue
         scan_layer_trees "$srel" "$i"
         continue
@@ -3027,6 +3167,7 @@ scan_layer_trees() {
       other_prev=-1
       providers=0
       children=
+      win=$i
       # shellcheck disable=SC2086
       for k in $layers; do
         if [ "$first" -lt 0 ]; then
@@ -3052,8 +3193,15 @@ scan_layer_trees() {
         fi
         if [ "$kind" = "$first_kind" ]; then
           # Two directories merge, and a file over a file is the ordinary
-          # shadowing this whole tool is for.
-          [ "$kind" != directory ] || children="$children $k"
+          # shadowing this whole tool is for.  A file's content comes from the
+          # highest layer that provides it and a directory's from all of them,
+          # so the two arms keep different things: the last agreeing layer, and
+          # every agreeing layer.
+          if [ "$kind" = directory ]; then
+            children="$children $k"
+          else
+            win=$k
+          fi
         elif [ "$other" -lt 0 ]; then
           other=$k
           other_kind=$kind
@@ -3086,6 +3234,23 @@ scan_layer_trees() {
         [ "$providers" -le 2 ] ||
           lines[${#lines[@]}]="$providers layers provide $srel, so removing one of the two named here may leave another pair that disagrees"
         blocking_finding ${lines[@]+"${lines[@]}"}
+      else
+        # Only where the layers agree about the kind here, which is where a
+        # build composes something.  A path they disagree at stops every build,
+        # so nothing lands there and no stow ever reads what is spelled there -
+        # and reporting it anyway would make the answer turn on layer order,
+        # since the collision is found from the first provider and the spelling
+        # from the layer whose bytes would have won.  The blocking finding above
+        # is the one thing to act on; if the link survives the fix, the doctor
+        # run after it names the spelling.
+        #
+        # $win rather than $i: the kind at a path is the first provider's, but
+        # the bytes are the last agreeing provider's - build copies each layer
+        # over the one before it - so a lower layer's link that a higher layer's
+        # file shadows is a link no build composes and no stow ever sees.
+        [ "$first_kind" = directory ] ||
+          layer_absolute_link "${LAYER_NAMES[$win]}" \
+            "$DOTFILES/${LAYER_PATHS[$win]}/$srel" "$srel"
       fi
       [ "$first_kind" = directory ] || continue
       scan_layer_trees "$srel" "$children"
@@ -5838,7 +6003,7 @@ cmd_doctor() {
     command -v "$tool" >/dev/null 2>&1 && continue
     # stow is wanted only by apply, so it stops no build on its own; every other
     # name here does, and no line below may then offer one.  What it does stop is
-    # every apply, which is apply_offerable's third input.
+    # every apply, which is apply_offerable's fourth input.
     if [ "$tool" = stow ]; then
       APPLY_TOOL_MISSING=$((APPLY_TOOL_MISSING + 1))
     else
@@ -6007,6 +6172,9 @@ cmd_doctor() {
   LAYER_DENIED=0
   APPLY_CONFLICTS=0
   APPLY_CONFLICT_PATHS=()
+  ABS_LINK_COUNT=0
+  ABS_LINK_PATHS=()
+  ABS_LINK_LINES=()
   HOME_CONFLICT_SKIP=
   STRAY_COUNT=0
   STRAY_PATHS=()
@@ -6016,6 +6184,14 @@ cmd_doctor() {
     i=$((LAYER_DENIED - LAYER_DENIED_CAP))
     note "and $i more layer paths shale cannot read, not named here"
   fi
+  # What the layers hold on its own terms, before the comparison below it: an
+  # absolutely spelled link is a defect in the layer whatever is in $HOME, and a
+  # link to a directory can be both - it is refused for its spelling here and
+  # collides with a real directory of yours there.  Two findings at one path,
+  # and both are wanted: respelling the link does not move your directory, and
+  # moving your directory does not respell the link.
+  report_absolute_links
+
   # The other half of that walk: what the layers hold, against what is in $HOME
   # at the same paths.
   report_home_conflicts

--- a/tests/run
+++ b/tests/run
@@ -9383,6 +9383,12 @@ test_doctor_reports_its_checks_in_order() {
   # The path a layer provides that $HOME already holds, which is reported off the
   # back of the layer walk and belongs with it.
   sandbox_write "$HOME" .zshrc 'mine'
+  # An absolutely spelled layer link, reported off the back of that same walk and
+  # ahead of the comparison with $HOME: what the layers hold on their own terms
+  # comes before what they hold against what is already there.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s "$HOME/elsewhere/vimrc" "$sandbox_path" || fail 'could not plant the layer link'
   sandbox_write "$HOME" .stowrc '--ignore=secret'
   stub_path_without stow
   saved=$PATH
@@ -9396,15 +9402,16 @@ test_doctor_reports_its_checks_in_order() {
       'shale: stow is not installed') seen="$seen prerequisite" ;;
       "shale: $HOME/.dotfiles/shale.conf:3:"*) seen="$seen config" ;;
       "shale: layer 'work'"*) seen="$seen layer" ;;
+      'shale: 1 symlink in the layers has an absolute target') seen="$seen spelling" ;;
       *' holds something no apply put there, and a layer provides it') seen="$seen home" ;;
       *' is not a layer, and no build reads it') seen="$seen stray" ;;
       'shale: a stow resource file'*) seen="$seen stowrc" ;;
-      'shale: 4 problems found') seen="$seen summary" ;;
+      'shale: 5 problems found') seen="$seen summary" ;;
     esac
   done <<EOF
 $shale_out
 EOF
-  assert_eq ' prerequisite config layer home stray stowrc summary' "$seen" \
+  assert_eq ' prerequisite config layer spelling home stray stowrc summary' "$seen" \
     'the order of the report'
 }
 
@@ -11440,12 +11447,14 @@ test_doctor_an_applied_tree_with_no_orphans_reports_no_problems() {
 
 # A layer may ship a symlink that points at nothing - a path another machine has,
 # a mount that is not up - and shale copies it verbatim.  This is the absolute
-# spelling of one, and it reaches the built tree and stops there: stow refuses to
-# stow a package symlink whose target is absolute, so no link in $HOME ever points
-# at it and the refused apply below is what says so rather than a comment.  What
-# is left is two broken links under ~/.dotfiles - the layer's and the built tree's
-# copy - both of which 'chkstow -b' reports and neither of which is a defect in
-# this setup.
+# spelling of one, and doctor reports it for the spelling alone: what it points
+# at, and whether anything is there, makes no difference to stow, which reads
+# the target text and nothing else.  The apply below is what says so rather than
+# a comment.
+#
+# The dangling half of the claim is the other one, and it is a silence: neither
+# the layer's copy nor the built tree's is reported as a broken link, because
+# apply makes no link inside ~/.dotfiles and the remedy could not reach one.
 #
 # The layer link is at the top of the layer because that is where the two stow
 # versions this suite meets agree.  Both refuse in Stow.pm's stow_node(), but
@@ -11453,9 +11462,10 @@ test_doctor_an_applied_tree_with_no_orphans_reports_no_problems() {
 # created in while its cwd is the target root, so below the top level it tests a
 # path prefixed '../' that cannot exist, the refusal never fires and the link is
 # stowed; 2.4.1 builds that path from the cwd instead - $pkg_path_from_cwd - and
-# refuses at every depth.  Planted a directory down, this case passes on 2.3.1 and
-# fails on 2.4.1, and that difference is stow's rather than shale's.
-test_doctor_an_absolute_dangling_link_a_layer_ships_is_not_a_finding() {
+# refuses at every depth.  Planted a directory down, the apply below exits 0 on
+# 2.3.1 and 1 on 2.4.1, and that difference is stow's rather than shale's - which
+# is why doctor's own answer, asserted before it, is the same at either depth.
+test_doctor_an_absolute_dangling_link_a_layer_ships_is_a_finding() {
   local conflict
   conf 'base personal/base'
   mklayer personal/base .zshrc
@@ -11469,13 +11479,18 @@ test_doctor_an_absolute_dangling_link_a_layer_ships_is_not_a_finding() {
   assert_dangling_symlink "$HOME/.dotfiles/personal/base/.secrets" 'the layer link'
   assert_dangling_symlink "$HOME/.dotfiles/current/.secrets" 'the built copy'
   run_shale doctor
-  assert_status 0 "$shale_status"
-  assert_not_contains "$shale_out" 'points at' 'stdout'
-  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
-  # The third place a dangling layer link would appear, and why this spelling has
-  # not got one.  Pinned as fragments: the phrase is the same statement in both
-  # versions of Stow.pm, and the path beside it is the built tree's copy in both,
-  # but the rest of the line is stow's to word.
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   layer 'base': $HOME/.dotfiles/personal/base/.secrets -> $HOME/elsewhere/secrets" \
+    'stdout'
+  # The broken-link audit, which is a different check and stays silent: the two
+  # copies under ~/.dotfiles are not links any apply wrote.
+  assert_not_contains "$shale_out" 'which the built tree no longer provides' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # The apply doctor predicted.  Pinned as fragments: the phrase is the same
+  # statement in both versions of Stow.pm, and the path beside it is the built
+  # tree's copy in both, but the rest of the line is stow's to word.
   run_shale apply
   assert_status 1 "$shale_status"
   assert_contains "$shale_err" 'source is an absolute symlink' 'stow stderr'
@@ -11484,9 +11499,295 @@ test_doctor_an_absolute_dangling_link_a_layer_ships_is_not_a_finding() {
   assert_missing "$HOME/.secrets" 'the link stow refused to make'
   # And the state that refusal leaves is the one the user runs doctor in.
   run_shale doctor
-  assert_status 0 "$shale_status"
-  assert_not_contains "$shale_out" 'points at' 'stdout'
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_not_contains "$shale_out" 'which the built tree no longer provides' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  # The remedy the finding prescribes, carried out: the same link respelled
+  # relative to the directory it sits in applies, and the report goes quiet.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  # Removed through the resolved directory rather than through sandbox_leaf,
+  # whose weak mode refuses a name that holds a symlink - which is exactly what
+  # this name holds and what is being replaced.
+  rm -f "$sandbox_dir/.secrets" || fail 'could not clear the layer link'
+  sandbox_leaf "$sandbox_dir" .secrets new
+  ln -s ../../../elsewhere/secrets "$sandbox_path" || fail 'could not respell the layer link'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the remedy'
+  assert_dangling_symlink "$HOME/.secrets" 'the applied link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The shape the check exists for: a leaf below the top of the tree, which 2.4.1
+# refuses - aborting the whole apply - and 2.3.1 stows without a word.  No apply
+# is run, because its status here is the stow version rather than the behaviour
+# under test; the top-level case above runs one, that being the depth the two
+# versions agree at.  The whole finding is asserted, once, so the wording that
+# has to be true of both versions is pinned somewhere.
+test_doctor_an_absolute_symlink_below_the_top_of_a_layer_is_a_finding() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim"
+  sandbox_leaf "$sandbox_dir" spell.add new
+  # A target that exists, where the top-level case above dangles: stow reads the
+  # text and never follows it, and both are refused on 2.4.1 alike - measured.
+  ln -s "$HOME/.dotfiles/personal/base/.zshrc" "$sandbox_path" ||
+    fail 'could not plant the layer link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_eq "shale: 1 symlink in the layers has an absolute target
+shale:   apply gives the composed tree to stow, and stow will not link a symlink whose target starts with a '/': stow 2.4.1 refuses one wherever it is in the tree, and abandons the whole apply
+shale:   stow 2.3.1 refuses one at the top of the tree and links a deeper one instead, so a layer that applies here today can stop applying the day stow is upgraded
+shale:   respell the target relative to the directory the link is in
+shale:   layer 'base': $HOME/.dotfiles/personal/base/.config/nvim/spell.add -> $HOME/.dotfiles/personal/base/.zshrc
+shale: there is no built tree at $HOME/.dotfiles/current, so shale cannot tell a link into it from any other broken link
+shale:   build one with: shale build
+shale: 1 problem found" "$shale_out" 'the whole report'
+  # The composer says nothing: it copies a link without reading it, and the
+  # built tree is correct whatever the target says.
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  assert_empty "$shale_err" 'the build stderr'
+  assert_symlink_to "$HOME/.dotfiles/current/.config/nvim/spell.add" \
+    "$HOME/.dotfiles/personal/base/.zshrc" 'the built copy'
+}
+
+# The supported spelling, in every shape it comes in, and the plan's own answer:
+# a relative link is what a layer is meant to ship, and a dangling one is a path
+# another machine has rather than a defect here.  Reported would be worse than
+# useless - there is no remedy, and stow links every one of these.
+test_doctor_a_relative_symlink_in_a_layer_is_not_a_finding() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .exrc new
+  ln -s .zshrc "$sandbox_path" || fail 'could not plant the sibling link'
+  sandbox_leaf "$sandbox_dir" .secrets new
+  ln -s nowhere "$sandbox_path" || fail 'could not plant the dangling link'
+  sandbox_leaf "$sandbox_dir" .vim new
+  ln -s .config/nvim "$sandbox_path" || fail 'could not plant the directory link'
+  sandbox_leaf "$sandbox_dir" .outward new
+  ln -s ../../../elsewhere/thing "$sandbox_path" || fail 'could not plant the outward link'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  # The whole report, not a fragment of it: the everyday state has to read
+  # exactly as it did before this check existed, and a line added anywhere in it
+  # is what that claim is about.
+  assert_eq 'shale: no problems found' "$shale_out" 'the whole report'
+  assert_empty "$shale_err" 'stderr'
+}
+
+# Which layer's copy lands is the whole of what decides this: a link a higher
+# layer shadows with a file is a link no build composes, so stow never sees it
+# and a finding about it would send someone to edit a layer that is working.
+# Both directions, because a check that reported neither would pass the first
+# half of this on its own.
+test_doctor_an_absolute_symlink_a_higher_layer_shadows_is_not_a_finding() {
+  conf 'base personal/base' 'local local'
+  mklayer personal/base .zshrc
+  mklayer local .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s "$HOME/elsewhere/vimrc" "$sandbox_path" || fail 'could not plant the layer link'
+  mklayer local .vimrc
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the shadowed link'
+  assert_not_contains "$shale_out" 'absolute target' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  # And the same pair the other way up: the higher layer's link is the copy that
+  # lands, and it is named against that layer.
+  sandbox_mkdir "$HOME/.dotfiles/local"
+  rm -f "$sandbox_dir/.vimrc" || fail 'could not clear the layer file'
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s "$HOME/elsewhere/vimrc" "$sandbox_path" || fail 'could not plant the layer link'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  rm -f "$sandbox_dir/.vimrc" || fail 'could not clear the layer link'
+  mklayer personal/base .vimrc
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the winning link'
+  assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   layer 'local': $HOME/.dotfiles/local/.vimrc -> $HOME/elsewhere/vimrc" 'stdout'
+  assert_not_contains "$shale_out" "layer 'base':" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# One file, two configured layers reaching it, and one thing to edit.  With
+# 'outer' and 'inner' both configured, the link inside 'inner' is met by that
+# layer's own listing and again by the walk down from 'outer', landing at two
+# composed paths - so without the dedup this is one link counted twice, and the
+# reader is sent to respell a file they have already respelled.
+#
+# The count is asserted as well as the line, because the cap and the dedup are
+# separate: a list that printed the path once and still counted two would read
+# as a report that had lost a line.
+test_doctor_an_absolute_symlink_two_layers_reach_is_named_once() {
+  conf 'outer personal' 'inner personal/base'
+  mklayer personal .zshrc
+  mklayer personal/base .vimrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .exrc new
+  ln -s "$HOME/elsewhere/exrc" "$sandbox_path" || fail 'could not plant the layer link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   layer 'outer': $HOME/.dotfiles/personal/base/.exrc -> $HOME/elsewhere/exrc" 'stdout'
+  assert_not_contains "$shale_out" "layer 'inner':" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# One path, two findings, and both of them true: an absolutely spelled link to a
+# directory is refused for its spelling wherever it points, and collides with a
+# real directory of yours at the same path for being a file where $HOME has a
+# directory.  Respelling it relative leaves the collision; moving the directory
+# aside leaves the spelling.  They are worded from different sides - one names
+# the layer's copy, the other the path in $HOME - so neither reads as the other
+# repeated.
+test_doctor_an_absolute_symlink_to_a_directory_over_a_home_directory_is_both() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_mkdir "$HOME/.config/nvim"
+  sandbox_write "$HOME/.config/nvim" mine.lua 'mine'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  rm -rf "$sandbox_dir/nvim" || fail 'could not remove the layer directory'
+  sandbox_leaf "$sandbox_dir" nvim new
+  ln -s "$HOME/elsewhere/nvim" "$sandbox_path" || fail 'could not plant the layer link'
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   layer 'base': $HOME/.dotfiles/personal/base/.config/nvim -> $HOME/elsewhere/nvim" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale: 1 path in $HOME holds something no apply put there, and a layer provides it" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.config/nvim" 'stdout'
+  assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
+}
+
+# The bound every other list doctor keeps has, and the same bargain: the cap
+# changes what is printed and never what is counted, so the summary still says
+# one problem however many links there are.
+test_doctor_bounds_the_absolute_symlink_findings_at_ten() {
+  local i n
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  # Two digits, so the glob order the walk sees is the counting order and the
+  # assertions below can name which two fall past the cap.
+  i=0
+  while [ "$i" -lt 12 ]; do
+    n=$(printf 'link%02d' "$i")
+    sandbox_leaf "$sandbox_dir" "$n" new
+    ln -s "$HOME/elsewhere/$n" "$sandbox_path" || fail "could not plant $n"
+    i=$((i + 1))
+  done
+  run_shale doctor
+  assert_status 1 "$shale_status"
+  assert_contains "$shale_out" 'shale: 12 symlinks in the layers have absolute targets' 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   respell each target relative to the directory its link is in' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   layer 'base': $HOME/.dotfiles/personal/base/link09 -> $HOME/elsewhere/link09" 'stdout'
+  assert_not_contains "$shale_out" 'link10 ->' 'stdout'
+  assert_not_contains "$shale_out" 'link11 ->' 'stdout'
+  assert_contains "$shale_out" 'shale:   and 2 more, not named here' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# A path stow passes over is a path no apply can be refused at, so the spelling
+# of a link there costs nothing - measured on both versions, which stow neither
+# at the leaf an ignore pattern covers nor anywhere below a directory it does.
+# Reported, this would be a finding on a working setup for ever, with a remedy
+# that changes nothing.
+test_doctor_says_nothing_about_an_absolute_symlink_stow_never_looks_at() {
+  conf 'base personal/base'
+  mkignore personal '*.swp' 'private'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .zshrc.swp new
+  ln -s "$HOME/elsewhere/swap" "$sandbox_path" || fail 'could not plant the covered link'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/private/deep"
+  sandbox_leaf "$sandbox_dir" key new
+  ln -s "$HOME/elsewhere/key" "$sandbox_path" || fail 'could not plant the buried link'
+  # And a name on the list stow reads whether or not there is an ignore file:
+  # build writes that list into current/.stow-local-ignore on every build.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config"
+  sandbox_leaf "$sandbox_dir" .gitignore new
+  ln -s "$HOME/elsewhere/gitignore" "$sandbox_path" || fail 'could not plant the listed link'
+  run_shale doctor
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'absolute target' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# What a link points at is read with readlink, and without it there is no way to
+# tell an absolute target from a relative one.  Silence is the answer, and the
+# note the prerequisite block has already printed is what says why: a finding
+# raised on a guess is worse than the check not running.
+# shellcheck disable=SC2123
+test_doctor_without_readlink_says_nothing_about_an_absolute_symlink() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s "$HOME/elsewhere/vimrc" "$sandbox_path" || fail 'could not plant the layer link'
+  stub_path_without readlink
+  saved=$PATH
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 0 "$shale_status"
+  assert_not_contains "$shale_out" 'absolute target' 'stdout'
+  assert_contains "$shale_out" 'shale: readlink is not installed' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The fourth gate, and the one whose answer is version-dependent: on 2.4.1 the
+# apply that would be offered aborts over the link, so offering it would put a
+# command in the report that a finding above it says will not finish.  The link
+# is at the top of the layer, which is the depth the two stow versions agree
+# at, so the apply below exits 1 on either of them.
+#
+# The orphan is a file that left a layer whose directory the tree still holds,
+# which is the shape doctor offers an apply for at all.
+test_doctor_offers_no_apply_for_an_orphan_beside_an_absolute_layer_symlink() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/extra.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim"
+  sandbox_leaf "$sandbox_dir" extra.lua
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" 'shale: clear it with: shale apply' 'the sound stdout'
+  # The same links with an absolutely spelled one beside them: the offer goes.
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .vimrc new
+  ln -s "$HOME/elsewhere/vimrc" "$sandbox_path" || fail 'could not plant the layer link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the setup with the link'
+  assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_contains "$shale_out" \
+    'shale: no apply will finish until the problems above are fixed, so this link stays' \
+    'the blocked stdout'
+  assert_not_contains "$shale_out" 'clear it with' 'the blocked stdout'
+  assert_not_contains "$shale_out" 'shale apply' 'the blocked stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply no line offered'
 }
 
 # Everything else chkstow finds under $HOME belongs to whoever put it there.
@@ -11709,9 +12010,13 @@ test_doctor_a_broken_link_inside_the_dotfiles_directory_is_not_a_finding() {
   assert_status 0 "$shale_status"
   # All three point into the built tree at a path it has not got, which is
   # exactly the shape a finding has anywhere else under $HOME.
+  #
+  # The layer's copy is spelled relative to itself, where the other two are
+  # absolute: a layer entry spelled from the root is a finding of its own, and
+  # this case is about the audit of $HOME rather than about that.
   sandbox_mkdir "$HOME/.dotfiles/personal/base"
   sandbox_leaf "$sandbox_dir" .layerlink new
-  ln -s "$HOME/.dotfiles/current/.absent" "$sandbox_path" ||
+  ln -s ../../current/.absent "$sandbox_path" ||
     fail 'could not plant the layer link'
   sandbox_mkdir "$HOME/.dotfiles"
   sandbox_leaf "$sandbox_dir" .stray new
@@ -12410,22 +12715,49 @@ EOF
 # directory under a real directory in a higher layer is a collision - and
 # calling the link a directory here would make doctor promise a merge that
 # build refuses.
+#
+# The link is spelled absolutely, and the total is asserted, because that is
+# where the collision and the spelling check meet: a path the layers disagree at
+# composes nothing, so the spelling there is not reported and the count is one
+# either way up.  Reported, it would be one problem with the link in the lower
+# layer and two with it in the higher - the same defect, counted by config
+# order - so both orders are run.
 test_doctor_a_layer_symlink_under_a_layer_directory_is_a_finding() {
-  conf 'base personal/base' 'work work'
-  mklayer personal/base .zshrc
-  mklayer work d/inner
-  sandbox_mkdir "$HOME/elsewhere"
-  sandbox_mkdir "$HOME/.dotfiles/personal/base"
-  sandbox_leaf "$sandbox_dir" d new
-  ln -s "$HOME/elsewhere" "$sandbox_path" || fail 'could not plant the link'
-  run_shale doctor
-  assert_status 1 "$shale_status"
-  assert_contains "$shale_out" \
-    "shale: 'build' would fail at d — it is a file in layer 'base' and a directory in layer 'work'" \
-    'stdout'
-  run_shale build
-  assert_status 1 "$shale_status" 'the build'
-  assert_contains "$shale_err" 'shale: conflict at d' 'the build stderr'
+  local order lower upper
+  for order in link-lower link-higher; do
+    case "$order" in
+      link-lower) conf 'base personal/base' 'work work' ;;
+      link-higher) conf 'work work' 'base personal/base' ;;
+    esac
+    mklayer personal/base .zshrc
+    mklayer work d/inner
+    sandbox_mkdir "$HOME/elsewhere"
+    sandbox_mkdir "$HOME/.dotfiles/personal/base"
+    if [ "$order" = link-lower ]; then
+      sandbox_leaf "$sandbox_dir" d new
+      ln -s "$HOME/elsewhere" "$sandbox_path" || fail 'could not plant the link'
+    fi
+    case "$order" in
+      link-lower) lower=base upper=work ;;
+      link-higher) lower=work upper=base ;;
+    esac
+    run_shale doctor
+    assert_status 1 "$shale_status" "$order exit status"
+    if [ "$order" = link-lower ]; then
+      assert_contains "$shale_out" \
+        "shale: 'build' would fail at d — it is a file in layer '$lower' and a directory in layer '$upper'" \
+        "$order stdout"
+    else
+      assert_contains "$shale_out" \
+        "shale: 'build' would fail at d — it is a directory in layer '$lower' and a file in layer '$upper'" \
+        "$order stdout"
+    fi
+    assert_not_contains "$shale_out" 'absolute target' "$order stdout"
+    assert_contains "$shale_out" 'shale: 1 problem found' "$order stdout"
+    run_shale build
+    assert_status 1 "$shale_status" "$order build"
+    assert_contains "$shale_err" 'shale: conflict at d' "$order build stderr"
+  done
 }
 
 # build does not descend a layer that collided at a directory, so nothing under
@@ -12506,11 +12838,13 @@ test_doctor_says_nothing_about_a_layer_entry_no_build_reads() {
   conf 'base personal/base'
   mklayer personal/base .zshrc
   # A file outside every layer, unreadable, with a layer link pointing at it.
-  sandbox_write "$CASE_DIR/outside" target 'PRECIOUS'
+  # Spelled relative to the link, because a layer entry spelled from the root is
+  # a finding of its own and this case is about what a build opens.
+  sandbox_write "$HOME/outside" target 'PRECIOUS'
   chmod 0000 "$sandbox_path" || fail 'could not remove the mode bits'
   sandbox_mkdir "$HOME/.dotfiles/personal/base"
   sandbox_leaf "$sandbox_dir" tolink new
-  ln -s "$CASE_DIR/outside/target" "$sandbox_path" || fail 'could not plant the link'
+  ln -s ../../../outside/target "$sandbox_path" || fail 'could not plant the link'
   sandbox_leaf "$sandbox_dir" dangling new
   ln -s nowhere "$sandbox_path" || fail 'could not plant the dangling link'
   sandbox_leaf "$sandbox_dir" pipe new
@@ -12522,7 +12856,7 @@ test_doctor_says_nothing_about_a_layer_entry_no_build_reads() {
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
   # And the build that says so: it composes all three and exits 0.
   run_shale build
-  chmod 0644 "$CASE_DIR/outside/target" || fail 'could not restore the mode'
+  chmod 0644 "$HOME/outside/target" || fail 'could not restore the mode'
   assert_status 0 "$shale_status" 'the build'
   assert_empty "$shale_err" 'the build stderr'
   assert_exists "$HOME/.dotfiles/current/tolink" 'the copied link'
@@ -13122,7 +13456,7 @@ test_doctor_compares_no_symlink_in_the_built_tree() {
   sandbox_mkdir "$HOME/.dotfiles/local"
   sandbox_leaf "$sandbox_dir" layerlink
   rm -f "$sandbox_path" || fail 'could not clear the layer file'
-  ln -s "$HOME/outside/thing" "$sandbox_path" ||
+  ln -s ../../outside/thing "$sandbox_path" ||
     fail 'could not replace the layer file with a link'
   # And the built copy is a link where the layer entry is a plain file.
   sandbox_mkdir "$HOME/.dotfiles/current"
@@ -13611,7 +13945,7 @@ test_doctor_a_layer_providing_the_running_script_is_a_finding() {
         sandbox_mkdir "$HOME/.dotfiles/local/.local/bin"
         sandbox_leaf "$sandbox_dir" shale
         rm -f "$sandbox_path" || fail 'could not clear the layer file'
-        ln -s "$sandbox_dir/gone" "$sandbox_path" || fail 'could not link the layer file'
+        ln -s gone "$sandbox_path" || fail 'could not link the layer file'
         ;;
       *) mklayer local .local/bin/shale ;;
     esac


### PR DESCRIPTION
Closes #176.

The last known doctor-green/apply-fails state: a layer symlink with an absolute target works under stow 2.3.1 below the top of the tree and aborts the entire apply under 2.4.1 — the version Homebrew ships — so a setup that applies today stops applying on upgrade, with doctor saying nothing first. Doctor now reports each such link (winner-only, deduped on the layer entry, capped at ten, silent for paths stow never looks at) as a finding that also withholds the apply offer, with wording version-scoped from measurements reproduced independently by the gate on both stow versions. The remedy — respell the target relative — carried out makes the report quiet and the apply succeed on both. Everyday reports byte-identical to main.

Gate run: full depth-and-target matrix executed on 2.3.1 and a 2.4.1 source build, win-tracking traced through six multi-layer shapes, the ignore-interaction question settled by execution (stow links nothing at skipped paths — no false silence). 553 passed, 0 failed, 0 skipped under bash 5.2.21, 3.2.57, and stow 2.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)