### PR TITLE
Report a hand-made absolute link at a path the tree still provides

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,15 +389,16 @@ configured layer directory is there and that nothing in one is a directory it ca
 file it cannot open, that no two layers disagree about whether a path is a file or a directory, that
 no layer ships a symlink whose target is spelled from the root, which stow will not link, that
 nothing in `$HOME` at a path the layers provide is something no apply put there — a file, a
-directory, or a link of your own, none of which stow will write over — that no layer ships
-`.stow-local-ignore`, which shale writes itself, or shale itself, that `~/.dotfiles/current` is a
-directory rather than a file or a link to one, that a build could create the tree it composes into,
-that nothing in `~/.dotfiles` whose name does not begin with a dot is a stray, that no `current.new`
-has been left beside `current` and no `current.old` holding anything the layers cannot produce
-again, and that no link in `$HOME` points into the built tree at a path it no longer provides. Where
-a `.stowrc` exists it says so, because stow appends its `--ignore` patterns to the ones shale passes
-and one of them can drop a file from an apply without a word. It reads nothing out of that file, and
-changes nothing itself.
+directory, or a link of your own, none of which stow will write over — that no link in `$HOME` at
+such a path is spelled from the root, which reads as applied and which stow refuses, that no layer
+ships `.stow-local-ignore`, which shale writes itself, or shale itself, that `~/.dotfiles/current`
+is a directory rather than a file or a link to one, that a build could create the tree it composes
+into, that nothing in `~/.dotfiles` whose name does not begin with a dot is a stray, that no
+`current.new` has been left beside `current` and no `current.old` holding anything the layers cannot
+produce again, and that no link in `$HOME` points into the built tree at a path it no longer
+provides. Where a `.stowrc` exists it says so, because stow appends its `--ignore` patterns to the
+ones shale passes and one of them can drop a file from an apply without a word. It reads nothing out
+of that file, and changes nothing itself.
 
 ```
 $ shale doctor
@@ -409,8 +410,7 @@ and makes doctor exit 1. Everything else is a note about something worth knowing
 nor changes the exit code. Every state doctor can see that stops a build or an apply outright is a
 problem, so `no problems found` is a strong signal that both will run rather than a guarantee that
 they must. What it does not see: whether `$HOME` is writable, which fails an apply rather than a
-build, nor whether a leftover `current.old` can be removed, nor an absolute link in `$HOME` pointing
-at the built tree's own copy of that same path, which stow refuses and which only a hand ever makes.
+build, nor whether a leftover `current.old` can be removed.
 
 That verdict is about the checks that ran. The audit of `$HOME` for broken links is the only one that
 looks outside `~/.dotfiles`, and it needs a built tree, `chkstow`, `readlink` and a `$HOME` to walk.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -347,11 +347,17 @@ every layer, the links inside it are left dangling and the apply still exits 0: 
 only visits directories the package still has.
 
 Spelling is the other reason a link is kept. Stow takes back only the relative links an apply wrote,
-so a link at a managed path that you re-spelled as an absolute one stays where it is even though the
-built tree still holds the directory around it — and on stow 2.3.1, an absolute link directly in
-`$HOME` makes every apply print `BUG in find_stowed_path? Absolute/relative mismatch ...` on stderr,
-which shale passes through unchanged under its own `stow exited 0 and wrote output` warning. Either
-way the link is left behind, and the apply counts it.
+so a link at a path the layers have moved past that you re-spelled as an absolute one stays where it
+is even though the built tree still holds the directory around it — and on stow 2.3.1, an absolute
+link directly in `$HOME` makes every apply print `BUG in find_stowed_path? Absolute/relative mismatch
+...` on stderr, which shale passes through unchanged under its own `stow exited 0 and wrote output`
+warning. Either way the link is left behind, and the apply counts it.
+
+Re-spell one at a path a layer still provides and nothing is left behind, because nothing runs: stow
+compares the text of the link it finds against the text it would write, never the file at the end of
+it, so an absolute spelling of the very path it wants is a target it does not own — and it abandons
+the whole apply, on 2.3.1 and 2.4.1 alike. `doctor` names such a link, and the way out is to remove
+it and apply again.
 
 The apply says so, in one line and no more:
 

--- a/shale
+++ b/shale
@@ -2528,14 +2528,16 @@ UNCHECKED_LINKS=0
 # saying what an apply is for states a mechanism, and stays true whether or not
 # one can run today.
 #
-# Four inputs, each sufficient on its own.  An apply builds before it stows, so
+# Five inputs, each sufficient on its own.  An apply builds before it stows, so
 # everything that stops a build stops it.  stow will not write over what it did
 # not create, so a path in $HOME that a layer provides stops the stow half; that
 # is APPLY_CONFLICTS, which blocks no build and so is not counted in
 # BUILD_BLOCKED.  stow will not link an absolutely spelled symlink either, and
 # on 2.4.1 abandons the whole apply over one anywhere in the tree; that is
-# ABS_LINK_COUNT, which blocks no build for the same reason.  And stow is the
-# one tool an apply needs that a build does not, so a machine without it
+# ABS_LINK_COUNT, which blocks no build for the same reason.  Nor will it accept
+# one in $HOME at a path it is being asked to link, however the link resolves;
+# that is HOME_ABS_COUNT, and both versions abandon the apply over it.  And stow
+# is the one tool an apply needs that a build does not, so a machine without it
 # composes every layer and links none of them.
 #
 # ABS_LINK_COUNT is the one input whose answer is version-dependent: 2.3.1
@@ -2546,11 +2548,13 @@ UNCHECKED_LINKS=0
 # apply aborts.
 #
 # Read where the line is printed rather than answered once: BUILD_BLOCKED,
-# APPLY_CONFLICTS and ABS_LINK_COUNT go on rising until the last check has run.
+# APPLY_CONFLICTS, ABS_LINK_COUNT and HOME_ABS_COUNT go on rising until the last
+# check has run.
 apply_offerable() {
   [ "$BUILD_BLOCKED" -eq 0 ] &&
     [ "$APPLY_CONFLICTS" -eq 0 ] &&
     [ "$ABS_LINK_COUNT" -eq 0 ] &&
+    [ "$HOME_ABS_COUNT" -eq 0 ] &&
     [ "$APPLY_TOOL_MISSING" -eq 0 ]
 }
 
@@ -2712,6 +2716,15 @@ APPLY_CONFLICT_PATHS=()
 # The subtree below a path already answered for, empty when there is none.
 HOME_CONFLICT_SKIP=
 
+# The links in $HOME that resolve to the built tree's copy of their own path and
+# are spelled from the root, collected by that same walk.  Capped like every
+# other list doctor keeps: the cap changes what is printed and never what is
+# counted.  One list, holding the line as it is printed - the path and what it
+# points at - because nothing else asks a question of these.
+HOME_ABS_CAP=10
+HOME_ABS_COUNT=0
+HOME_ABS_LINES=()
+
 # Non-zero unless stow never looks at the composed path $1, which is the one
 # question two checks below share: a path stow passes over is a path no apply
 # can be refused at, whatever the layers put there and whatever is in $HOME.
@@ -2774,13 +2787,17 @@ stow_skips_path() {
 # copy of that same path.  A link to another path in the tree is 'stowed to a
 # different package', one to anywhere else is 'not owned by stow', and both are
 # refusals on both versions.  -ef is what answers that in two stats and no fork,
-# because an apply's link resolves to the very file it is compared against -
-# where readlink would be a process per path in $HOME, on the walk that has to
-# stay cheap.  It is read only where it cannot mislead: -ef is true of an
-# absolute link to the right file as well, and stow refuses that one, so this
-# check is silent about a link nobody but a hand makes.  A dangling link is the
-# one shape -ef cannot speak for at all, and the only one readlink is spent on:
-# there is at most a handful in any $HOME, and every one of them costs a fork.
+# because an apply's link resolves to the very file it is compared against.  A
+# dangling link is the one shape -ef cannot speak for at all: what it points at
+# is what decides, and readlink is spent on it.
+#
+# -ef is true of an absolute link to the right file as well, and stow refuses
+# that one, so where -ef says applied the spelling is still an open question -
+# home_absolute_link below closes the absolute half of it, and is the second
+# finding this walk can raise at one path.  Only that half: a relative target
+# that resolves to the tree's copy without passing through the stow directory
+# textually - '../you/.dotfiles/current/.zshrc' from $HOME - is refused by both
+# versions too, and nothing here reports it.
 home_conflict() {
   local srel=$1 kind=$2 path
   # Everything below a path this has already answered for.  Two shapes need it:
@@ -2803,8 +2820,22 @@ home_conflict() {
   [ -n "${HOME-}" ] || return 0
   path=$HOME_PREFIX/$srel
   if [ -L "$path" ]; then
-    # The applied state, and the whole of it: one lstat and one pair of stats.
-    [ ! "$path" -ef "$CUR/$srel" ] || return 0
+    # The applied state, in one lstat and one pair of stats - and the spelling
+    # is the rest of it, which costs the fork this walk used to refuse.
+    if [ "$path" -ef "$CUR/$srel" ]; then
+      # A directory reached through a link into the built tree is a directory
+      # whose every path below resolves inside that tree, so a finding there
+      # would name current/'s own file and tell the reader to move it aside.
+      # Set before the call rather than after it, so that a 'return' added to
+      # home_absolute_link cannot quietly put the descent back.  Both spellings,
+      # because both leave the same subtree: stow refuses the absolute one and
+      # the finding below names it, and it takes the relative one back by itself
+      # and puts a real directory in its place - measured on 2.3.1 and 2.4.1 -
+      # so neither leaves anything under it for a reader to act on.
+      [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
+      home_absolute_link "$path"
+      return 0
+    fi
     [ "$kind" != directory ] || HOME_CONFLICT_SKIP=$srel
     if [ ! -e "$path" ]; then
       # Dangling, and -ef cannot answer for one at all: what it points at is
@@ -2820,6 +2851,56 @@ home_conflict() {
   APPLY_CONFLICTS=$((APPLY_CONFLICTS + 1))
   [ "$APPLY_CONFLICTS" -gt "$APPLY_CONFLICT_CAP" ] ||
     APPLY_CONFLICT_PATHS+=("$path")
+  return 0
+}
+
+# Records the link $1, which resolves to the built tree's copy of its own path,
+# when its target is spelled from the root.  That link reads as applied to every
+# test shale can make cheaply and stow will not have it: stow compares the text
+# of the link it finds against the text it would write, never the file at the
+# end of it, so an absolute spelling of the very path it wants is a target it
+# does not own - and it abandons the whole apply over one.
+#
+# Measured on both versions, and here they agree, where for the layer-side link
+# report_absolute_links answers for they do not: a link in $HOME at the top of
+# the tree and one below it are refused alike by 2.3.1 and by 2.4.1, and both
+# abandon the whole operation over it.  The difference between them is noise -
+# 2.3.1 prints a pair of 'BUG in find_stowed_path?' lines about a link at the
+# top of the tree and none about a deeper one - so this finding needs no version
+# split.  The two read the two ends of the same operation, which is why they
+# differ: the layer-side test is on the source scan, this one on the target.
+#
+# A directory path reaches this as well - --no-folding leaves a real directory
+# in $HOME and never a link, so one here is a hand's too - and both remedies
+# hold for it: the apply after the removal makes the directory back, and stow
+# takes a relative link there back by itself and puts the directory in its
+# place.  Measured on both, and it is why the remedy names neither a link nor a
+# directory.
+#
+# The fork is the cost this walk had refused, and what changed is the answer it
+# was buying: -ef alone reports a machine clean whose every apply aborts, which
+# is the reading of doctor that costs a reader the most.  It is spent on the
+# paths in $HOME an apply has already linked and nowhere else - not on a plain
+# file, not on a link pointing anywhere but at the tree's copy of its own path,
+# and not at all on a $HOME nothing has been applied to.
+#
+# 'Cannot say' answers the same as 'not absolute', which is the answer that
+# reports nothing: a missing readlink is a note doctor has already printed, and
+# a finding raised on a guess is worse than the silence it replaces.
+#
+# Not deduplicated, unlike the layer-side list: the caller reaches each composed
+# path once, so two sightings are two links in $HOME and two things to remove.
+home_absolute_link() {
+  local path=$1 dest
+  command -v readlink >/dev/null 2>&1 || return 0
+  dest=$(readlink "$path") || return 0
+  case "$dest" in
+    /*) ;;
+    *) return 0 ;;
+  esac
+  HOME_ABS_COUNT=$((HOME_ABS_COUNT + 1))
+  [ "$HOME_ABS_COUNT" -gt "$HOME_ABS_CAP" ] ||
+    HOME_ABS_LINES+=("$path -> $dest")
   return 0
 }
 
@@ -2892,6 +2973,44 @@ report_home_conflicts() {
   done
   if [ "$n" -gt "$APPLY_CONFLICT_CAP" ]; then
     rest=$((n - APPLY_CONFLICT_CAP))
+    lines[${#lines[@]}]="and $rest more, not named here"
+  fi
+  finding ${lines[@]+"${lines[@]}"}
+}
+
+# One finding however many links, on report_home_conflicts' reasoning: what they
+# add up to is one apply that will not run, and one line of remedy covers every
+# one of them.
+#
+# A finding rather than a note, and the state it names is the one doctor was
+# most wrong about: the link resolves to the right file, so every other check
+# here reads it as applied, doctor closed 'no problems found', and every apply
+# from the day the link was made aborted having written nothing.
+#
+# It stops no build, so BUILD_BLOCKED is left alone: nothing in $HOME is read by
+# a build at all.
+report_home_absolute_links() {
+  local n=$HOME_ABS_COUNT i lines links looks remedy rest
+  [ "$n" -gt 0 ] || return 0
+  links="$n symlinks in $HOME have absolute targets at paths the layers provide"
+  looks="each of them points at the built tree's own copy of its path, so they look applied and are not"
+  remedy='remove them and apply again, which puts back what stow writes there, or respell each target relative to the directory its link is in'
+  if [ "$n" -eq 1 ]; then
+    links="1 symlink in $HOME has an absolute target at a path a layer provides"
+    looks="it points at the built tree's own copy of its path, so it looks applied and is not"
+    remedy='remove it and apply again, which puts back what stow writes there, or respell the target relative to the directory the link is in'
+  fi
+  lines=("$links"
+    "$looks: stow compares the text of a link it finds against the text it would write, never the file at the end of it, so a target spelled from the root is one it does not own"
+    'one such link abandons the whole apply, wherever it is in the tree, on stow 2.3.1 and 2.4.1'
+    "$remedy")
+  i=0
+  while [ "$i" -lt "${#HOME_ABS_LINES[@]}" ]; do
+    lines[${#lines[@]}]=${HOME_ABS_LINES[$i]}
+    i=$((i + 1))
+  done
+  if [ "$n" -gt "$HOME_ABS_CAP" ]; then
+    rest=$((n - HOME_ABS_CAP))
     lines[${#lines[@]}]="and $rest more, not named here"
   fi
   finding ${lines[@]+"${lines[@]}"}
@@ -6003,7 +6122,7 @@ cmd_doctor() {
     command -v "$tool" >/dev/null 2>&1 && continue
     # stow is wanted only by apply, so it stops no build on its own; every other
     # name here does, and no line below may then offer one.  What it does stop is
-    # every apply, which is apply_offerable's fourth input.
+    # every apply, which is apply_offerable's fifth input.
     if [ "$tool" = stow ]; then
       APPLY_TOOL_MISSING=$((APPLY_TOOL_MISSING + 1))
     else
@@ -6025,19 +6144,22 @@ cmd_doctor() {
       'it stops no build and no apply: what it costs is that one check' \
       "it ships with GNU stow, so the package to install is 'stow', the same one that provides stow itself"
   # The same shape #170 gave chkstow, with two differences facts force rather
-  # than style: readlink is read by two checks here, not one - the broken-link
-  # audit and the layer scan's absolute-target check - so the first line names
-  # both rather than the one chkstow has.  And it is not confined to doctor the
-  # way chkstow is: which_describe dies rather than degrade when 'shale which'
-  # is asked about a path that is a symlink, a wrong answer there being the
-  # failure that command exists to avoid, so the second line says that plainly
-  # instead of reusing chkstow's 'what it costs is that one check', which would
-  # be false of this tool.  The package is coreutils, checked with dpkg -S
-  # against the binary on PATH; it is also what already provides every other
-  # tool the loop above requires bar stow, so a reader who has those has this
-  # too, or is about to install it for the same reason.
+  # than style: readlink is read by three checks here, not one - the broken-link
+  # audit, the layer scan's absolute-target check, and the same question asked
+  # of $HOME - so the first line names all three rather than the one chkstow
+  # has.  The third is the one whose silence costs most: without it doctor says
+  # nothing about a link that aborts every apply, and a note that did not name
+  # it would leave the reader exactly where the check found them.  And it is not
+  # confined to doctor the way chkstow is: which_describe dies rather than
+  # degrade when 'shale which' is asked about a path that is a symlink, a wrong
+  # answer there being the failure that command exists to avoid, so the second
+  # line says that plainly instead of reusing chkstow's 'what it costs is that
+  # one check', which would be false of this tool.  The package is coreutils,
+  # checked with dpkg -S against the binary on PATH; it is also what already
+  # provides every other tool the loop above requires bar stow, so a reader who
+  # has those has this too, or is about to install it for the same reason.
   command -v readlink >/dev/null 2>&1 ||
-    note "readlink is not installed, so this report cannot audit ${HOME-} for broken links or check the layers for a symlink with an absolute target" \
+    note "readlink is not installed, so this report cannot audit ${HOME-} for broken links, check the layers for a symlink with an absolute target, or find a symlink in ${HOME-} with an absolute target at a path a layer provides" \
       "it stops no build and no apply, but 'shale which' refuses a path that a layer provides as a symlink" \
       "it ships with GNU coreutils, so the package to install is 'coreutils', the same one that already provides chmod, cp, ls, mkdir, mv and rm"
 
@@ -6187,6 +6309,8 @@ cmd_doctor() {
   ABS_LINK_COUNT=0
   ABS_LINK_PATHS=()
   ABS_LINK_LINES=()
+  HOME_ABS_COUNT=0
+  HOME_ABS_LINES=()
   HOME_CONFLICT_SKIP=
   STRAY_COUNT=0
   STRAY_PATHS=()
@@ -6205,8 +6329,11 @@ cmd_doctor() {
   report_absolute_links
 
   # The other half of that walk: what the layers hold, against what is in $HOME
-  # at the same paths.
+  # at the same paths.  The refusal first, then the state that reads as no
+  # refusal at all: a reader meeting both has the paths stow will not write over
+  # before the ones it will not take back.
   report_home_conflicts
+  report_home_absolute_links
 
   # build's own refusal, in build's own words.  It is checked against the layers
   # rather than against the composed tree because that is where the file has to

--- a/tests/run
+++ b/tests/run
@@ -9389,6 +9389,16 @@ test_doctor_reports_its_checks_in_order() {
   sandbox_mkdir "$HOME/.dotfiles/personal/base"
   sandbox_leaf "$sandbox_dir" .vimrc new
   ln -s "$HOME/elsewhere/vimrc" "$sandbox_path" || fail 'could not plant the layer link'
+  # The link in $HOME that reads as applied, reported off the back of the same
+  # comparison and after it: the paths stow will not write over come before the
+  # one it will not take back.  It needs a built copy to resolve to, and the
+  # config above has an error in it, so the tree is planted rather than built.
+  mklayer personal/base .gitconfig
+  sandbox_write "$HOME/.dotfiles/current" .gitconfig 'built'
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .gitconfig new
+  ln -s "$HOME/.dotfiles/current/.gitconfig" "$sandbox_path" ||
+    fail 'could not plant the home link'
   sandbox_write "$HOME" .stowrc '--ignore=secret'
   stub_path_without stow
   saved=$PATH
@@ -9404,14 +9414,15 @@ test_doctor_reports_its_checks_in_order() {
       "shale: layer 'work'"*) seen="$seen layer" ;;
       'shale: 1 symlink in the layers has an absolute target') seen="$seen spelling" ;;
       *' holds something no apply put there, and a layer provides it') seen="$seen home" ;;
+      *' has an absolute target at a path a layer provides') seen="$seen home-spelling" ;;
       *' is not a layer, and no build reads it') seen="$seen stray" ;;
       'shale: a stow resource file'*) seen="$seen stowrc" ;;
-      'shale: 5 problems found') seen="$seen summary" ;;
+      'shale: 6 problems found') seen="$seen summary" ;;
     esac
   done <<EOF
 $shale_out
 EOF
-  assert_eq ' prerequisite config layer spelling home stray stowrc summary' "$seen" \
+  assert_eq ' prerequisite config layer spelling home home-spelling stray stowrc summary' "$seen" \
     'the order of the report'
 }
 
@@ -11757,6 +11768,51 @@ test_doctor_without_readlink_says_nothing_about_an_absolute_symlink() {
   assert_contains "$shale_out" 'shale: no problems found' 'stdout'
 }
 
+
+# The same for the $HOME side, and the state that makes the note's third clause
+# worth its width: the link is one every apply aborts over, readlink is what
+# reads its spelling, and without it doctor has nothing to say about it.  The
+# silence is right - a finding raised on a guess is worse - but a reader left
+# with 'no problems found' and no word about which check did not run is back
+# where #181 found them, so the note has to name this check by what it looks
+# for.  The apply below is what the note is warning about, run with readlink
+# back on PATH because it is stow's answer rather than shale's.
+#
+# Anchored on the clause rather than on 'readlink is not installed', which the
+# case above already pins and which says nothing about this check.
+# shellcheck disable=SC2123
+test_doctor_without_readlink_says_nothing_about_an_absolute_link_in_home() {
+  local saved
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the link'
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.zshrc" || fail 'could not clear the applied link'
+  sandbox_leaf "$sandbox_dir" .zshrc new
+  ln -s "$HOME/.dotfiles/current/.zshrc" "$sandbox_path" ||
+    fail 'could not plant the absolute link'
+  stub_path_without readlink
+  saved=$PATH
+  PATH=$stub_path
+  run_shale doctor
+  PATH=$saved
+  assert_status 0 "$shale_status" 'the doctor without readlink'
+  assert_not_contains "$shale_out" 'has an absolute target at a path a layer provides' 'stdout'
+  assert_contains "$shale_out" \
+    "shale: readlink is not installed, so this report cannot audit $HOME for broken links, check the layers for a symlink with an absolute target, or find a symlink in $HOME with an absolute target at a path a layer provides" \
+    'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply the report could not predict'
+  assert_contains "$shale_err" 'existing target is not owned by stow' 'stow stderr'
+  assert_contains "$shale_err" 'All operations aborted' 'stow stderr'
+  # And with readlink back, the check that was skipped names it.
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor with readlink'
+  assert_contains "$shale_out" \
+    "shale: 1 symlink in $HOME has an absolute target at a path a layer provides" 'stdout'
+}
+
 # The fourth gate, and the one whose answer is version-dependent: on 2.4.1 the
 # apply that would be offered aborts over the link, so offering it would put a
 # command in the report that a finding above it says will not finish.  The link
@@ -11787,6 +11843,347 @@ test_doctor_offers_no_apply_for_an_orphan_beside_an_absolute_layer_symlink() {
   run_shale doctor
   assert_status 1 "$shale_status" 'the setup with the link'
   assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_contains "$shale_out" \
+    'shale: no apply will finish until the problems above are fixed, so this link stays' \
+    'the blocked stdout'
+  assert_not_contains "$shale_out" 'clear it with' 'the blocked stdout'
+  assert_not_contains "$shale_out" 'shale apply' 'the blocked stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply no line offered'
+}
+
+
+# The state this check exists for, and the one doctor was most wrong about: a
+# link made by hand at a path a layer still provides, pointing at the built
+# tree's own copy of that same path.  It resolves to the very file stow wants
+# there, so every cheap test in doctor read it as applied and the report closed
+# 'no problems found' - while stow compares the text of the link instead,
+# refuses it, and abandons the whole apply.
+#
+# The whole finding is asserted once, here, so its wording is pinned somewhere.
+# What stow prints is taken as fragments: both phrases ship with stow in both
+# versions - 'existing target is not owned by stow' in Stow.pm and 'All
+# operations aborted.' in the stow script itself - and the rest of the refusal
+# does not: 2.3.1 adds a pair of 'BUG in find_stowed_path?' lines at this depth
+# that 2.4.1 does not print at all.
+#
+# '.vimrc' joins the layer after the first apply and is what proves the abort:
+# stow plans the whole operation and writes nothing, so the file that had never
+# been linked is still not linked when the apply that met the hand-made link
+# exits.
+test_doctor_an_absolute_link_in_home_at_a_layer_path_is_a_finding() {
+  local target
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the link'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc" 'the applied link'
+  mklayer personal/base .vimrc
+  # Removed through the resolved directory rather than through sandbox_leaf,
+  # whose weak mode refuses a name that holds a symlink - which is what this
+  # name holds and what is being respelled.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.zshrc" || fail 'could not clear the applied link'
+  sandbox_leaf "$sandbox_dir" .zshrc new
+  ln -s "$HOME/.dotfiles/current/.zshrc" "$sandbox_path" ||
+    fail 'could not plant the absolute link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_eq "shale: 1 symlink in $HOME has an absolute target at a path a layer provides
+shale:   it points at the built tree's own copy of its path, so it looks applied and is not: stow compares the text of a link it finds against the text it would write, never the file at the end of it, so a target spelled from the root is one it does not own
+shale:   one such link abandons the whole apply, wherever it is in the tree, on stow 2.3.1 and 2.4.1
+shale:   remove it and apply again, which puts back what stow writes there, or respell the target relative to the directory the link is in
+shale:   $HOME/.zshrc -> $HOME/.dotfiles/current/.zshrc
+shale: 1 problem found" "$shale_out" 'the whole report'
+  # The apply the finding predicted, on either version.
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply the finding predicted'
+  assert_contains "$shale_err" 'existing target is not owned by stow' 'stow stderr'
+  assert_contains "$shale_err" 'All operations aborted' 'stow stderr'
+  # Nothing was linked, which is what 'the whole apply' means: the file added to
+  # the layer above has never had a link and still has none.
+  assert_missing "$HOME/.vimrc" 'the link the aborted apply never made'
+  # The remedy, carried out the first way the finding offers: the link goes, and
+  # the apply writes the relative one back.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.zshrc" || fail 'could not remove the absolute link'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the remedy'
+  assert_symlink_to "$HOME/.zshrc" "$HOME/.dotfiles/current/.zshrc" 'the relinked path'
+  assert_symlink_to "$HOME/.vimrc" "$HOME/.dotfiles/current/.vimrc" 'the path the abort had left'
+  # The spelling rather than the resolution, which -ef cannot tell apart: what
+  # stow writes is the text this finding wanted.  The text itself is stow's to
+  # choose, so only its first character is pinned.
+  target=$(readlink "$HOME/.zshrc") || fail 'could not read the relinked path'
+  case "$target" in
+    /*) fail "the relinked path is still absolute: $target" ;;
+  esac
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# The same link one directory down, which is where #176's layer-side finding has
+# to split the two stow versions and this one does not: measured on 2.3.1 and
+# 2.4.1, a link in $HOME is refused at every depth by both, because the test
+# that reads it is the target scan rather than the source scan the layer-side
+# link meets.
+#
+# The second remedy the finding offers is the one carried out here - the target
+# respelled relative, by hand, with no apply in between - so that both halves of
+# that line are covered by a case.
+test_doctor_an_absolute_link_in_home_below_the_top_is_a_finding() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the link'
+  sandbox_mkdir "$HOME/.config/nvim"
+  rm -f "$sandbox_dir/init.lua" || fail 'could not clear the applied link'
+  sandbox_leaf "$sandbox_dir" init.lua new
+  ln -s "$HOME/.dotfiles/current/.config/nvim/init.lua" "$sandbox_path" ||
+    fail 'could not plant the absolute link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: 1 symlink in $HOME has an absolute target at a path a layer provides" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.config/nvim/init.lua -> $HOME/.dotfiles/current/.config/nvim/init.lua" \
+    'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply the finding predicted'
+  assert_contains "$shale_err" 'existing target is not owned by stow' 'stow stderr'
+  assert_contains "$shale_err" 'All operations aborted' 'stow stderr'
+  # The other remedy: the same link, respelled relative to the directory it sits
+  # in, and no apply needed to make it good.
+  sandbox_mkdir "$HOME/.config/nvim"
+  rm -f "$sandbox_dir/init.lua" || fail 'could not remove the absolute link'
+  sandbox_leaf "$sandbox_dir" init.lua new
+  ln -s ../../.dotfiles/current/.config/nvim/init.lua "$sandbox_path" ||
+    fail 'could not respell the link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the remedy'
+}
+
+
+# The shape at a directory rather than a file, which reaches the same check by
+# the same route: --no-folding means a directory in $HOME is a directory of its
+# own after an apply, so a link there is one somebody made, and stow refuses it
+# on both versions for the spelling alone - measured.  Both remedies hold: the
+# apply that follows the removal makes the real directory back, and stow takes
+# a relative link there back by itself and makes the directory in its place.
+#
+# One finding and no other, which is what the subtree skip on this arm buys:
+# the walk that descended through the link went on to call current/'s own file
+# something no apply put in $HOME, and prescribed moving it aside - a reader
+# following that line deletes out of the built tree.  Both the count and the
+# path are asserted, because the count alone would pass on a report that named
+# the wrong path twice.
+test_doctor_an_absolute_link_in_home_at_a_layer_directory_is_a_finding() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the directory'
+  assert_real_dir "$HOME/.config" 'the directory the apply made'
+  sandbox_mkdir "$HOME/.config"
+  rm -rf "$sandbox_dir" || fail 'could not clear the applied directory'
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .config new
+  ln -s "$HOME/.dotfiles/current/.config" "$sandbox_path" ||
+    fail 'could not plant the absolute link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: 1 symlink in $HOME has an absolute target at a path a layer provides" 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   $HOME/.config -> $HOME/.dotfiles/current/.config" 'stdout'
+  assert_not_contains "$shale_out" 'holds something no apply put there' 'stdout'
+  assert_not_contains "$shale_out" "$HOME/.config/nvim/init.lua" 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+  run_shale apply
+  assert_status 1 "$shale_status" 'the apply the finding predicted'
+  assert_contains "$shale_err" 'existing target is not owned by stow' 'stow stderr'
+  assert_contains "$shale_err" 'All operations aborted' 'stow stderr'
+  # Respelled relative: stow takes the link back and leaves the directory it
+  # wanted there, on both versions.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.config" || fail 'could not remove the absolute link'
+  sandbox_leaf "$sandbox_dir" .config new
+  ln -s .dotfiles/current/.config "$sandbox_path" || fail 'could not respell the link'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply after the remedy'
+  assert_real_dir "$HOME/.config" 'the directory the apply put back'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor after the remedy'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+
+# The other spelling at the same shape, and the reason the subtree below one is
+# skipped whichever it is: stow takes a relative link at a directory path back
+# by itself and puts the real directory in its place, exit 0 on 2.3.1 and 2.4.1
+# both, so there was never anything under it to report either.  Doctor says
+# nothing at all - not about the link, which is a spelling stow accepts, and not
+# about the paths below it, which resolve into the built tree.
+test_doctor_a_relative_link_in_home_at_a_layer_directory_is_silent() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the directory'
+  sandbox_mkdir "$HOME/.config"
+  rm -rf "$sandbox_dir" || fail 'could not clear the applied directory'
+  sandbox_mkdir "$HOME"
+  sandbox_leaf "$sandbox_dir" .config new
+  ln -s .dotfiles/current/.config "$sandbox_path" || fail 'could not plant the link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_not_contains "$shale_out" 'has an absolute target at a path a layer provides' 'stdout'
+  assert_not_contains "$shale_out" 'holds something no apply put there' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  assert_real_dir "$HOME/.config" 'the directory stow put back'
+  assert_symlink_to "$HOME/.config/nvim/init.lua" \
+    "$HOME/.dotfiles/current/.config/nvim/init.lua" 'the link inside it'
+}
+
+# The supported spelling, at both depths, which is what every apply writes and
+# what this check has to stay silent about: the finding costs a fork per applied
+# path in $HOME, and a report that named them would name every managed file on
+# the machine.
+#
+# Anchored on the finding's own wording in both numbers rather than on 'absolute
+# target', which the layer-side finding says too.
+test_doctor_a_relative_applied_link_is_not_an_absolute_one() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_not_contains "$shale_out" 'has an absolute target at a path a layer provides' 'stdout'
+  assert_not_contains "$shale_out" 'have absolute targets at paths the layers provide' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+}
+
+# A path no layer provides is a path stow never looks at, so the spelling of a
+# link there is nobody's business: measured on 2.3.1 and 2.4.1, the apply below
+# walks past it and exits 0.  It is one directory down deliberately - at the top
+# of the tree 2.3.1 prints a 'BUG in find_stowed_path?' line about it and still
+# exits 0, which shale would pass through as its own 'stow exited 0 and wrote
+# output' warning on that version only.
+test_doctor_says_nothing_about_an_absolute_link_at_a_path_no_layer_provides() {
+  conf 'base personal/base'
+  mklayer personal/base .config/nvim/init.lua
+  sandbox_write "$HOME/elsewhere" notes 'mine'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.config/nvim"
+  sandbox_leaf "$sandbox_dir" notes.md new
+  ln -s "$HOME/elsewhere/notes" "$sandbox_path" || fail 'could not plant the link'
+  run_shale doctor
+  assert_status 0 "$shale_status" 'the doctor'
+  assert_not_contains "$shale_out" 'has an absolute target at a path a layer provides' 'stdout'
+  assert_contains "$shale_out" 'shale: no problems found' 'stdout'
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that walks past it'
+  assert_symlink_to "$HOME/.config/nvim/notes.md" "$HOME/elsewhere/notes" 'the link left alone'
+}
+
+# The two absolute-link findings are about different links and both are wanted:
+# one names a file in a layer to respell, the other a link in $HOME to remove,
+# and neither remedy does the other's work.  The counts are each finding's own.
+test_doctor_an_absolute_link_in_home_and_one_in_a_layer_are_both_findings() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the link'
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.zshrc" || fail 'could not clear the applied link'
+  sandbox_leaf "$sandbox_dir" .zshrc new
+  ln -s "$HOME/.dotfiles/current/.zshrc" "$sandbox_path" ||
+    fail 'could not plant the absolute link'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base"
+  sandbox_leaf "$sandbox_dir" .secrets new
+  ln -s "$HOME/elsewhere/secrets" "$sandbox_path" || fail 'could not plant the layer link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" 'shale: 1 symlink in the layers has an absolute target' 'stdout'
+  assert_contains "$shale_out" \
+    "shale:   layer 'base': $HOME/.dotfiles/personal/base/.secrets -> $HOME/elsewhere/secrets" \
+    'stdout'
+  assert_contains "$shale_out" \
+    "shale: 1 symlink in $HOME has an absolute target at a path a layer provides" 'stdout'
+  assert_contains "$shale_out" "shale:   $HOME/.zshrc -> $HOME/.dotfiles/current/.zshrc" 'stdout'
+  assert_contains "$shale_out" 'shale: 2 problems found' 'stdout'
+}
+
+# The cap, and the count above it: the list is bounded and the total is not.
+test_doctor_bounds_the_absolute_home_link_findings_at_ten() {
+  local i
+  conf 'base personal/base'
+  i=1
+  while [ "$i" -le 12 ]; do
+    mklayer personal/base "link$i"
+    i=$((i + 1))
+  done
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply that made the links'
+  sandbox_mkdir "$HOME"
+  i=1
+  while [ "$i" -le 12 ]; do
+    rm -f "$sandbox_dir/link$i" || fail "could not clear link$i"
+    sandbox_leaf "$sandbox_dir" "link$i" new
+    ln -s "$HOME/.dotfiles/current/link$i" "$sandbox_path" ||
+      fail "could not plant link$i"
+    i=$((i + 1))
+  done
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the doctor'
+  assert_contains "$shale_out" \
+    "shale: 12 symlinks in $HOME have absolute targets at paths the layers provide" 'stdout'
+  assert_contains "$shale_out" \
+    'shale:   remove them and apply again, which puts back what stow writes there, or respell each target relative to the directory its link is in' \
+    'stdout'
+  assert_contains "$shale_out" 'shale:   and 2 more, not named here' 'stdout'
+  assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
+}
+
+# The gate this check adds to the offer of an apply, and the plainest of them:
+# the apply doctor would otherwise name aborts over this link on both versions,
+# so no line in the report may name that command.
+#
+# The orphan is a file that left a layer whose directory the tree still holds,
+# which is the shape doctor offers an apply for at all.
+test_doctor_offers_no_apply_for_an_orphan_beside_an_absolute_home_link() {
+  conf 'base personal/base'
+  mklayer personal/base .zshrc
+  mklayer personal/base .config/nvim/init.lua
+  mklayer personal/base .config/nvim/extra.lua
+  run_shale apply
+  assert_status 0 "$shale_status" 'the apply'
+  sandbox_mkdir "$HOME/.dotfiles/personal/base/.config/nvim"
+  sandbox_leaf "$sandbox_dir" extra.lua
+  rm -f "$sandbox_path" || fail 'could not remove the layer file'
+  run_shale build
+  assert_status 0 "$shale_status" 'the build'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the sound setup'
+  assert_contains "$shale_out" 'shale: clear it with: shale apply' 'the sound stdout'
+  # The same links with one of them respelled by hand: the offer goes.
+  sandbox_mkdir "$HOME"
+  rm -f "$sandbox_dir/.zshrc" || fail 'could not clear the applied link'
+  sandbox_leaf "$sandbox_dir" .zshrc new
+  ln -s "$HOME/.dotfiles/current/.zshrc" "$sandbox_path" ||
+    fail 'could not plant the absolute link'
+  run_shale doctor
+  assert_status 1 "$shale_status" 'the setup with the link'
+  assert_contains "$shale_out" \
+    "shale: 1 symlink in $HOME has an absolute target at a path a layer provides" 'stdout'
   assert_contains "$shale_out" \
     'shale: no apply will finish until the problems above are fixed, so this link stays' \
     'the blocked stdout'
@@ -11841,7 +12238,7 @@ test_doctor_a_missing_readlink_warns_without_failing() {
   run_shale doctor
   PATH=$saved
   assert_status 0 "$shale_status"
-  assert_eq "shale: readlink is not installed, so this report cannot audit $HOME for broken links or check the layers for a symlink with an absolute target
+  assert_eq "shale: readlink is not installed, so this report cannot audit $HOME for broken links, check the layers for a symlink with an absolute target, or find a symlink in $HOME with an absolute target at a path a layer provides
 shale:   it stops no build and no apply, but 'shale which' refuses a path that a layer provides as a symlink
 shale:   it ships with GNU coreutils, so the package to install is 'coreutils', the same one that already provides chmod, cp, ls, mkdir, mv and rm
 shale: no problems found, but $HOME was not audited for broken links: read the note above" \
@@ -11876,7 +12273,7 @@ test_doctor_a_missing_readlink_says_nothing_of_its_own_on_stderr() {
   assert_status 1 "$shale_status" 'the doctor'
   assert_empty "$shale_err" 'the doctor stderr'
   assert_contains "$shale_out" \
-    "shale: readlink is not installed, so this report cannot audit $HOME for broken links or check the layers for a symlink with an absolute target" 'stdout'
+    "shale: readlink is not installed, so this report cannot audit $HOME for broken links, check the layers for a symlink with an absolute target, or find a symlink in $HOME with an absolute target at a path a layer provides" 'stdout'
   assert_contains "$shale_out" "shale:   $HOME/.config/nvim" 'stdout'
 }
 
@@ -11902,7 +12299,7 @@ test_doctor_a_missing_readlink_is_reported_before_the_first_build() {
   # audited, though - two reasons the walk did not run, this note and the
   # unbuilt tree above it, and one verdict that says so once.
   assert_status 0 "$shale_status"
-  assert_eq "shale: readlink is not installed, so this report cannot audit $HOME for broken links or check the layers for a symlink with an absolute target
+  assert_eq "shale: readlink is not installed, so this report cannot audit $HOME for broken links, check the layers for a symlink with an absolute target, or find a symlink in $HOME with an absolute target at a path a layer provides
 shale:   it stops no build and no apply, but 'shale which' refuses a path that a layer provides as a symlink
 shale:   it ships with GNU coreutils, so the package to install is 'coreutils', the same one that already provides chmod, cp, ls, mkdir, mv and rm
 shale: there is no built tree at $HOME/.dotfiles/current, so shale cannot tell a link into it from any other broken link
@@ -11930,7 +12327,7 @@ test_doctor_reports_readlink_with_no_chkstow_to_audit_with() {
   assert_eq "shale: chkstow is not installed, so this report cannot audit $HOME for broken links
 shale:   it stops no build and no apply: what it costs is that one check
 shale:   it ships with GNU stow, so the package to install is 'stow', the same one that provides stow itself
-shale: readlink is not installed, so this report cannot audit $HOME for broken links or check the layers for a symlink with an absolute target
+shale: readlink is not installed, so this report cannot audit $HOME for broken links, check the layers for a symlink with an absolute target, or find a symlink in $HOME with an absolute target at a path a layer provides
 shale:   it stops no build and no apply, but 'shale which' refuses a path that a layer provides as a symlink
 shale:   it ships with GNU coreutils, so the package to install is 'coreutils', the same one that already provides chmod, cp, ls, mkdir, mv and rm
 shale: no problems found, but $HOME was not audited for broken links: read the 2 notes above" \


### PR DESCRIPTION
Closes #181.

A user-made absolutely-spelled symlink in `$HOME` at a layer-provided path aborts every apply on stow 2.3.1 and 2.4.1 alike (measured on both real images; root cause in Stow.pm's find_stowed_path), while doctor said `no problems found`. Doctor now reports it as a finding (own family, capped, fifth apply_offerable input) with a remedy that works on both versions. Scope extended by one line per the issue comment: the walk no longer descends through a directory link into the built tree and misreports `current/`'s own files. The readlink-missing note names the new check it costs. Everyday reports byte-identical to main (stream-level compare on 1,000 applied links). Cost: one readlink per applied link, ~1.4 ms each, doctor-only; single-fork alternatives are off the portability floor and were declined by the gate.

Gate run: measurement table reproduced on debian:12 and debian:trixie, remedies executed, cost measured, suites green under bash 5.2.21, 3.2.57, and inside both images. 563 passed, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)