### PR TITLE
Three follow-ups from the stow 2.4.1 trial

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -289,6 +289,22 @@ All operations aborted.
 Unstow that package. Every path both packages provide collides this way, and stow has no notion of
 one package outranking another.
 
+That transcript assumes the old package sits inside `~/.dotfiles`. Where it doesn't —
+`~/dotfiles/common`, the shape a checkout already has before anyone moves it under the dotfiles root
+— the link resolves nowhere stow understands as its own, and both versions call it what the
+folded-directory shape below is called rather than naming a package:
+
+```
+WARNING! unstowing current would cause conflicts:
+  * existing target is not owned by stow: .profile => dotfiles/common/.profile
+WARNING! stowing current would cause conflicts:
+  * existing target is not owned by stow: .profile
+All operations aborted.
+```
+
+Unstow it the same way, giving `-d` the directory it actually lives in: `stow -D -d ~/dotfiles -t ~
+common`.
+
 A folded directory owned by a package outside `~/.dotfiles` — the old setup's `~/.config` being a
 single link into it:
 

--- a/shale
+++ b/shale
@@ -4633,6 +4633,11 @@ EOF
   # is neither a link nor a directory - one ~/notes.txt is enough - and 2.4.1
   # takes the orphan back with it.  Nothing here probes for the version; the
   # line says which one it needs.
+  #
+  # A sweep that finishes, on either version, still warns about the one target
+  # it always skips - the stow directory sitting inside the tree it walks - and
+  # exits 0 anyway; measured on both.  The last line of the remedy says so, or a
+  # reader pasting the command reads a WARNING as the sweep having failed.
   shell_quote "$DOTFILES"
   qdots=$QUOTED
   shell_quote "$HOME"
@@ -4706,7 +4711,8 @@ EOF
     if apply_offerable; then
       remedy+=('stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:' \
         "  stow -D -p --no-folding -d $qdots -t $qhome current && shale apply" \
-        'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory')
+        'earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory' \
+        'that sweep also prints a "WARNING: skipping target" line naming its own stow directory — expected, and not a second problem, on either version')
     fi
   fi
 
@@ -5353,15 +5359,15 @@ cmd_build() {
 
   # A package-local ignore list replaces stow's built-in one wholesale rather
   # than adding to it, so whatever is missing here is linked into $HOME with
-  # apply exiting 0.  Everything below the nine-line header is GNU Stow 2.4.1's
-  # default-ignore-list verbatim, so that nothing plain stow skips stops being
-  # skipped; its last three entries are the ^/README.*, ^/LICENSE.* and
-  # ^/COPYING shale once wrote on their own.  Upstream's inline comments are
-  # kept because both 2.3.1 and 2.4.1 strip a '#' that has whitespace before
-  # it, leaving the pattern alone.  Upstream's own first line, which says
-  # comments and blank lines are allowed, is the one thing not reproduced: it
-  # invites editing a file every build overwrites, and the header says so
-  # instead.
+  # apply exiting 0.  Everything from the first pattern line, 'RCS', onward is
+  # GNU Stow 2.4.1's default-ignore-list verbatim, so that nothing plain stow
+  # skips stops being skipped; its last three entries are the ^/README.*,
+  # ^/LICENSE.* and ^/COPYING shale once wrote on their own.  Upstream's inline
+  # comments are kept because both 2.3.1 and 2.4.1 strip a '#' that has
+  # whitespace before it, leaving the pattern alone.  Upstream's own first
+  # line, which says comments and blank lines are allowed, is the one thing
+  # not reproduced: it invites editing a file every build overwrites, and the
+  # header above 'RCS' says so instead.
   #
   # On 2.4.1 the file changes no outcome, and that is not a reason to delete
   # it: 2.3.1's built-in list has no \.gitmodules, so writing 2.4.1's list is
@@ -5381,6 +5387,11 @@ cmd_build() {
     "# links what plain stow skips.  Writing 2.4.1's list rather than the" \
     "# installed stow's is also what makes stow 2.3.1 apply the same tree:" \
     '# 2.3.1 built in the same list without \.gitmodules.' \
+    '#' \
+    '# Not a line below: ^/\.stow-local-ignore$ is not part of that list' \
+    '# either.  Stow adds its own name to every list it reads - the' \
+    '# built-in one and any file a package provides - so this file does' \
+    '# not have to say it.' \
     '' \
     'RCS' \
     '.+,v' \

--- a/tests/run
+++ b/tests/run
@@ -4875,7 +4875,7 @@ test_build_refuses_a_layer_shipping_a_stow_local_ignore() {
   assert_missing "$HOME/.dotfiles/current.new"
 }
 
-# A nine-line shale header and then GNU Stow 2.4.1's default-ignore-list
+# A shale-written header and then GNU Stow 2.4.1's default-ignore-list
 # verbatim, asserted whole because a package-local list replaces stow's built-in
 # one wholesale rather than adding to it: a line dropped from here is a file
 # plain stow skips that an apply then links, with everything exiting 0.  The
@@ -4884,9 +4884,11 @@ test_build_refuses_a_layer_shipping_a_stow_local_ignore() {
 # versions land the same tree.
 #
 # The header replaces upstream's own first line, which says comments and blank
-# lines are allowed and so invites editing a file every build overwrites.  Keep
-# it nine lines and 'diff <(tail -n +10 file) <(tail -n +2 default-ignore-list)'
-# stays clean against upstream, which is how the body below is checked.
+# lines are allowed and so invites editing a file every build overwrites.  The
+# header's own length is not the invariant - diff <(sed -n '/^RCS$/,$p' file)
+# <(sed -n '/^RCS$/,$p' default-ignore-list) stays clean against upstream from
+# the first pattern line onward, whatever the header above it grows to, which
+# is how the body below is checked.
 #
 # The inline comments further down are upstream's.  They are kept rather than
 # stripped because both versions of stow strip a '#' that has whitespace before
@@ -4906,6 +4908,11 @@ test_build_writes_the_stow_local_ignore_list() {
 # links what plain stow skips.  Writing 2.4.1'"'"'s list rather than the
 # installed stow'"'"'s is also what makes stow 2.3.1 apply the same tree:
 # 2.3.1 built in the same list without \.gitmodules.
+#
+# Not a line below: ^/\.stow-local-ignore$ is not part of that list
+# either.  Stow adds its own name to every list it reads - the
+# built-in one and any file a package provides - so this file does
+# not have to say it.
 
 RCS
 .+,v
@@ -10808,6 +10815,9 @@ test_doctor_a_link_into_the_built_tree_it_no_longer_provides_is_a_finding() {
   assert_contains "$shale_out" \
     'shale:   earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory' \
     'stdout'
+  assert_contains "$shale_out" \
+    'shale:   that sweep also prints a "WARNING: skipping target" line naming its own stow directory — expected, and not a second problem, on either version' \
+    'stdout'
   # The remedy is the remedy for the finding, not a second one.
   assert_contains "$shale_out" 'shale: 1 problem found' 'stdout'
   assert_empty "$shale_err" 'stderr'
@@ -15847,8 +15857,11 @@ shale:   stow adds that entry itself, so there is no line for it in $HOME/.dotfi
   run_shale build
   assert_status 0 "$shale_status" 'the build'
   assert_exists "$HOME/.dotfiles/current/$trailing" 'the composed copy'
-  # The line the third note says is not there, in the file it names.
-  assert_not_contains "$(cat "$HOME/.dotfiles/current/.stow-local-ignore")" \
+  # The line the third note says is not there, in the file it names - checked
+  # from the pattern list itself, past the header's own prose about the entry
+  # being absent, or that prose would make this assertion false about the very
+  # thing it says is true.
+  assert_not_contains "$(sed -n '/^RCS$/,$p' "$HOME/.dotfiles/current/.stow-local-ignore")" \
     'stow-local-ignore' 'the built list'
   run_shale apply
   assert_status 0 "$shale_status" 'the apply'


### PR DESCRIPTION
Closes #182.

Three follow-ups, each measured on debian:12 (stow 2.3.1) and debian:trixie (2.4.1) in Docker before writing: docs/migrating.md gains the refusal shape for an old stow package living outside `~/.dotfiles` (byte-identical to real output on both versions); the `.stow-local-ignore` header stops claiming `^/\.stow-local-ignore$` belongs to the default list — Stow.pm adds that pattern to every list it reads, on both versions — with the body-vs-upstream invariant now anchored on the first pattern line rather than a header line count; and doctor's sweep advice says the `WARNING: skipping target which was current stow directory` line is expected, which it is on both versions.

Gate run: every claim re-executed on both images; suites 563 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)