### PR TITLE
Give shale a version, a release install path, and a coherence read

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ is the machine's business, not the repos'.
 ## Requirements
 
 `bash`, `git` and GNU `stow`, installed with your system package manager, and the coreutils any
-system already has — `cp`, `mv`, `rm`, `mkdir` and `readlink`. Shale installs nothing,
-including itself. `git` is used only to clone a layer repository the machine does not have yet, so
-`doctor` reports it missing as a note where no configured layer needs cloning and as a problem where
-one does.
+system already has — `chmod`, `cp`, `date`, `ls`, `mkdir`, `mv`, `readlink`, `rm` and `rmdir`. Shale
+installs nothing, including itself. `git` is used only to clone a layer repository the machine does
+not have yet, so `doctor` reports it missing as a note where no configured layer needs cloning and
+as a problem where one does.
 `chkstow` ships with GNU stow and is what `doctor` audits `$HOME` with; without it `doctor` says so
 and skips that one check. `shale doctor` names every one of these it cannot find, so it is the
 fastest answer to a machine where something will not run.
@@ -28,11 +28,27 @@ exercised rather than assumed. WSL is Linux for shale's purposes. No other platf
 
 ## Install
 
-Clone this repository, and copy the script from the clone to any directory on your `PATH`. These
-commands and the bootstrap below run from the clone's root, which is where `shale` and the example
-configs are:
+Shale is one file, so installing it is downloading that file and putting it on your `PATH`. The
+quick way is the released script, from any directory — `-O` writes it into the working one:
 
 ```sh
+mkdir -p ~/.local/bin
+curl -fsSLO https://github.com/bencmorrison/shale/releases/latest/download/shale
+mv shale ~/.local/bin/shale
+chmod +x ~/.local/bin/shale
+command -v shale
+```
+
+`latest/download` tracks whatever release is newest; `download/v2.0.0` in its place pins the version
+that URL gives you.
+
+Cloning gets the same script plus `examples/` and `docs/`, which the bootstrap below and
+[docs/migrating.md](docs/migrating.md) both draw on. These commands, and every one in the bootstrap,
+run from the clone's root:
+
+```sh
+git clone https://github.com/bencmorrison/shale.git
+cd shale
 mkdir -p ~/.local/bin
 cp shale ~/.local/bin/shale
 command -v shale
@@ -40,12 +56,12 @@ command -v shale
 
 `~/.local/bin` is the usual choice, and it is often not on `PATH` on the machine you are
 bootstrapping, because putting it there is a thing your dotfiles do and they are not applied yet.
-That is what the third line is for: nothing printed means this shell cannot find shale, and
+That is what the `command -v` line is for: nothing printed means this shell cannot find shale, and
 `export PATH="$HOME/.local/bin:$PATH"` is enough to get through the bootstrap below. Applying your
 layers is what makes it permanent.
 
-Shale never needs to know where it lives, and there is nothing else to install. There is no version
-command: shale is one file, and the copy you have is whatever the repository held when you copied it.
+Shale never needs to know where it lives, and there is nothing else to install. There is no flag
+that prints the version: the header of the usage text names it, and that is the copy you have.
 
 ## Bootstrap on a new machine
 
@@ -231,7 +247,7 @@ transcript needed a fault to show, the text says what was broken first.
 
 ```
 $ shale
-shale - layered dotfiles builder
+shale 2.0.0 - layered dotfiles builder
 
 usage:
   shale build          compose the configured layers into ~/.dotfiles/current
@@ -543,7 +559,7 @@ overwrites, and how to carry on from a block that stopped.
   symlinks in `$HOME` point at nothing. Apply relinks immediately afterwards.
 - No build is incremental: every one composes every layer from scratch, so a one-character edit
   costs what a first build costs. Roughly two and a half milliseconds a file — 5.0 seconds for a
-  2000-file tree spread over 400 directories, 40 milliseconds for a seven-file one, on the container
+  2000-file tree spread over 400 directories, 35 milliseconds for a seven-file one, on the container
   these were measured in. A directory
   is one `mkdir` and costs less than a file: no layer's directory mode is read or copied. What costs
   instead is each line of a `.shale-modes` — one `chmod` in the build, and a read and a `chmod` in

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -119,8 +119,8 @@ about. Rename one of them.
 
 ```
 shale: 'build' would fail at .config/profile.d — it is a directory in layer 'base' and a file in layer 'work'
-shale:   /home/you/.dotfiles/base/.config/profile.d
-shale:   /home/you/.dotfiles/work/.config/profile.d
+shale:   /home/you/.dotfiles/personal/base/.config/profile.d
+shale:   /home/you/.dotfiles/work/base/.config/profile.d
 shale:   a layer cannot replace a directory with a file, or a file with a directory
 shale:   remove or rename one of them
 ```
@@ -779,8 +779,8 @@ shale: 2 files in /home/you/.dotfiles/current do not match the layer copies that
 shale:   either something moved them into the built tree, which is what stow --adopt does, or a layer changed and there has been no build since
 shale:   the next build replaces them with the layer copies, keeping what is there now at /home/you/.dotfiles/current.old
 shale:   the build after that removes /home/you/.dotfiles/current.old, so a file moved into the built tree is recoverable for one build and no longer
-shale:   /home/you/.dotfiles/current/.zshrc
 shale:   /home/you/.dotfiles/current/.vimrc
+shale:   /home/you/.dotfiles/current/.zshrc
 ```
 
 Shale cannot tell an adopted file from a built tree its layers have moved past, and does not guess:
@@ -840,10 +840,10 @@ stow run. The one case it does not cover is a whole directory leaving every laye
 never visits — `shale doctor` finds those, and `docs/migrating.md` says what to do about them.
 
 Nothing about a build is incremental. Every one of them composes every layer from scratch, so a
-one-character edit costs what a first build costs: on this machine 4.1 seconds for a 2000-file tree,
-against 31 milliseconds for a seven-file one, and the edited build was 4.08 seconds — roughly two
-milliseconds a file, on whatever your disk does. There is nothing to tune and no cache to warm; keep
-the trees the size the dotfiles actually are.
+one-character edit costs what a first build costs: on the container these were measured in, 5.0
+seconds for a 2000-file tree, against 35 milliseconds for a seven-file one, and the edited build was
+4.9 seconds — roughly two and a half milliseconds a file, on whatever your disk does. There is
+nothing to tune and no cache to warm; keep the trees the size the dotfiles actually are.
 
 Shale clones a layer root that is missing and never touches it again; updating a checkout is git's
 job. Pull each clone root, then apply:

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -293,9 +293,10 @@ Stow plans the whole operation and abandons all of it if any part conflicts, so 
 changes nothing in `$HOME`. The built tree is fine; clear what stow named and apply again. Apply
 restows, so stow runs an unstow phase and then a stow phase, and a collision both phases see is
 named once for each. Every transcript below is stow 2.3.1's. Match the intent rather than the shape,
-because the shape is what moves between stow versions: on 2.4.1 two of these three arrive as one
-block rather than two, one of them loses the `=> package/path` half of the line, and the third is
-reworded into advice to use `--adopt` — see *Coming from plain files*.
+because the shape is what moves between stow versions: on 2.4.1 the second and third arrive as one
+block rather than two and each loses the `=> package/path` half of the line, the first is word for
+word what it is here, and the ordinary-file refusal below them is reworded into advice to use
+`--adopt` — see *Coming from plain files*.
 
 An old package still stowed over a path the built tree also provides:
 
@@ -428,6 +429,7 @@ shale:   stow prunes only the links an apply wrote — relative, and in a direct
 shale:   stow 2.4 or later can sweep the whole target tree instead, which unstows everything and needs the apply after it:
 shale:     stow -D -p --no-folding -d '/home/you/.dotfiles' -t '/home/you' current && shale apply
 shale:   earlier stow, 2.3.1 included, abandons that sweep at the first file in the target that is neither a link nor a directory
+shale:   that sweep also prints a "WARNING: skipping target" line naming its own stow directory — expected, and not a second problem, on either version
 ```
 
 Delete the links it names. Each one points at a path that is not there, `current` is already correct,
@@ -440,6 +442,7 @@ the target as a conflict — one `~/notes.txt` is enough — and abandons the ru
 anything:
 
 ```
+WARNING: skipping target which was current stow directory .dotfiles
 WARNING! unstowing current would cause conflicts:
   * existing target is neither a link nor a directory: notes.txt
 All operations aborted.

--- a/shale
+++ b/shale
@@ -155,6 +155,10 @@ shopt -u dotglob extglob failglob nocaseglob nocasematch nullglob
 
 PROG=shale
 
+# Printed by the usage header and nowhere else: there is no --version flag, the
+# command surface being closed.
+VERSION=2.0.0
+
 # Stripped once, here: "$HOME"/* matches nothing under a home that already ends
 # in a slash, so which reports every absolute path as being outside $HOME.
 case "${HOME-}" in
@@ -388,7 +392,7 @@ denied_verb() {
 usage() {
   # shellcheck disable=SC2088  # a tilde to print, not one to expand
   printf '%s\n' \
-    'shale - layered dotfiles builder' \
+    "$PROG $VERSION - layered dotfiles builder" \
     '' \
     'usage:' \
     "  shale build          compose the configured layers into $DOTFILES_SHOWN/current" \

--- a/tests/run
+++ b/tests/run
@@ -1301,7 +1301,7 @@ EOF
 test_usage_bare_prints_usage_on_stdout() {
   run_shale
   assert_status 0 "$shale_status"
-  assert_contains "$shale_out" 'shale - layered dotfiles builder' 'stdout'
+  assert_contains "$shale_out" 'shale 2.0.0 - layered dotfiles builder' 'stdout'
   assert_contains "$shale_out" 'shale which PATH' 'stdout'
   assert_empty "$shale_err" 'stderr'
 }
@@ -1400,7 +1400,7 @@ test_usage_prints_without_cat() {
   local saved out err bad_out bad_err status
   run_shale
   assert_status 0 "$shale_status"
-  assert_contains "$shale_out" 'shale - layered dotfiles builder' 'stdout'
+  assert_contains "$shale_out" 'shale 2.0.0 - layered dotfiles builder' 'stdout'
   stub_path_without cat
   # All four captures proven before either run, in the way run_shale proves its
   # own: a case that planted something at any of them must stop rather than have
@@ -1545,7 +1545,7 @@ test_usage_a_wrong_invocation_does_not_print_the_usage_text() {
     # shellcheck disable=SC2086
     run_shale $invocation
     assert_status 2 "$shale_status" "'shale $invocation' exit status"
-    assert_not_contains "$shale_err" 'shale - layered dotfiles builder' \
+    assert_not_contains "$shale_err" 'shale 2.0.0 - layered dotfiles builder' \
       "'shale $invocation' stderr"
     assert_not_contains "$shale_err" 'usage:' "'shale $invocation' stderr"
     assert_not_contains "$shale_err" '  shale which PATH     show which layer provides PATH' \


### PR DESCRIPTION
Closes #187.

`VERSION=2.0.0` shown in the usage header (no new flag); the README gains the release install path via `releases/latest/download/shale` (the alias verified live against the existing v1.1.0 asset) with the clone path kept for `examples/` and docs; and a coherence read of README + docs/ against the shipped script with every quoted transcript re-executed — on both stow versions where wording differs — fixing wrong layer paths in a conflict transcript, a mis-described 2.4.1 refusal shape, two transcripts missing lines shale now prints, inconsistent timing figures, and an outdated coreutils list. A padding change the read introduced was itself caught by the gate and reverted with evidence.

Gate run: every changed hunk re-executed (Docker for the stow-2.4.1 claims), the `latest` alias probed, the usage-header pins mutation-checked. 591 passed, 0 failed, 0 skipped under bash 5.2.21 and 3.2.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)